### PR TITLE
fix(api): pin /metrics to VERSION_NEUTRAL and swap bullmq probe to getJobCounts

### DIFF
--- a/apps/api/src/common/health/bullmq-health.indicator.ts
+++ b/apps/api/src/common/health/bullmq-health.indicator.ts
@@ -42,10 +42,10 @@ export class BullMqHealthIndicator extends HealthIndicator implements OnModuleDe
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
     try {
-      await withTimeout(
-        this.queue.client.then((client) => client.ping()),
-        PROBE_TIMEOUT_MS,
-      );
+      // getJobCounts exercises the queue end-to-end (Redis connection + prefix
+      // + queue key lookup) without touching BullMQ's IRedisClient internals —
+      // 5.77.x narrowed that type so `ping` is no longer publicly exposed.
+      await withTimeout(this.queue.getJobCounts('waiting'), PROBE_TIMEOUT_MS);
       return this.getStatus(key, true);
     } catch (err) {
       throw new HealthCheckError(

--- a/apps/api/src/common/metrics/metrics.controller.ts
+++ b/apps/api/src/common/metrics/metrics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Res, UseGuards, VERSION_NEUTRAL } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { Public } from '@nestjs-fastify-nx/infra-auth';
@@ -8,11 +8,15 @@ import { MetricsIpAllowGuard } from './metrics-ip-allow.guard';
 
 // Prometheus scrape endpoint — internal-only, IP-allowlist guarded; response is
 // `text/plain; version=0.0.4`, not JSON, so it carries no value in the public OpenAPI spec.
+// VERSION_NEUTRAL keeps the route at /metrics; enableVersioning('1') in main.ts
+// would otherwise rewrite it to /v1/metrics and break Prometheus scrape configs.
+// The setGlobalPrefix exclude only strips the `api` prefix — URI versioning is a
+// separate concern that the controller has to opt out of explicitly.
 @ApiExcludeController()
 @Public()
 @SkipThrottle()
 @UseGuards(MetricsIpAllowGuard)
-@Controller('metrics')
+@Controller({ path: 'metrics', version: VERSION_NEUTRAL })
 export class MetricsController {
   constructor(private readonly metrics: MetricsService) {}
 


### PR DESCRIPTION
## Why

Two regressions blocking the four open Dependabot PRs (#44, #45, #46, #47):

### 1. `/metrics` returns 404 in e2e

Commit 7d898a1 switched from `setGlobalPrefix('api/v1', { exclude: ['metrics'] })` to `setGlobalPrefix('api', { exclude: ['metrics'] }) + enableVersioning(URI, '1')`. The exclude only strips the `api` prefix; URI versioning still applies, so MetricsController landed at `/v1/metrics`.

The integration workflow runs on `pull_request` only — no `push` trigger to main — so the regression slipped through unnoticed until the Dependabot PRs ran it.

Fix: `@Controller({ path: 'metrics', version: VERSION_NEUTRAL })` keeps the route at `/metrics` where Prometheus scrape configs expect it.

### 2. TS2339 on `client.ping()` after bullmq 5.77.x

`apps/api/src/common/health/bullmq-health.indicator.ts:46` calls `(await this.queue.client).ping()`. BullMQ 5.77.x narrowed `IRedisClient` and dropped `ping` from the public type. Runtime still works (the underlying object is `ioredis.Redis`), but `tsc` fails and webpack build breaks.

Fix: probe via `queue.getJobCounts('waiting')` — BullMQ-native, exercises Redis connection + prefix + queue key lookup, no dependency on private types that move between minor versions.

## Test

- `pnpm nx run api:lint` ✅
- `pnpm nx run api:typecheck` ✅ (full transitive graph)
- `pnpm nx run api:test --testPathPattern="(metrics|health)"` ✅ 100/100
- `pnpm nx run api:build` ✅

Integration / e2e validated via CI on this PR.

## Unblocks

- #44 chore(ci)(deps): bump the github-actions-major group
- #45 chore(deps)(deps): bump the production-dependencies group
- #46 chore(deps-dev)(deps-dev): bump the development-dependencies group
- #47 chore(deps-dev)(deps-dev): bump the development-major group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health check robustness by updating the health probe mechanism to use native BullMQ methods.

* **Chores**
  * Ensured the Prometheus metrics endpoint remains stable and unaffected by system versioning changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chuanghiduoc/nestjs-fastify-nx/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->