### PR TITLE
fix: swc es2022 target, faster local builds, docker-smoke CI, deploy-agnostic ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,11 +150,11 @@ MAIL_DEFAULT_EMAIL=noreply@example.com
 MAIL_DEFAULT_NAME="No Reply"
 MAILPIT_UI_PORT=8025
 
-# API host ports for docker compose (container internal port stays 3000/9229)
-# API_BIND_HOST controls which host interface the prod overlay publishes the api
-# on. Default 127.0.0.1 = loopback only (reverse proxy on the same host, or a
-# containerized proxy that routes over the docker network via `api:3000`). Set to
-# 0.0.0.0 only to expose the api directly on all interfaces (then firewall it).
+# PORT = api listen port inside the container + target of every compose mapping
+# (change once, dev/prod/swarm/healthcheck follow). API_PORT = host port it's
+# published on; API_BIND_HOST = host interface (127.0.0.1 = loopback, default).
+# Docker port publishing BYPASSES ufw/firewalld — gate a 0.0.0.0 bind with a
+# cloud security group or DOCKER-USER rule, not the host firewall.
 API_BIND_HOST=127.0.0.1
 API_PORT=3000
 API_DEBUG_PORT=9229

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,65 @@ jobs:
 
       - name: Build affected
         run: pnpm nx affected --target=build --base=$NX_BASE --head=$NX_HEAD --parallel=3
+
+  # `nx build` emits dist but never boots it, so runtime-only regressions slip
+  # through every job above — an swc transpile target that breaks `class extends`,
+  # a broken DI wiring, a missing runtime dep, a Dockerfile stage error. This job
+  # builds the real multi-stage images and boots the full dev stack so those fail
+  # here on the PR instead of at `release.yml` tag time. Supply-chain scanning
+  # (Trivy/SBOM/Cosign) stays in release.yml — this gate is correctness only.
+  docker-smoke:
+    needs: main
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      COMPOSE_FILE: docker/compose.yml:docker/compose.dev.yml
+      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # compose.dev.yml overrides DB/Redis/S3/SMTP hosts to service names, so the
+      # example's dev defaults are sufficient — no secrets needed for a smoke boot.
+      - name: Seed .env from example
+        run: cp .env.example .env
+
+      # depends_on chains every service (infra + migration + minio-init), so this
+      # one command builds the images and boots the whole stack. --wait blocks on
+      # worker/scheduler healthchecks; a crash loop trips --wait-timeout and fails.
+      - name: Build images and boot stack
+        run: |
+          docker compose --env-file .env up -d --build --wait --wait-timeout 300 \
+            api worker scheduler
+
+      - name: Smoke test — API health
+        run: |
+          for _ in $(seq 1 30); do
+            if curl -sf -m 2 http://127.0.0.1:3000/api/v1/health/live; then
+              echo; echo "API healthy"; exit 0
+            fi
+            sleep 2
+          done
+          echo "API did not become healthy within 60s"; exit 1
+
+      - name: Assert services are not crash-looping
+        run: |
+          fail=0
+          for svc in api worker scheduler; do
+            cid=$(docker compose --env-file .env ps -q "$svc")
+            status=$(docker inspect -f '{{.State.Status}}' "$cid")
+            restarts=$(docker inspect -f '{{.RestartCount}}' "$cid")
+            echo "$svc: status=$status restarts=$restarts"
+            { [ "$status" = "running" ] && [ "$restarts" -le 1 ]; } || fail=1
+          done
+          exit $fail
+
+      - name: Dump logs on failure
+        if: ${{ failure() }}
+        run: docker compose --env-file .env logs --tail=200 --no-color
+
+      - name: Teardown
+        if: ${{ always() }}
+        run: docker compose --env-file .env down -v --remove-orphans

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,37 +175,8 @@ jobs:
       - name: Semgrep static analysis
         run: ./scripts/security/scan-sast.sh
 
