### PR TITLE
chore: ignore generated sources in eslint, bump hono override

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,12 @@ export default tseslint.config(
       '**/.nx/**',
       '**/coverage/**',
       '**/tmp/**',
+      // Tool-generated sources (Orval REST client, etc.) are owned by the
+      // generator, not the developer — regenerated on every codegen run and
+      // never hand-edited. Linting them only surfaces the generator's stylistic
+      // choices (e.g. orval 8.15's escaped `\/` in string literals), which we
+      // cannot fix without forking the tool.
+      '**/generated/**',
       '**/*.js',
       '**/*.mjs',
       '**/*.cjs',

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
       "uuid": "^14.0.0",
       "fast-uri": ">=3.1.2",
       "fast-xml-builder": ">=1.2.0",
-      "hono": ">=4.12.18",
+      "hono": ">=4.12.21",
       "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
       "axios": ">=1.16.0",
       "kysely": ">=0.28.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   uuid: ^14.0.0
   fast-uri: '>=3.1.2'
   fast-xml-builder: '>=1.2.0'
-  hono: '>=4.12.18'
+  hono: '>=4.12.21'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   axios: '>=1.16.0'
   kysely: '>=0.28.17'
@@ -1647,7 +1647,7 @@ packages:
     resolution: {integrity: sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.18'
+      hono: '>=4.12.21'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -6121,8 +6121,8 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -10987,9 +10987,9 @@ snapshots:
       protobufjs: 8.5.0
       yargs: 17.7.2
 
-  '@hono/node-server@2.0.1(hono@4.12.18)':
+  '@hono/node-server@2.0.1(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -13120,13 +13120,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 2.0.1(hono@4.12.18)
+      '@hono/node-server': 2.0.1(hono@4.12.23)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.18
+      hono: 4.12.23
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -16196,7 +16196,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hono@4.12.18: {}
+  hono@4.12.23: {}
 
   hookified@1.15.1: {}
 


### PR DESCRIPTION
## What

Two CI-gate fixes that currently block the open dependabot PRs (#54, #55):

1. **Stop linting generated sources.** `eslint.config.mjs` now ignores `**/generated/**`. The orval-generated REST client under `libs/api-client/src/generated/` is owned by the generator and regenerated on every `codegen` run — never hand-edited. orval 8.15 emits escaped forward slashes in string literals that trip `no-useless-escape`, which is why PR #55's `api-client:lint` fails. Linting tool output only surfaces the generator's stylistic choices, so the correct fix is to exclude it rather than patch generated files.

2. **Bump `hono` override 4.12.18 → 4.12.21.** Clears the 4 medium GHSA advisories (`GHSA-2gcr-mfcq-wcc3`, `GHSA-3hrh-pfw6-9m5x`, `GHSA-f577-qrjj-4474`, `GHSA-xrhx-7g5j-rcj5`) flagged by the `osv-scanner` `dep-scan` gate. `hono` is transitive via Better Auth; lockfile now resolves `hono@4.12.23`.

## Why

`dep-scan` fails on both #54 and #55 because of the pre-existing `hono` advisory on `main`. `#55` additionally fails `api-client:lint` after the orval 8.15 bump. Landing these two fixes on `main` unblocks both dependabot PRs after a rebase.

## Verification

- `pnpm exec eslint libs/api-client/src/generated/...` → "File ignored because of a matching ignore pattern" (ignore confirmed effective).
- `pnpm nx run-many -t lint typecheck` → green across all 21 projects.
- Lockfile resolves `hono@4.12.23` (≥ 4.12.21).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude auto-generated source files from checks.
  * Increased minimum Hono dependency version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->