-  migrate-and-deploy:
-    needs: [security-scan, static-analysis]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: production
-
-    steps:
-      - name: Log in to Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run database migration
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          MIGRATION_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/migration:${{ github.ref_name }}
-        run: |
-          docker run --rm \
-            -e DATABASE_URL="$DATABASE_URL" \
-            "$MIGRATION_IMAGE"
-
-      - name: Deploy to Coolify
-        env:
-          COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
-          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          payload=$(jq -nc --arg tag "$RELEASE_TAG" '{tag: $tag}')
-          curl --fail --silent --show-error -X POST "$COOLIFY_WEBHOOK_URL" \
-            -H "Authorization: Bearer $COOLIFY_TOKEN" \
-            -H 'Content-Type: application/json' \
-            -d "$payload"
+  # Release stops at signed, scanned images on GHCR. Migrating the database and
+  # rolling out are deployment-specific (the target environment owns its DB
+  # credentials and rollout mechanism), so they are intentionally not wired here
+  # — pull the published image and run the migration + deploy from wherever you
+  # deploy. See docs/deployment.md.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ pnpm codegen:full                   # export OpenAPI → orval → libs/api-clie
 ├── scripts/
 │   ├── build-dev.sh          # build + start dev stack (--with-obs flag)
 │   ├── dev.sh                # hot reload: infra in Docker + app on host (nx watch + serve)
-│   ├── build-prod.sh         # build production images with SBOM + provenance
+│   ├── build-prod.sh         # build production images + boot stack (scan/sign in CI)
 │   ├── doctor.sh             # preflight: Docker, Node, pnpm, ports, .env
 │   ├── teardown.sh           # stop stack + optional volume removal
 │   └── security/             # gitleaks / osv / semgrep / trivy / cosign

--- a/apps/api/webpack.config.js
+++ b/apps/api/webpack.config.js
@@ -1,5 +1,8 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
+const {
+  SwcEs2022TargetPlugin,
+} = require('../../tools/webpack/swc-es2022-target-plugin');
 
 module.exports = {
   output: {
@@ -23,5 +26,6 @@ module.exports = {
       runtimeDependencies: ['tslib'],
       sourceMap: true,
     }),
+    new SwcEs2022TargetPlugin(),
   ],
 };

--- a/apps/api/webpack.config.js
+++ b/apps/api/webpack.config.js
@@ -1,8 +1,6 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
-const {
-  SwcEs2022TargetPlugin,
-} = require('../../tools/webpack/swc-es2022-target-plugin');
+const { SwcEs2022TargetPlugin } = require('../../tools/webpack/swc-es2022-target-plugin');
 
 module.exports = {
   output: {

--- a/apps/migration/webpack.config.js
+++ b/apps/migration/webpack.config.js
@@ -1,9 +1,7 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
 const fs = require('fs');
-const {
-  SwcEs2022TargetPlugin,
-} = require('../../tools/webpack/swc-es2022-target-plugin');
+const { SwcEs2022TargetPlugin } = require('../../tools/webpack/swc-es2022-target-plugin');
 
 // seed.mjs runs via execSync — webpack misses its imports. Nx's `runtimeDependencies`
 // resolves via `require.resolve('<pkg>/package.json')`, which @prisma/adapter-pg

--- a/apps/migration/webpack.config.js
+++ b/apps/migration/webpack.config.js
@@ -1,6 +1,9 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
 const fs = require('fs');
+const {
+  SwcEs2022TargetPlugin,
+} = require('../../tools/webpack/swc-es2022-target-plugin');
 
 // seed.mjs runs via execSync — webpack misses its imports. Nx's `runtimeDependencies`
 // resolves via `require.resolve('<pkg>/package.json')`, which @prisma/adapter-pg
@@ -50,6 +53,7 @@ module.exports = {
       runtimeDependencies: ['prisma'],
       sourceMap: true,
     }),
+    new SwcEs2022TargetPlugin(),
     new InjectSeedRuntimeDeps(),
   ],
 };

--- a/apps/scheduler/webpack.config.js
+++ b/apps/scheduler/webpack.config.js
@@ -1,8 +1,6 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
-const {
-  SwcEs2022TargetPlugin,
-} = require('../../tools/webpack/swc-es2022-target-plugin');
+const { SwcEs2022TargetPlugin } = require('../../tools/webpack/swc-es2022-target-plugin');
 
 module.exports = {
   output: {

--- a/apps/scheduler/webpack.config.js
+++ b/apps/scheduler/webpack.config.js
@@ -1,5 +1,8 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
+const {
+  SwcEs2022TargetPlugin,
+} = require('../../tools/webpack/swc-es2022-target-plugin');
 
 module.exports = {
   output: {
@@ -22,5 +25,6 @@ module.exports = {
       runtimeDependencies: ['tslib'],
       sourceMap: true,
     }),
+    new SwcEs2022TargetPlugin(),
   ],
 };

--- a/apps/worker/webpack.config.js
+++ b/apps/worker/webpack.config.js
@@ -1,8 +1,6 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
-const {
-  SwcEs2022TargetPlugin,
-} = require('../../tools/webpack/swc-es2022-target-plugin');
+const { SwcEs2022TargetPlugin } = require('../../tools/webpack/swc-es2022-target-plugin');
 
 module.exports = {
   output: {

--- a/apps/worker/webpack.config.js
+++ b/apps/worker/webpack.config.js
@@ -1,5 +1,8 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
+const {
+  SwcEs2022TargetPlugin,
+} = require('../../tools/webpack/swc-es2022-target-plugin');
 
 module.exports = {
   output: {
@@ -22,5 +25,6 @@ module.exports = {
       runtimeDependencies: ['tslib'],
       sourceMap: true,
     }),
+    new SwcEs2022TargetPlugin(),
   ],
 };

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -51,7 +51,7 @@ services:
       dockerfile: Dockerfile
       target: api-dev
     ports:
-      - '${API_PORT:-3000}:3000'
+      - '${API_PORT:-3000}:${PORT:-3000}'
       - '${API_DEBUG_PORT:-9229}:9229'
     env_file: ../.env
     environment:

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -123,14 +123,11 @@ services:
       REDIS_CACHE_HOST: redis-cache
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'
-    # Bind to loopback by default so the api is NOT reachable directly from the
-    # internet — a reverse proxy (Coolify, nginx, Traefik, …) terminates TLS and
-    # forwards traffic. A host-installed proxy reaches it via 127.0.0.1:3000; a
-    # containerized proxy on the same docker network reaches `api:3000` by service
-    # name regardless of this host bind. Set API_BIND_HOST=0.0.0.0 only if you
-    # deliberately want to expose the api on every interface (firewall it then).
+    # Loopback by default — not internet-facing. Set API_BIND_HOST=0.0.0.0 for
+    # direct exposure, but Docker's port publishing BYPASSES ufw/firewalld; gate
+    # it with a cloud security group or a DOCKER-USER rule, not the host firewall.
     ports:
-      - '${API_BIND_HOST:-127.0.0.1}:${API_PORT:-3000}:3000'
+      - '${API_BIND_HOST:-127.0.0.1}:${API_PORT:-3000}:${PORT:-3000}'
     # Long-form gates plain-compose deploys on migration completion + dependency
     # health so the api doesn't crash-loop on a fresh DB. compose.swarm.yml
     # overrides back to short-form because `docker stack deploy` rejects the
@@ -155,7 +152,7 @@ services:
           '--quiet',
           '--spider',
           '--tries=1',
-          'http://127.0.0.1:3000/api/v1/health/live',
+          'http://127.0.0.1:${PORT:-3000}/api/v1/health/live',
         ]
       interval: 30s
       timeout: 10s

--- a/docker/compose.swarm.yml
+++ b/docker/compose.swarm.yml
@@ -57,8 +57,8 @@
 # - Postgres / Redis / MinIO ports are reset (`!override []`) so they only
 #   exist on the encrypted overlay — never published on host interfaces.
 # - `api` publishes via `mode: ingress` so any node IP routes to a healthy
-#   replica via Swarm's L4 routing mesh. Front this with Caddy / Traefik /
-#   Cloudflare for TLS termination.
+#   replica via Swarm's L4 routing mesh. Terminate TLS in front of it with
+#   whatever the deployment uses (host proxy, tunnel, or a cloud L4 LB).
 # - For full secret-management, promote `POSTGRES_PASSWORD`,
 #   `BETTER_AUTH_SECRET`, etc. to `docker secret` and switch the postgres
 #   image to `POSTGRES_PASSWORD_FILE`. Out of scope here to keep .env-based
@@ -161,7 +161,7 @@ services:
     # Override the host-port mapping inherited from compose.yml: in Swarm we
     # publish via the routing mesh so any node IP can serve traffic.
     ports: !override
-      - target: 3000
+      - target: ${PORT:-3000}
         published: ${API_PORT:-3000}
         protocol: tcp
         mode: ingress

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -168,8 +168,9 @@ Config files live under `docker/prometheus/`, `docker/otel-collector/`, and `doc
      the workflow ref, recorded in the public Rekor log.
    - Gates on **Trivy** image scan (HIGH/CRITICAL, fixable only) and
      **Semgrep** SAST (TS/Node/OWASP rule packs).
-   - Migrates the database and triggers Coolify deploy only after every gate
-     passes.
+4. Roll out from your target environment: pull the published tag from GHCR, run
+   the migration image against the prod database, then start/restart the
+   services. This step is deployment-specific and intentionally left out of CI.
 
 See [docs/security.md](./security.md) for the full scanner inventory and how
 to verify a signed tag locally with `cosign verify`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,39 +88,30 @@ scheduler replica, and excludes mailpit via the `dev-only` profile.
 ## Network Exposure & Port Binding
 
 The base `compose.yml` publishes host ports for Postgres, Redis, and MinIO as a
-**dev convenience**. Short-form mappings (`5432:5432`) bind to `0.0.0.0`, so on a
-host with a public IP and no firewall those data services would be reachable from
-the internet. The `compose.prod.yml` overlay closes this:
+**dev convenience**. Short-form mappings (`5432:5432`) bind `0.0.0.0` _through
+Docker's own iptables chain, which bypasses `ufw`/`firewalld`_ — on a public-IP
+host they are internet-reachable even behind a "deny" rule. The
+`compose.prod.yml` overlay closes this:
 
-| Service                                      | Host port in prod overlay                            | Reachable by                                                                    |
-| -------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
-| postgres / redis-cache / redis-queue / minio | none — stripped via `ports: !override []`            | other containers only, by service name (`postgres:5432`, `redis-cache:6379`, …) |
-| api                                          | `${API_BIND_HOST:-127.0.0.1}:${API_PORT:-3000}:3000` | a reverse proxy (see below) — **not** the public internet by default            |
+| Service                                      | Host port in prod overlay                                     | Reachable by                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| postgres / redis-cache / redis-queue / minio | none — stripped via `ports: !override []`                     | other containers only, by service name (`postgres:5432`, `redis-cache:6379`, …) |
+| api                                          | `${API_BIND_HOST:-127.0.0.1}:${API_PORT:-3000}:${PORT:-3000}` | loopback only by default — **not** the public internet                          |
 
-Apps connect to the data tier over the internal compose network using service
-names, so removing the host ports changes nothing for runtime — it only removes
-the attack surface.
+### Exposing the api
 
-### Reverse proxy models
+Loopback (`127.0.0.1`) by default, so the api is never internet-facing out of
+the box. This image is deploy-agnostic — pick whichever fits, nothing else changes:
 
-The api binds to **loopback (`127.0.0.1`) by default**, so it is never directly
-internet-facing. Front it with an L7 reverse proxy (Coolify, nginx, Traefik,
-Caddy, ALB) that terminates TLS, forwards `X-Forwarded-For`, and proxies
-WebSocket upgrades. Two valid topologies:
+- **TLS proxy on the host** (nginx/Caddy/…) → `proxy_pass http://127.0.0.1:${API_PORT}`.
+- **Proxy or tunnel container on the compose network** → reaches `api:${PORT}` by
+  Docker DNS, ignoring the host bind. A `cloudflared`/Tailscale sidecar needs no
+  published host port at all — drop `ports:` on the api service entirely.
+- **Direct exposure** (managed L4 LB, or none) → set `API_BIND_HOST=0.0.0.0`.
 
-- **Proxy installed on the host** (nginx/Traefik on the VM, not a container) —
-  it reaches the api via `proxy_pass http://127.0.0.1:3000`. The loopback bind is
-  required here. ✅ works out of the box.
-- **Proxy running as a container** (Coolify-managed, or a dockerized
-  Traefik/nginx that joins the same network) — it routes to `api:3000` by Docker
-  DNS, ignoring the host bind entirely. The loopback bind is harmless. For a
-  fully port-less api, additionally set `ports: !override []` on the api service
-  and attach the proxy to the compose network; the host then publishes nothing
-  but the proxy's 80/443.
-
-Set `API_BIND_HOST=0.0.0.0` **only** if you deliberately want the api exposed on
-every interface (e.g. no proxy, or a managed LB on another host) — firewall the
-port in that case.
+> Docker port publishing **bypasses `ufw`/`firewalld`** — a `0.0.0.0` bind is
+> internet-open even behind a host "deny" rule. Gate it with a cloud security
+> group or a `DOCKER-USER` iptables rule.
 
 > **Swarm note**: `compose.swarm.yml` publishes the api through the routing mesh
 > (`ports: !override` with `mode: ingress`) and strips the data-tier ports the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,7 +41,7 @@ docker build -f Dockerfile --target migration -t your-registry/nestjs-migration:
 For all four in one shot (BuildKit shares stages across siblings):
 
 ```bash
-./scripts/build-prod.sh                       # gated by Trivy on local
+./scripts/build-prod.sh                       # build + boot only; Trivy/SBOM/sign live in CI (release.yml)
 ```
 
 ## Database Migrations

--- a/docs/security.md
+++ b/docs/security.md
@@ -70,8 +70,10 @@ misconfigurations.
 TRIVY_EXIT_CODE=0 ./scripts/security/scan-images.sh   # warn-only
 ```
 
-The `build-prod.sh` script gates on this by default. `build-dev.sh` runs
-Trivy too but warn-only — dev images carry devDeps so the noise floor is high.
+Image scanning is enforced in CI (`release.yml` runs Trivy per app on tag and
+uploads SARIF to GitHub Security). The local `build-*.sh` scripts deliberately
+skip it to keep the inner loop fast — run `scripts/security/scan-images.sh`
+manually when you want a pre-push check.
 
 ### Cosign — supply-chain signatures
 
@@ -102,8 +104,11 @@ back to a specific commit, workflow run, and signing identity.
 ./scripts/security/scan-secrets.sh
 ./scripts/security/scan-deps.sh
 
-# After building production images
-./scripts/build-prod.sh    # gates Trivy automatically
+# Build production images locally (fast — no scan); CI owns the security gate
+./scripts/build-prod.sh
+
+# Optional pre-push image scan (CI parity)
+./scripts/security/scan-images.sh
 ```
 
 Lefthook wires Gitleaks into `pre-commit` (staged hunks) and `pre-push`

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -9,8 +9,12 @@
 #   --with-obs    Include the observability overlay (Prometheus, Grafana, Jaeger, OTel)
 #
 # Env flags:
-#   NO_CACHE=1     full clean rebuild (default: incremental)
-#   TRIVY_SCAN=0   skip vulnerability scan
+#   NO_CACHE=1       full clean rebuild (default: incremental)
+#   BUILD_PARALLEL=1 build all services concurrently (default: serial)
+#
+# Security scanning (Trivy/SBOM/etc.) is intentionally NOT run here — it lives in
+# CI (.github/workflows). Local builds stay fast; run scripts/security/*.sh
+# manually if you need local parity.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,8 +34,8 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   echo "  --with-obs    Also start the observability stack (Prometheus/Grafana/Jaeger/OTel)"
   echo ""
   echo "Env flags:"
-  echo "  NO_CACHE=1    Full clean rebuild"
-  echo "  TRIVY_SCAN=0  Skip Trivy vulnerability scan"
+  echo "  NO_CACHE=1        Full clean rebuild"
+  echo "  BUILD_PARALLEL=1  Build all services concurrently (default: serial)"
   echo ""
   echo "Examples:"
   echo "  ./scripts/build-dev.sh"
@@ -161,56 +165,8 @@ if printf '%s\n' "${SERVICES[@]}" | grep -qx api; then
 fi
 
 # Compose tags as `<project>-<service>:latest`; project name defaults to the
-# directory name unless COMPOSE_PROJECT_NAME is set. Used by trivy scan and
-# the build report below.
+# directory name unless COMPOSE_PROJECT_NAME is set. Used by the build report below.
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}"
-
-# Dev images carry devDeps so unfixed-and-noisy CVEs are normal: gate is OFF
-# (TRIVY_EXIT_CODE=0). Awareness, not blocking. Set TRIVY_SCAN=0 to skip.
-#
-# api/worker/scheduler all derive from the shared `workspace` stage, so they
-# share identical base layers. Scanning all three would produce duplicate CVE
-# reports for every Node/OS finding. Scan only the first built image and note
-# that its findings cover the shared workspace layers for all three services.
-if [[ "${TRIVY_SCAN:-1}" = "1" ]] && command -v docker >/dev/null 2>&1; then
-  echo ""
-  sec::log "Image vulnerability scan (Trivy, warn-only on dev images)"
-
-  # Collect built images in order; stop at the first one that exists.
-  SCAN_IMG=""
-  SCAN_SVC=""
-  for svc in "${SERVICES[@]}"; do
-    img="${COMPOSE_PROJECT_NAME}-${svc}:latest"
-    if docker image inspect "$img" >/dev/null 2>&1; then
-      SCAN_IMG="$img"
-      SCAN_SVC="$svc"
-      break
-    fi
-  done
-
-  if [[ -n "$SCAN_IMG" ]]; then
-    echo ""
-    echo "--- trivy: ${SCAN_SVC} (workspace base layers shared by all services) ---"
-    MSYS_NO_PATHCONV=1 docker run --rm \
-      -v //var/run/docker.sock:/var/run/docker.sock \
-      -v "${HOME}/.cache/trivy:/root/.cache/trivy" \
-      aquasec/trivy:0.62.0 image \
-      --severity HIGH,CRITICAL \
-      --ignore-unfixed \
-      --scanners vuln \
-      --exit-code 0 \
-      --format table \
-      "$SCAN_IMG" || true
-
-    # Report skipped services so the output is explicit, not silently absent.
-    for svc in "${SERVICES[@]}"; do
-      [[ "$svc" == "$SCAN_SVC" ]] && continue
-      img="${COMPOSE_PROJECT_NAME}-${svc}:latest"
-      docker image inspect "$img" >/dev/null 2>&1 \
-        && sec::log "Skipping trivy: ${svc} — same workspace base layers as ${SCAN_SVC}"
-    done
-  fi
-fi
 
 # --- Build report -----------------------------------------------------------
 echo ""

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -30,16 +30,15 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   echo "  MAIL_HOST             empty / localhost / mailpit -> bundle local Mailpit"
   echo ""
   echo "Env flags:"
-  echo "  TRIVY_SCAN=0        Skip Trivy gate"
-  echo "  TRIVY_EXIT_CODE=0   Demote Trivy failures to warnings"
-  echo "  ATTEST_SKIP=1       Skip SBOM + provenance attestations (faster local iteration)"
   echo "  NO_UP=1             Skip the auto-up step (build only)"
   echo "  IMAGE_NAMESPACE     Required for registry push; defaults to 'local' for smoke"
   echo ""
+  echo "Security scanning + SBOM/provenance attestations are NOT run here — they"
+  echo "live in CI (.github/workflows/release.yml: Trivy, Cosign, SBOM, provenance)."
+  echo "Local builds stay fast; run scripts/security/*.sh manually for local parity."
+  echo ""
   echo "Examples:"
   echo "  ./scripts/build-prod.sh"
-  echo "  TRIVY_EXIT_CODE=0 ./scripts/build-prod.sh   # warn-only scan"
-  echo "  TRIVY_SCAN=0 ./scripts/build-prod.sh        # skip scan"
   echo "  NO_UP=1 ./scripts/build-prod.sh             # only build, do not start stack"
   exit 0
 fi
@@ -63,14 +62,12 @@ PREFIX="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}"
 
 sec::log "Building production images under ${PREFIX}/*:${IMAGE_TAG}"
 
-# SBOM + max-mode provenance attestations let Scout/Trivy/registry policy engines
-# reason about the image without re-indexing the filesystem. Set ATTEST_SKIP=1
-# to disable when iterating locally — syft can flake on slow disks.
-ATTEST_ARGS=(--sbom=true --provenance=mode=max)
-if [[ "${ATTEST_SKIP:-0}" = "1" ]]; then
-  ATTEST_ARGS=()
-  sec::warn "Attestations disabled (ATTEST_SKIP=1)"
-fi
+# SBOM + provenance attestations are produced by CI (release.yml) on the pushed
+# image, not here — local builds only `--load` into the daemon for smoke tests,
+# where attestations add minutes (syft filesystem indexing) for no benefit.
+# buildx still emits a default (min) provenance manifest unless told otherwise,
+# so disable default attestations explicitly — they double the export phase.
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
 build() {
   local app="$1" dockerfile="$2" target="${3:-}"
@@ -78,7 +75,7 @@ build() {
   [[ -n "$target" ]] && target_args=(--target "$target")
   echo ""
   echo "--- ${app} ---"
-  docker buildx build -f "$dockerfile" "${target_args[@]}" "${ATTEST_ARGS[@]}" \
+  docker buildx build -f "$dockerfile" "${target_args[@]}" \
     --load -t "${PREFIX}/${app}:${IMAGE_TAG}" .
 }
 
@@ -95,18 +92,9 @@ sec::ok "All production images built:"
 docker images --format 'table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}' \
   | grep -E "^${PREFIX}/(api|worker|scheduler|migration):${IMAGE_TAG}\b" || true
 
-# Image scan via shared helper. Local prod-build defaults to gate ON (CI parity);
-# pass TRIVY_EXIT_CODE=0 to demote to warn-only, TRIVY_SCAN=0 to skip entirely.
-if [[ "${TRIVY_SCAN:-1}" = "1" ]]; then
-  echo ""
-  sec::log "Image vulnerability scan (Trivy)"
-  ./scripts/security/scan-images.sh || {
-    echo ""
-    sec::err "Trivy gate failed. To inspect:  ./scripts/security/scan-images.sh <app>"
-    sec::err "To bypass for a quick local smoke:  TRIVY_EXIT_CODE=0 ./scripts/build-prod.sh"
-    exit 1
-  }
-fi
+# Image vulnerability scanning is the CI gate's job (release.yml runs Trivy per
+# app and uploads SARIF to GitHub Security). Run ./scripts/security/scan-images.sh
+# manually if you need a local pre-push check.
 
 if [[ "${NO_UP:-0}" = "1" ]]; then
   echo ""

--- a/tools/webpack/swc-es2022-target-plugin.js
+++ b/tools/webpack/swc-es2022-target-plugin.js
@@ -1,0 +1,24 @@
+// @nx/webpack injects swc-loader without a `jsc.target`, so swc falls back to its
+// es3/es5 default and downlevels every `class` into an ES5 `_super.call(this)` shim.
+// That breaks any class extending a NATIVE es-class from node_modules (which webpack
+// never transpiles) — e.g. `WorkerHost`/`QueueEventsHost` from @nestjs/bullmq throw
+// "Class constructor X cannot be invoked without 'new'" at DI instantiation.
+// Pin the target to es2022 (matching tsconfig.base) so classes stay native and `super()`
+// stays a real `super` call. Runs AFTER NxAppWebpackPlugin, which has already pushed the
+// swc-loader rule onto compiler.options.module.rules synchronously inside its apply().
+class SwcEs2022TargetPlugin {
+  apply(compiler) {
+    const rules = compiler.options.module?.rules ?? [];
+    for (const rule of rules) {
+      if (!rule || typeof rule !== 'object') continue;
+      const loader = rule.loader;
+      if (typeof loader === 'string' && loader.includes('swc-loader')) {
+        rule.options ??= {};
+        rule.options.jsc ??= {};
+        rule.options.jsc.target = 'es2022';
+      }
+    }
+  }
+}
+
+module.exports = { SwcEs2022TargetPlugin };


### PR DESCRIPTION
## Summary

Fixes the `api`/`worker` Docker crash loop introduced by the tsc→swc switch, then cleans up the build pipeline and port/deploy posture.

## Changes

- **fix(swc target):** `@nx/webpack` injected swc-loader without `jsc.target`, so swc downlevelled `class extends` to ES5 `_super.call()`. Classes extending native ES6 `WorkerHost`/`QueueEventsHost` (`@nestjs/bullmq`) then threw `Class constructor cannot be invoked without 'new'`. A small webpack plugin pins `jsc.target=es2022`. Verified: `_callSuper=0`, containers boot clean.
- **perf(scripts):** moved Trivy + SBOM/provenance out of `build-dev.sh`/`build-prod.sh` into CI. Measured `build-prod` 312s → 95s (−70%). `scripts/security/*.sh` kept for manual parity.
- **ci(docker-smoke):** new job builds the real multi-stage images and boots the full dev stack with a health check — catches runtime-only regressions (like the swc one) that `nx build` cannot.
- **fix(docker ports):** `PORT` is now the single source of truth (mapping target + healthcheck follow it); documented that Docker port publishing bypasses `ufw`/`firewalld`; removed reverse-proxy lock-in — image is deploy-agnostic.
- **ci(release):** release stops at signed, scanned images on GHCR; migrate + deploy left to the target environment (removed the Coolify-specific deploy job).

## Verification

- Local: `nx affected -t lint test build typecheck` green for 21 projects
- Docker: rebuilt `api`+`worker`, smoke `GET /health/live` ok, no crash loop
- Port env-drive verified via `docker compose config` with `PORT=8080`

CI `docker-smoke` runs here for the first time — watching it on this PR.