### PR TITLE
fix: remediate deep code-audit findings (6 high + 9 medium)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 
 on:
+  push:
+    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
 

--- a/apps/api/src/common/filters/fastify-error-handler.spec.ts
+++ b/apps/api/src/common/filters/fastify-error-handler.spec.ts
@@ -136,6 +136,27 @@ describe('applyFastifyErrorHandler', () => {
     }
   });
 
+  it('does not pass through a pre-shaped 5xx body unmasked in production', async () => {
+    app.get('/preshaped-5xx', async () => {
+      throw {
+        type: 'about:blank',
+        title: 'Internal Server Error',
+        status: 503,
+        detail: 'upstream postgres at 10.0.0.5 refused connection',
+      };
+    });
+
+    const prev = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'production';
+    try {
+      const res = await app.inject({ method: 'GET', url: '/preshaped-5xx' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json().detail).not.toContain('10.0.0.5');
+    } finally {
+      process.env['NODE_ENV'] = prev;
+    }
+  });
+
   it('does not overwrite a hijacked reply', async () => {
     app.get('/hijack', async (_req, reply) => {
       reply.hijack();

--- a/apps/api/src/common/filters/fastify-error-handler.spec.ts
+++ b/apps/api/src/common/filters/fastify-error-handler.spec.ts
@@ -117,6 +117,25 @@ describe('applyFastifyErrorHandler', () => {
     expect(res.headers['x-request-id']).toBe('caller-supplied-id-123');
   });
 
+  it('masks 5xx detail in production but keeps it in non-production', async () => {
+    app.get('/leak', async () => {
+      throw new Error('internal db connection string leak');
+    });
+
+    const devRes = await app.inject({ method: 'GET', url: '/leak' });
+    expect(devRes.json().detail).toBe('internal db connection string leak');
+
+    const prev = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'production';
+    try {
+      const prodRes = await app.inject({ method: 'GET', url: '/leak' });
+      expect(prodRes.json().detail).toBe('Internal Server Error');
+      expect(prodRes.json().detail).not.toContain('leak');
+    } finally {
+      process.env['NODE_ENV'] = prev;
+    }
+  });
+
   it('does not overwrite a hijacked reply', async () => {
     app.get('/hijack', async (_req, reply) => {
       reply.hijack();

--- a/apps/api/src/common/filters/fastify-error-handler.ts
+++ b/apps/api/src/common/filters/fastify-error-handler.ts
@@ -53,8 +53,11 @@ export function applyFastifyErrorHandler(fastify: FastifyInstance): void {
       reply.header('x-request-id', requestId);
     }
 
-    // Pass through pre-shaped RFC 9457 bodies (@fastify/rate-limit) — rebuilding drops plugin-specific fields.
-    if (isProblemDetailsShape(error)) {
+    // Pass through pre-shaped RFC 9457 bodies (@fastify/rate-limit) — rebuilding
+    // drops plugin-specific fields. A production 5xx still falls through to the
+    // masked rebuild below so internal detail never leaks.
+    const isProdServerError = status >= 500 && process.env['NODE_ENV'] === 'production';
+    if (isProblemDetailsShape(error) && !isProdServerError) {
       void reply.status(status).header('content-type', PROBLEM_CONTENT_TYPE).send(error);
       return;
     }

--- a/apps/api/src/common/filters/fastify-error-handler.ts
+++ b/apps/api/src/common/filters/fastify-error-handler.ts
@@ -35,7 +35,9 @@ export function applyFastifyErrorHandler(fastify: FastifyInstance): void {
     const status = resolveStatus(error);
     const code = resolveCode(error, status);
     const title = HTTP_STATUS_TITLES[status] ?? 'Error';
-    const detail = error.message || title;
+    // Mask 5xx detail in production — raw FST_ERR_*/driver messages can leak internals.
+    const detail =
+      status >= 500 && process.env['NODE_ENV'] === 'production' ? title : error.message || title;
 
     if (status >= 500) {
       logger.error({ err: error, url: request.url }, 'Fastify-level exception');

--- a/apps/api/src/common/filters/global-exception.filter.ts
+++ b/apps/api/src/common/filters/global-exception.filter.ts
@@ -25,7 +25,7 @@ import {
   PROBLEM_CONTENT_TYPE,
 } from './problem-details.helper';
 
-type RawWithIds = IncomingMessage & { requestId?: string };
+type RawWithIds = IncomingMessage & { requestId?: string; correlationId?: string };
 
 interface NormalizedError {
   status: number;
@@ -81,7 +81,9 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
     if (normalized.status >= 500) {
       this.logger.error({ err: exception, url: request.url }, 'Unhandled exception');
-      Sentry.captureException(exception);
+      Sentry.captureException(exception, {
+        tags: { requestId: raw.requestId, correlationId: raw.correlationId },
+      });
     } else if (
       normalized.status === HttpStatus.UNAUTHORIZED ||
       normalized.status === HttpStatus.FORBIDDEN

--- a/apps/api/src/common/health/bullmq-health.indicator.spec.ts
+++ b/apps/api/src/common/health/bullmq-health.indicator.spec.ts
@@ -4,11 +4,13 @@ import { HealthCheckError } from '@nestjs/terminus';
 import type { ConfigService } from '@nestjs/config';
 import type { EnvConfig } from '../../config/env.validation';
 
-const mockQueue = {
-  getJobCounts: vi.fn(),
-  close: vi.fn().mockResolvedValue(undefined),
-  on: vi.fn(),
-};
+const { mockQueue } = vi.hoisted(() => ({
+  mockQueue: {
+    getJobCounts: vi.fn(),
+    close: vi.fn(() => Promise.resolve()),
+    on: vi.fn(),
+  },
+}));
 
 vi.mock('bullmq', () => ({
   Queue: class {

--- a/apps/api/src/common/health/bullmq-health.indicator.spec.ts
+++ b/apps/api/src/common/health/bullmq-health.indicator.spec.ts
@@ -1,0 +1,60 @@
+/// <reference types="vitest/globals" />
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { HealthCheckError } from '@nestjs/terminus';
+import type { ConfigService } from '@nestjs/config';
+import type { EnvConfig } from '../../config/env.validation';
+
+const mockQueue = {
+  getJobCounts: vi.fn(),
+  close: vi.fn().mockResolvedValue(undefined),
+  on: vi.fn(),
+};
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    constructor() {
+      return mockQueue;
+    }
+  },
+}));
+
+import { BullMqHealthIndicator } from './bullmq-health.indicator';
+
+function buildConfig(): ConfigService<EnvConfig, true> {
+  const values: Record<string, unknown> = {
+    REDIS_QUEUE_HOST: 'localhost',
+    REDIS_QUEUE_PORT: 6380,
+    REDIS_QUEUE_PREFIX: 'bull',
+  };
+  return { get: (key: string) => values[key] } as unknown as ConfigService<EnvConfig, true>;
+}
+
+describe('BullMqHealthIndicator', () => {
+  let indicator: BullMqHealthIndicator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    indicator = new BullMqHealthIndicator(buildConfig());
+  });
+
+  it('reports up when the queue responds', async () => {
+    mockQueue.getJobCounts.mockResolvedValueOnce({ waiting: 0 });
+
+    const result = await indicator.isHealthy('bullmq');
+
+    expect(result['bullmq'].status).toBe('up');
+    expect(mockQueue.getJobCounts).toHaveBeenCalledWith('waiting');
+  });
+
+  it('throws HealthCheckError when the queue probe fails', async () => {
+    mockQueue.getJobCounts.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(indicator.isHealthy('bullmq')).rejects.toBeInstanceOf(HealthCheckError);
+  });
+
+  it('closes the queue on shutdown', async () => {
+    await indicator.onModuleDestroy();
+
+    expect(mockQueue.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/common/swagger/export-spec.ts
+++ b/apps/api/src/common/swagger/export-spec.ts
@@ -34,6 +34,28 @@ process.stderr.write = ((...args: StderrWriteArgs): boolean => {
   return origStderrWrite(...args);
 }) as typeof process.stderr.write;
 
+// Swallow Redis connection failures (codegen has no Redis service); the spec
+// only needs the DI graph. Any other fault still fails the build.
+const isRedisConnectionError = (err: unknown): boolean => {
+  const parts = [String((err as Error)?.message ?? err), (err as { code?: string })?.code ?? ''];
+  const nested = (err as AggregateError)?.errors;
+  if (Array.isArray(nested))
+    parts.push(...nested.map((e) => `${e?.message ?? ''} ${e?.code ?? ''}`));
+  return /ECONNREFUSED|ioredis/i.test(parts.join(' '));
+};
+process.on('uncaughtException', (err) => {
+  if (isRedisConnectionError(err)) return;
+  origStderrWrite(
+    `Uncaught exception during spec export: ${(err as Error)?.stack ?? String(err)}\n`,
+  );
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  if (isRedisConnectionError(reason)) return;
+  origStderrWrite(`Unhandled rejection during spec export: ${String(reason)}\n`);
+  process.exit(1);
+});
+
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';

--- a/apps/api/src/config/env.validation.spec.ts
+++ b/apps/api/src/config/env.validation.spec.ts
@@ -16,6 +16,7 @@ const baseProdEnv = {
   STORAGE_SECRET_KEY: 'real-secret',
   BULL_BOARD_PASSWORD: 'strong-pw',
   MAIL_IGNORE_TLS: 'false',
+  MAIL_REQUIRE_TLS: 'true',
 };
 
 describe('validateConfig', () => {
@@ -100,6 +101,12 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ ...baseProdEnv, MAIL_IGNORE_TLS: 'true' })).toThrow(
       /MAIL_IGNORE_TLS/,
     );
+  });
+
+  it('requires MAIL_SECURE or MAIL_REQUIRE_TLS in production', () => {
+    expect(() =>
+      validateConfig({ ...baseProdEnv, MAIL_SECURE: 'false', MAIL_REQUIRE_TLS: 'false' }),
+    ).toThrow(/MAIL_REQUIRE_TLS/);
   });
 
   it('rejects default bull board password in production', () => {

--- a/apps/api/src/config/env.validation.spec.ts
+++ b/apps/api/src/config/env.validation.spec.ts
@@ -15,6 +15,7 @@ const baseProdEnv = {
   STORAGE_ACCESS_KEY: 'real-key',
   STORAGE_SECRET_KEY: 'real-secret',
   BULL_BOARD_PASSWORD: 'strong-pw',
+  MAIL_IGNORE_TLS: 'false',
 };
 
 describe('validateConfig', () => {
@@ -93,6 +94,12 @@ describe('validateConfig', () => {
 
   it('rejects localhost mail host in production', () => {
     expect(() => validateConfig({ ...baseProdEnv, MAIL_HOST: 'localhost' })).toThrow(/MAIL_HOST/);
+  });
+
+  it('rejects MAIL_IGNORE_TLS=true in production', () => {
+    expect(() => validateConfig({ ...baseProdEnv, MAIL_IGNORE_TLS: 'true' })).toThrow(
+      /MAIL_IGNORE_TLS/,
+    );
   });
 
   it('rejects default bull board password in production', () => {

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -217,6 +217,15 @@ const envSchema = z
       });
     }
 
+    if (data.MAIL_IGNORE_TLS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['MAIL_IGNORE_TLS'],
+        message:
+          'MAIL_IGNORE_TLS must be false in production — sending SMTP credentials without TLS exposes them in plaintext',
+      });
+    }
+
     if (data.CORS_ORIGINS.length === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -217,12 +217,21 @@ const envSchema = z
       });
     }
 
+    // SMTP runs in the worker, but api and worker share one .env in prod, so
+    // both validators enforce TLS to keep credentials off the wire.
     if (data.MAIL_IGNORE_TLS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['MAIL_IGNORE_TLS'],
         message:
           'MAIL_IGNORE_TLS must be false in production — sending SMTP credentials without TLS exposes them in plaintext',
+      });
+    }
+    if (!data.MAIL_SECURE && !data.MAIL_REQUIRE_TLS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['MAIL_REQUIRE_TLS'],
+        message: 'Enable MAIL_SECURE or MAIL_REQUIRE_TLS in production so SMTP negotiates TLS',
       });
     }
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -27,7 +27,7 @@ if (sentryDsn) {
   // Cap prod sample rates to avoid burning through Sentry quota.
   const sampleRateCap = isProduction ? 0.1 : 1;
   const tracesSampleRate = Math.min(
-    Number(process.env['SENTRY_TRACES_SAMPLE_RATE'] ?? 0.1),
+    Number(process.env['SENTRY_TRACES_SAMPLE_RATE'] ?? 0.01),
     sampleRateCap,
   );
   const profilesSampleRate = Math.min(0.1, sampleRateCap);
@@ -116,7 +116,6 @@ async function bootstrap() {
             scriptSrc: [
               "'self'",
               "'unsafe-inline'",
-              "'unsafe-eval'",
               'https://cdn.jsdelivr.net',
               'https://*.scalar.com',
             ],

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -26,10 +26,8 @@ if (sentryDsn) {
   const isProduction = process.env['NODE_ENV'] === 'production';
   // Cap prod sample rates to avoid burning through Sentry quota.
   const sampleRateCap = isProduction ? 0.1 : 1;
-  const tracesSampleRate = Math.min(
-    Number(process.env['SENTRY_TRACES_SAMPLE_RATE'] ?? 0.01),
-    sampleRateCap,
-  );
+  const parsedRate = Number(process.env['SENTRY_TRACES_SAMPLE_RATE'] ?? 0.01);
+  const tracesSampleRate = Math.min(Number.isFinite(parsedRate) ? parsedRate : 0.01, sampleRateCap);
   const profilesSampleRate = Math.min(0.1, sampleRateCap);
 
   Sentry.init({

--- a/apps/api/src/websocket/notification.gateway.ts
+++ b/apps/api/src/websocket/notification.gateway.ts
@@ -67,7 +67,7 @@ export class NotificationGateway
   afterInit(server: Server): void {
     // null after the cap stops ioredis reconnecting forever on a dead Redis.
     const retryStrategy = (times: number): number | null =>
-      times > 10 ? null : Math.min(times * 100, 3000);
+      times >= 10 ? null : Math.min(times * 100, 3000);
     const host = this.config.get('REDIS_CACHE_HOST', { infer: true });
     const port = this.config.get('REDIS_CACHE_PORT', { infer: true });
 

--- a/apps/api/src/websocket/notification.gateway.ts
+++ b/apps/api/src/websocket/notification.gateway.ts
@@ -65,7 +65,9 @@ export class NotificationGateway
   ) {}
 
   afterInit(server: Server): void {
-    const retryStrategy = (times: number) => Math.min(times * 100, 3000);
+    // null after the cap stops ioredis reconnecting forever on a dead Redis.
+    const retryStrategy = (times: number): number | null =>
+      times > 10 ? null : Math.min(times * 100, 3000);
     const host = this.config.get('REDIS_CACHE_HOST', { infer: true });
     const port = this.config.get('REDIS_CACHE_PORT', { infer: true });
 

--- a/apps/scheduler/src/main.ts
+++ b/apps/scheduler/src/main.ts
@@ -1,3 +1,4 @@
+import './tracing';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app/app.module';

--- a/apps/scheduler/src/tracing.ts
+++ b/apps/scheduler/src/tracing.ts
@@ -1,0 +1,10 @@
+/**
+ * OpenTelemetry SDK bootstrap for the cron scheduler. Must be imported at
+ * the very top of `main.ts` so the SDK patches native modules
+ * (`http`/`pg`/`ioredis`/etc.) before Nest or @nestjs/schedule resolve them.
+ *
+ * The SDK is a no-op unless `OTEL_ENABLED=true`.
+ */
+import { startTracing } from '@nestjs-fastify-nx/infra-observability';
+
+startTracing({ serviceName: 'nestjs-fastify-scheduler' });

--- a/apps/worker/src/config/env.validation.ts
+++ b/apps/worker/src/config/env.validation.ts
@@ -1,81 +1,100 @@
 import { z } from 'zod';
 
-const workerEnvSchema = z.object({
-  // Database (used by domain-event outbox / future audit-log writers if any)
-  DATABASE_URL: z.string().trim().min(1).optional(),
-  // Mirrors the api validator — accepted but unused by the worker at runtime.
-  // Validated here so .env.example parity is enforced and misconfiguration surfaces
-  // at boot rather than silently being ignored.
-  DATABASE_DIRECT_URL: z.string().trim().min(1).optional(),
-  // Mirrors api validator for .env.example parity — worker has zero DB connections.
-  DATABASE_REPLICA_URL: z.string().trim().min(1).optional(),
-  DATABASE_REPLICA_POOL_MAX: z.coerce.number().int().min(1).max(1000).default(10),
+const workerEnvSchema = z
+  .object({
+    // Database (used by domain-event outbox / future audit-log writers if any)
+    DATABASE_URL: z.string().trim().min(1).optional(),
+    // Mirrors the api validator — accepted but unused by the worker at runtime.
+    // Validated here so .env.example parity is enforced and misconfiguration surfaces
+    // at boot rather than silently being ignored.
+    DATABASE_DIRECT_URL: z.string().trim().min(1).optional(),
+    // Mirrors api validator for .env.example parity — worker has zero DB connections.
+    DATABASE_REPLICA_URL: z.string().trim().min(1).optional(),
+    DATABASE_REPLICA_POOL_MAX: z.coerce.number().int().min(1).max(1000).default(10),
 
-  // Redis queue
-  REDIS_QUEUE_HOST: z.string().default('localhost'),
-  REDIS_QUEUE_PORT: z.coerce.number().int().min(1).max(65535).default(6380),
-  REDIS_QUEUE_PREFIX: z.string().default('bull'),
+    // Redis queue
+    REDIS_QUEUE_HOST: z.string().default('localhost'),
+    REDIS_QUEUE_PORT: z.coerce.number().int().min(1).max(65535).default(6380),
+    REDIS_QUEUE_PREFIX: z.string().default('bull'),
 
-  // Storage (S3 / MinIO) — needed by the upload-verification processor.
-  STORAGE_ENDPOINT: z.string().default('http://localhost:9000'),
-  STORAGE_BUCKET: z.string().default('uploads'),
-  STORAGE_REGION: z.string().default('us-east-1'),
-  STORAGE_ACCESS_KEY: z.string().default('minioadmin'),
-  STORAGE_SECRET_KEY: z.string().default('minioadmin'),
+    // Storage (S3 / MinIO) — needed by the upload-verification processor.
+    STORAGE_ENDPOINT: z.string().default('http://localhost:9000'),
+    STORAGE_BUCKET: z.string().default('uploads'),
+    STORAGE_REGION: z.string().default('us-east-1'),
+    STORAGE_ACCESS_KEY: z.string().default('minioadmin'),
+    STORAGE_SECRET_KEY: z.string().default('minioadmin'),
 
-  // Mail (Nodemailer SMTP)
-  MAIL_HOST: z.string().default('localhost'),
-  MAIL_PORT: z.coerce.number().int().min(1).max(65535).default(1025),
-  MAIL_USER: z.string().default(''),
-  MAIL_PASSWORD: z.string().default(''),
-  MAIL_IGNORE_TLS: z
-    .string()
-    .default('true')
-    .transform((v) => v === 'true'),
-  MAIL_SECURE: z
-    .string()
-    .default('false')
-    .transform((v) => v === 'true'),
-  MAIL_REQUIRE_TLS: z
-    .string()
-    .default('false')
-    .transform((v) => v === 'true'),
-  MAIL_DEFAULT_EMAIL: z.string().email().default('noreply@example.com'),
-  MAIL_DEFAULT_NAME: z.string().default('No Reply'),
+    // Mail (Nodemailer SMTP)
+    MAIL_HOST: z.string().default('localhost'),
+    MAIL_PORT: z.coerce.number().int().min(1).max(65535).default(1025),
+    MAIL_USER: z.string().default(''),
+    MAIL_PASSWORD: z.string().default(''),
+    MAIL_IGNORE_TLS: z
+      .string()
+      .default('true')
+      .transform((v) => v === 'true'),
+    MAIL_SECURE: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
+    MAIL_REQUIRE_TLS: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
+    MAIL_DEFAULT_EMAIL: z.string().email().default('noreply@example.com'),
+    MAIL_DEFAULT_NAME: z.string().default('No Reply'),
 
-  // Per-queue worker concurrency. Evaluated at module load time (process.env is
-  // already populated by ConfigModule). Increase for I/O-bound queues before
-  // scaling WORKER_REPLICAS — concurrency × replicas is the effective parallelism.
-  WORKER_EMAIL_CONCURRENCY: z.coerce.number().int().min(1).max(500).default(5),
-  WORKER_UPLOAD_CONCURRENCY: z.coerce.number().int().min(1).max(500).default(5),
+    // Per-queue worker concurrency. Evaluated at module load time (process.env is
+    // already populated by ConfigModule). Increase for I/O-bound queues before
+    // scaling WORKER_REPLICAS — concurrency × replicas is the effective parallelism.
+    WORKER_EMAIL_CONCURRENCY: z.coerce.number().int().min(1).max(500).default(5),
+    WORKER_UPLOAD_CONCURRENCY: z.coerce.number().int().min(1).max(500).default(5),
 
-  // App
-  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  LOG_LEVEL: z.string().default('info'),
+    // App
+    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+    LOG_LEVEL: z.string().default('info'),
 
-  // OpenTelemetry (read by tracing.ts via process.env directly; included here for
-  // completeness and so misconfiguration surfaces at boot rather than at first span)
-  OTEL_ENABLED: z
-    .string()
-    .default('false')
-    .transform((v) => v === 'true'),
-  OTEL_SERVICE_NAME: z.string().default('nestjs-fastify-worker'),
-  OTEL_SERVICE_NAMESPACE: z.string().default('app'),
-  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default('http://localhost:4318'),
-  OTEL_EXPORTER_OTLP_HEADERS: z.string().default(''),
-  OTEL_TRACES_SAMPLER_RATIO: z.coerce.number().min(0).max(1).default(1),
+    // OpenTelemetry (read by tracing.ts via process.env directly; included here for
+    // completeness and so misconfiguration surfaces at boot rather than at first span)
+    OTEL_ENABLED: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
+    OTEL_SERVICE_NAME: z.string().default('nestjs-fastify-worker'),
+    OTEL_SERVICE_NAMESPACE: z.string().default('app'),
+    OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default('http://localhost:4318'),
+    OTEL_EXPORTER_OTLP_HEADERS: z.string().default(''),
+    OTEL_TRACES_SAMPLER_RATIO: z.coerce.number().min(0).max(1).default(1),
 
-  // Outbox event retention (validated here for .env.example parity; only the
-  // scheduler's purge cron is the runtime consumer).
-  OUTBOX_RETENTION_DAYS: z.coerce.number().int().min(1).max(365).default(7),
-  OUTBOX_PURGE_BATCH_SIZE: z.coerce.number().int().min(100).max(10000).default(1000),
-  OUTBOX_PURGE_MAX_BATCHES: z.coerce.number().int().min(1).max(10000).default(200),
+    // Outbox event retention (validated here for .env.example parity; only the
+    // scheduler's purge cron is the runtime consumer).
+    OUTBOX_RETENTION_DAYS: z.coerce.number().int().min(1).max(365).default(7),
+    OUTBOX_PURGE_BATCH_SIZE: z.coerce.number().int().min(100).max(10000).default(1000),
+    OUTBOX_PURGE_MAX_BATCHES: z.coerce.number().int().min(1).max(10000).default(200),
 
-  // Sentry
-  SENTRY_DSN: z.string().optional().default(''),
-  SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0.1),
-  SENTRY_ENVIRONMENT: z.string().default('development'),
-});
+    // Sentry
+    SENTRY_DSN: z.string().optional().default(''),
+    SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0.1),
+    SENTRY_ENVIRONMENT: z.string().default('development'),
+  })
+  .superRefine((data, ctx) => {
+    // The worker owns the SMTP transport, so the production TLS guard belongs here.
+    if (data.NODE_ENV !== 'production') return;
+    if (data.MAIL_IGNORE_TLS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['MAIL_IGNORE_TLS'],
+        message: 'MAIL_IGNORE_TLS must be false in production — plaintext SMTP exposes credentials',
+      });
+    }
+    if (!data.MAIL_SECURE && !data.MAIL_REQUIRE_TLS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['MAIL_REQUIRE_TLS'],
+        message: 'Enable MAIL_SECURE or MAIL_REQUIRE_TLS in production so SMTP negotiates TLS',
+      });
+    }
+  });
 
 export type WorkerEnvConfig = z.infer<typeof workerEnvSchema>;
 

--- a/docker/compose.observability.yml
+++ b/docker/compose.observability.yml
@@ -10,7 +10,10 @@
 # Or via the build script:
 #   ./scripts/build-dev.sh --with-obs
 #
-# Ports exposed on the host:
+# Ports bound to 127.0.0.1 ONLY (never 0.0.0.0) so they are not reachable from
+# the internet on a public host. From a workstation, reach the UIs on a remote
+# headless host via an SSH tunnel, e.g.:
+#   ssh -L 16686:localhost:16686 -L 3001:localhost:3001 -L 9090:localhost:9090 user@host
 #   16686  Jaeger UI         http://localhost:16686
 #   9090   Prometheus        http://localhost:9090
 #   3001   Grafana           http://localhost:3001  (admin / admin)
@@ -31,10 +34,12 @@ services:
     volumes:
       - ./otel-collector/config.yaml:/etc/otel/config.yaml:ro
     ports:
-      - '4317:4317' # OTLP gRPC
-      - '4318:4318' # OTLP HTTP
-      - '8888:8888' # collector internal metrics (scraped by Prometheus)
-      - '8889:8889' # Prometheus exporter for app metrics forwarded by collector
+      # Bound to 127.0.0.1 only — never 0.0.0.0. On a headless/remote host these
+      # UIs are reached over an SSH tunnel, never exposed to the internet.
+      - '127.0.0.1:4317:4317' # OTLP gRPC
+      - '127.0.0.1:4318:4318' # OTLP HTTP
+      - '127.0.0.1:8888:8888' # collector internal metrics (scraped by Prometheus)
+      - '127.0.0.1:8889:8889' # Prometheus exporter for app metrics forwarded by collector
 
   jaeger:
     image: jaegertracing/jaeger:2.6.0
@@ -42,7 +47,7 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: 'true'
     ports:
-      - '16686:16686' # Jaeger UI
+      - '127.0.0.1:16686:16686' # Jaeger UI
 
   prometheus:
     image: prom/prometheus:v3.3.0
@@ -56,7 +61,7 @@ services:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - '9090:9090'
+      - '127.0.0.1:9090:9090'
 
   grafana:
     image: grafana/grafana:11.6.0
@@ -69,7 +74,7 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     ports:
-      - '3001:3001'
+      - '127.0.0.1:3001:3001'
     depends_on:
       - prometheus
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,7 +436,7 @@ Pagination conventions:
 - **Page-based** (`PaginationDto`): query `page` + `pageSize`; response carries
   matching `page` + `pageSize` + `totalCount`.
 - **Cursor-based** (`CursorPaginationDto`, preferred for high-volume endpoints):
-  query `limit` + `startingAfter` / `endingBefore`; response carries `hasMore`
+  query `limit` + `startingAfter` (forward-only); response carries `hasMore`
   and omits `page` / `pageSize` / `totalCount`.
 - **Offset-based**: query `limit` + `offset` — only adopt when neither of the
   above fits.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -156,6 +156,39 @@ METRICS_ALLOW_CIDRS=172.0.0.0/8
 
 Config files live under `docker/prometheus/`, `docker/otel-collector/`, and `docker/grafana/provisioning/`. The observability stack is for local development and demos — production observability should use a managed service or a dedicated cluster.
 
+The overlay binds every port to `127.0.0.1` only, so none of these UIs are reachable from the internet even on a public host — reach them with an SSH tunnel (see below).
+
+### Viewing logs & errors on a headless server
+
+A container logs structured JSON to stdout — never to a file inside the container. Docker captures it via the `json-file` driver (rotated `50m × 5` in `compose.prod.yml`). On a server without a desktop, everything below runs in the SSH terminal — no browser needed.
+
+```bash
+# Tail one app's logs (JSON, one line per request)
+docker compose -f docker/compose.yml -f docker/compose.prod.yml logs -f api
+
+# Trace a single request end-to-end by its id (echoed in the RFC 9457 error body)
+docker compose -f docker/compose.yml -f docker/compose.prod.yml logs api | grep 'req-019732db'
+
+# Pretty-print while reading
+docker compose -f docker/compose.yml -f docker/compose.prod.yml logs api | npx pino-pretty
+```
+
+Typical failure-triage flow:
+
+1. The API error response carries `requestId` (RFC 9457 problem+json) — the user reports it.
+2. `grep` that id in `docker compose ... logs` to see the full ordered log chain for the request.
+3. Open **Sentry** and filter by the `requestId` tag for the exact stack trace and breadcrumbs.
+4. If it is slow rather than broken, copy the `trace_id` from the log line (present once `OTEL_ENABLED=true`) into **Jaeger** to find the offending span.
+
+To open Jaeger/Grafana/Prometheus that run on the remote host, do **not** expose them publicly. Tunnel them to your workstation over SSH:
+
+```bash
+# Run on your workstation, then open http://localhost:16686 etc. locally
+ssh -L 16686:localhost:16686 -L 3001:localhost:3001 -L 9090:localhost:9090 user@your-server
+```
+
+For a team that needs persistent access, put the host on a private network (VPN / Tailscale) or use a managed backend (Grafana Cloud, Sentry SaaS, Datadog). Only expose a dashboard publicly behind TLS **and** authentication, ideally behind a VPN — never a raw public port.
+
 ## Release Process
 
 1. Merge to `main`

--- a/libs/contracts/src/lib/dto/list-response.dto.ts
+++ b/libs/contracts/src/lib/dto/list-response.dto.ts
@@ -82,16 +82,6 @@ export class CursorPaginationDto {
   @IsString()
   @MaxLength(200)
   startingAfter?: string;
-
-  @ApiPropertyOptional({
-    description:
-      "Opaque cursor for the previous page — pass the first item's cursor from the current response. Same opaque format as `startingAfter`.",
-    example: 'MjAyNi0wNS0xOVQwMzowMDowMC4wMDBaOjAxOTczMmRiLTYwMTAtN2Y3Zi1iNDY0LTBkMjBjNWUzYThmOQ',
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(200)
-  endingBefore?: string;
 }
 
 export function toListResponse<T>(args: {

--- a/libs/infra/auth/src/lib/better-auth.module.ts
+++ b/libs/infra/auth/src/lib/better-auth.module.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Global, Module } from '@nestjs/common';
 import { BullModule, getQueueToken } from '@nestjs/bullmq';
 import type { Queue } from 'bullmq';
@@ -18,8 +19,14 @@ import { RolesGuard } from './roles.guard';
       useFactory: (prisma: PrismaService, emailQueue: Queue, i18n: I18nService) => {
         const mailer: AuthMailDispatcher = {
           send: async ({ to, subject, body, templateId }) => {
-            // BullMQ rejects ':' in jobIds — use '__' as separator.
-            const jobId = `auth-email__${templateId ?? 'generic'}__${to}__${Date.now()}`;
+            // Content fingerprint keeps the jobId idempotent: a retried callback
+            // with the identical email dedupes, while a fresh token (new body)
+            // produces a new id and still sends. BullMQ rejects ':' in jobIds.
+            const fingerprint = createHash('sha256')
+              .update(`${templateId ?? 'generic'}|${to}|${subject}|${body}`)
+              .digest('hex')
+              .slice(0, 32);
+            const jobId = `auth-email__${templateId ?? 'generic'}__${fingerprint}`;
             await emailQueue.add(
               templateId ?? 'auth-email',
               { to, subject, body, templateId },

--- a/libs/infra/auth/src/lib/better-auth.module.ts
+++ b/libs/infra/auth/src/lib/better-auth.module.ts
@@ -22,11 +22,12 @@ import { RolesGuard } from './roles.guard';
             // Content fingerprint keeps the jobId idempotent: a retried callback
             // with the identical email dedupes, while a fresh token (new body)
             // produces a new id and still sends. BullMQ rejects ':' in jobIds.
+            const label = (templateId ?? 'generic').replace(/[^a-zA-Z0-9_-]/g, '-');
             const fingerprint = createHash('sha256')
               .update(`${templateId ?? 'generic'}|${to}|${subject}|${body}`)
               .digest('hex')
               .slice(0, 32);
-            const jobId = `auth-email__${templateId ?? 'generic'}__${fingerprint}`;
+            const jobId = `auth-email__${label}__${fingerprint}`;
             await emailQueue.add(
               templateId ?? 'auth-email',
               { to, subject, body, templateId },

--- a/libs/infra/messaging/src/lib/outbox-relay.service.ts
+++ b/libs/infra/messaging/src/lib/outbox-relay.service.ts
@@ -26,6 +26,7 @@ export class OutboxRelayService implements OnModuleInit, OnModuleDestroy {
   private readonly pollIntervalMs = intEnv('OUTBOX_POLL_INTERVAL_MS', 1_000);
   private readonly batchSize = intEnv('OUTBOX_BATCH_SIZE', 50);
   private readonly maxAttempts = intEnv('OUTBOX_MAX_ATTEMPTS', 10);
+  private readonly txTimeoutMs = intEnv('OUTBOX_TX_TIMEOUT_MS', 30_000);
   private timer?: NodeJS.Timeout;
   private running = false;
   private stopped = false;
@@ -90,25 +91,28 @@ export class OutboxRelayService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async claimBatch(): Promise<OutboxRow[]> {
-    return this.prisma.transaction(async (tx) => {
-      return tx.$queryRawUnsafe<OutboxRow[]>(
-        `WITH locked AS (
-           SELECT id
-             FROM "outbox_events"
-            WHERE "processedAt" IS NULL AND attempts < $1
-            ORDER BY "createdAt"
-            LIMIT $2
-            FOR UPDATE SKIP LOCKED
-         )
-         UPDATE "outbox_events" o
-            SET attempts = o.attempts + 1
-           FROM locked
-          WHERE o.id = locked.id
-         RETURNING o.id, o."eventType", o."aggregateId", o.payload, o.attempts`,
-        this.maxAttempts,
-        this.batchSize,
-      );
-    });
+    return this.prisma.transaction(
+      async (tx) => {
+        return tx.$queryRawUnsafe<OutboxRow[]>(
+          `WITH locked AS (
+             SELECT id
+               FROM "outbox_events"
+              WHERE "processedAt" IS NULL AND attempts < $1
+              ORDER BY "createdAt"
+              LIMIT $2
+              FOR UPDATE SKIP LOCKED
+           )
+           UPDATE "outbox_events" o
+              SET attempts = o.attempts + 1
+             FROM locked
+            WHERE o.id = locked.id
+           RETURNING o.id, o."eventType", o."aggregateId", o.payload, o.attempts`,
+          this.maxAttempts,
+          this.batchSize,
+        );
+      },
+      { timeout: this.txTimeoutMs },
+    );
   }
 
   private async dispatchOne(row: OutboxRow): Promise<boolean> {

--- a/libs/infra/observability/src/lib/start-tracing.ts
+++ b/libs/infra/observability/src/lib/start-tracing.ts
@@ -77,7 +77,9 @@ export function startTracing(options: StartTracingOptions = {}): NodeSDK | null 
     instrumentations: [
       getNodeAutoInstrumentations({
         '@opentelemetry/instrumentation-fs': { enabled: false },
-        '@opentelemetry/instrumentation-pino': { enabled: false },
+        // Pino instrumentation injects trace_id/span_id into every log line so
+        // logs can be pivoted to their trace in the backend.
+        '@opentelemetry/instrumentation-pino': { enabled: true },
       }),
     ],
   });

--- a/libs/modules/users/src/application/queries/get-user-profile/get-user-profile.handler.spec.ts
+++ b/libs/modules/users/src/application/queries/get-user-profile/get-user-profile.handler.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { NotFoundException } from '@nestjs/common';
+import { BusinessRuleException } from '@nestjs-fastify-nx/core';
 import { GetUserProfileHandler } from './get-user-profile.handler';
 import { GetUserProfileQuery } from './get-user-profile.query';
 import { MockUserRepository } from '../../../testing/mock-user-repository';
@@ -27,9 +27,9 @@ describe('GetUserProfileHandler', () => {
     expect(result.createdAt).toBeInstanceOf(Date);
   });
 
-  it('throws NotFoundException when the user does not exist', async () => {
+  it('throws BusinessRuleException when the user does not exist', async () => {
     await expect(handler.execute(new GetUserProfileQuery('non-existent-id'))).rejects.toThrow(
-      NotFoundException,
+      BusinessRuleException,
     );
   });
 

--- a/libs/modules/users/src/application/queries/get-user-profile/get-user-profile.handler.ts
+++ b/libs/modules/users/src/application/queries/get-user-profile/get-user-profile.handler.ts
@@ -1,4 +1,5 @@
-import { HttpStatus, Injectable, NotFoundException, Inject } from '@nestjs/common';
+import { HttpStatus, Injectable, Inject } from '@nestjs/common';
+import { BusinessRuleException } from '@nestjs-fastify-nx/core';
 import { I18N_KEYS } from '@nestjs-fastify-nx/infra-i18n';
 import { GetUserProfileQuery } from './get-user-profile.query';
 import { USER_REPOSITORY_PORT } from '../../../domain/ports/user-repository.port';
@@ -22,10 +23,18 @@ export class GetUserProfileHandler {
   async execute(query: GetUserProfileQuery): Promise<UserProfileResult> {
     const user = await this.users.findById(query.userId);
     if (!user) {
-      throw new NotFoundException({
-        statusCode: HttpStatus.NOT_FOUND,
+      throw new BusinessRuleException({
+        status: HttpStatus.NOT_FOUND,
+        code: 'user_not_found',
         messageKey: I18N_KEYS.errors.users.not_found,
-        message: 'User not found',
+        violations: [
+          {
+            path: 'userId',
+            code: 'not_found',
+            message: 'User not found',
+            messageKey: I18N_KEYS.errors.users.not_found,
+          },
+        ],
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
       "hono": ">=4.12.21",
       "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
       "axios": ">=1.16.0",
+      "esbuild": ">=0.28.1",
       "kysely": ">=0.28.17",
       "protobufjs": ">=8.0.2",
       "qs": ">=6.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   hono: '>=4.12.21'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   axios: '>=1.16.0'
+  esbuild: '>=0.28.1'
   kysely: '>=0.28.17'
   protobufjs: '>=8.0.2'
   qs: '>=6.15.2'
@@ -265,16 +266,16 @@ importers:
         version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.2)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(eslint@10.4.1(jiti@2.7.0))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)
       '@nx/vite':
         specifier: 22.7.5
-        version: 22.7.5(6738a0ae84c09995e402b52fb02aff4b)
+        version: 22.7.5(e895b720bdb66119c2bf287f8a01e465)
       '@nx/vitest':
         specifier: ^22.7.5
-        version: 22.7.5(6738a0ae84c09995e402b52fb02aff4b)
+        version: 22.7.5(e895b720bdb66119c2bf287f8a01e465)
       '@nx/web':
         specifier: 22.7.5
-        version: 22.7.5(997a024a5fdc74ce5e7f3a9c3e2f7db7)
+        version: 22.7.5(dd5adb7630e71434b53715ab05ff039c)
       '@nx/webpack':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)(webpack-cli@5.1.4(webpack@5.107.2))
+        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)(webpack-cli@5.1.4(webpack@5.107.2))
       '@swc-node/register':
         specifier: ~1.11.1
         version: 1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3)
@@ -340,10 +341,10 @@ importers:
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vitest:
         specifier: ~4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.107.2)
@@ -1329,158 +1330,158 @@ packages:
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -5593,8 +5594,8 @@ packages:
   es-toolkit@1.47.0:
     resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9100,7 +9101,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -10724,82 +10725,82 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.0':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.28.0':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.0':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.0':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.0':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.0':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))':
@@ -11881,11 +11882,11 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.7.5':
     optional: true
 
-  '@nx/vite@22.7.5(6738a0ae84c09995e402b52fb02aff4b)':
+  '@nx/vite@22.7.5(e895b720bdb66119c2bf287f8a01e465)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      '@nx/vitest': 22.7.5(6738a0ae84c09995e402b52fb02aff4b)
+      '@nx/vitest': 22.7.5(e895b720bdb66119c2bf287f8a01e465)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
       ajv: 8.20.0
       enquirer: 2.3.6
@@ -11893,8 +11894,8 @@ snapshots:
       semver: 7.8.1
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -11906,7 +11907,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.7.5(6738a0ae84c09995e402b52fb02aff4b)':
+  '@nx/vitest@22.7.5(e895b720bdb66119c2bf287f8a01e465)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -11915,8 +11916,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.2)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.7.0))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -11927,7 +11928,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.7.5(997a024a5fdc74ce5e7f3a9c3e2f7db7)':
+  '@nx/web@22.7.5(dd5adb7630e71434b53715ab05ff039c)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -11938,8 +11939,8 @@ snapshots:
     optionalDependencies:
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.2)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.7.0))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.2)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)
-      '@nx/vite': 22.7.5(6738a0ae84c09995e402b52fb02aff4b)
-      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)(webpack-cli@5.1.4(webpack@5.107.2))
+      '@nx/vite': 22.7.5(e895b720bdb66119c2bf287f8a01e465)
+      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)(webpack-cli@5.1.4(webpack@5.107.2))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -11949,7 +11950,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/webpack@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)(webpack-cli@5.1.4(webpack@5.107.2))':
+  '@nx/webpack@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@6.0.3)(webpack-cli@5.1.4(webpack@5.107.2))':
     dependencies:
       '@babel/core': 7.29.7
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -11961,7 +11962,7 @@ snapshots:
       browserslist: 4.28.2
       copy-webpack-plugin: 14.0.0(webpack@5.107.2)
       css-loader: 6.11.0(webpack@5.107.2)
-      css-minimizer-webpack-plugin: 8.0.0(esbuild@0.28.0)(webpack@5.107.2)
+      css-minimizer-webpack-plugin: 8.0.0(esbuild@0.28.1)(webpack@5.107.2)
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.107.2)
       less: 4.5.1
       less-loader: 12.3.3(less@4.5.1)(webpack@5.107.2)
@@ -11979,11 +11980,11 @@ snapshots:
       sass-loader: 16.0.8(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2)
       source-map-loader: 5.0.0(webpack@5.107.2)
       style-loader: 3.3.4(webpack@5.107.2)
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.107.2)
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2)
       ts-loader: 9.6.0(loader-utils@2.0.4)(typescript@6.0.3)(webpack@5.107.2)
       tsconfig-paths-webpack-plugin: 4.2.0
       tslib: 2.8.1
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4(webpack@5.107.2))(webpack@5.107.2)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(webpack@5.107.2)
@@ -12741,7 +12742,7 @@ snapshots:
       acorn: 8.16.0
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@7.2.0)
-      esbuild: 0.28.0
+      esbuild: 0.28.1
       esutils: 2.0.3
       fs-extra: 11.3.5
       jiti: 2.7.0
@@ -14124,7 +14125,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -14135,13 +14136,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -14245,17 +14246,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.107.2))(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
       webpack-cli: 5.1.4(webpack@5.107.2)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.107.2))(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
       webpack-cli: 5.1.4(webpack@5.107.2)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.107.2))(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
       webpack-cli: 5.1.4(webpack@5.107.2)
 
   '@whatwg-node/promise-helpers@1.3.2':
@@ -14517,7 +14518,7 @@ snapshots:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.29.7):
     dependencies:
@@ -14690,7 +14691,7 @@ snapshots:
       prisma: 7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -15112,7 +15113,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       tinyglobby: 0.2.17
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   core-js-compat@3.49.0:
     dependencies:
@@ -15212,9 +15213,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.2
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
-  css-minimizer-webpack-plugin@8.0.0(esbuild@0.28.0)(webpack@5.107.2):
+  css-minimizer-webpack-plugin@8.0.0(esbuild@0.28.1)(webpack@5.107.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.9(postcss@8.5.15)
@@ -15222,9 +15223,9 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
     optionalDependencies:
-      esbuild: 0.28.0
+      esbuild: 0.28.1
 
   css-select@5.2.2:
     dependencies:
@@ -15553,34 +15554,34 @@ snapshots:
 
   es-toolkit@1.47.0: {}
 
-  esbuild@0.28.0:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -16023,7 +16024,7 @@ snapshots:
       semver: 7.8.2
       tapable: 2.3.3
       typescript: 6.0.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   form-data@4.0.5:
     dependencies:
@@ -16990,7 +16991,7 @@ snapshots:
     dependencies:
       less: 4.5.1
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   less@4.5.1:
     dependencies:
@@ -17021,7 +17022,7 @@ snapshots:
     dependencies:
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   light-my-request@6.6.0:
     dependencies:
@@ -17315,7 +17316,7 @@ snapshots:
   mini-css-extract-plugin@2.4.7(webpack@5.107.2):
     dependencies:
       schema-utils: 4.3.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   minimalistic-assert@1.0.1: {}
 
@@ -18037,7 +18038,7 @@ snapshots:
       postcss: 8.5.15
       semver: 7.8.2
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
     transitivePeerDependencies:
       - typescript
 
@@ -18629,7 +18630,7 @@ snapshots:
     optionalDependencies:
       sass: 1.100.0
       sass-embedded: 1.100.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   sass@1.100.0:
     dependencies:
@@ -18868,7 +18869,7 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   source-map-support@0.5.13:
     dependencies:
@@ -19029,7 +19030,7 @@ snapshots:
 
   style-loader@3.3.4(webpack@5.107.2):
     dependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   stylehacks@7.0.11(postcss@8.5.15):
     dependencies:
@@ -19099,7 +19100,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
   symbol-observable@1.2.0: {}
 
@@ -19173,16 +19174,16 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.107.2):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
     optionalDependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.23)
-      esbuild: 0.28.0
+      esbuild: 0.28.1
       postcss: 8.5.15
 
   terser@5.48.0:
@@ -19290,7 +19291,7 @@ snapshots:
       semver: 7.8.2
       source-map: 0.7.6
       typescript: 6.0.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
     optionalDependencies:
       loader-utils: 2.0.4
 
@@ -19478,7 +19479,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -19487,7 +19488,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.2
-      esbuild: 0.28.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       less: 4.5.1
@@ -19496,10 +19497,10 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -19516,7 +19517,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -19558,7 +19559,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
       webpack-merge: 5.10.0
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.107.2):
@@ -19570,7 +19571,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
     transitivePeerDependencies:
       - tslib
 
@@ -19605,7 +19606,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.2)
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
       webpack-cli: 5.1.4(webpack@5.107.2)
     transitivePeerDependencies:
       - bufferutil
@@ -19627,9 +19628,9 @@ snapshots:
   webpack-subresource-integrity@5.1.0(webpack@5.107.2):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2))
 
-  webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2)):
+  webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack-cli@5.1.4(webpack@5.107.2)):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -19651,7 +19652,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.107.2)
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2)
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     optionalDependencies:

--- a/prisma/migrations/20260701000000_session_account_fk_indexes/migration.sql
+++ b/prisma/migrations/20260701000000_session_account_fk_indexes/migration.sql
@@ -1,0 +1,15 @@
+-- Foreign-key index hardening for the Better Auth tables:
+--   - `sessions.userId` is read on every authenticated request when Better Auth
+--     resolves the active session, and the ON DELETE CASCADE from `users` walks
+--     it during account deletion. Without a standalone index Postgres falls back
+--     to a sequential scan as the sessions table grows.
+--   - `accounts.userId` has the same CASCADE-delete requirement; the existing
+--     UNIQUE on (providerId, accountId) does not cover userId lookups.
+--
+-- Idempotent (CREATE INDEX IF NOT EXISTS). CREATE INDEX CONCURRENTLY cannot run
+-- inside the migration transaction wrapper, so plain CREATE INDEX is used —
+-- acceptable for these small tables on an initial bootstrap.
+
+CREATE INDEX IF NOT EXISTS "sessions_userId_idx" ON "sessions" ("userId");
+
+CREATE INDEX IF NOT EXISTS "accounts_userId_idx" ON "accounts" ("userId");

--- a/prisma/migrations/20260701100000_users_constraints_and_trgm_index/migration.sql
+++ b/prisma/migrations/20260701100000_users_constraints_and_trgm_index/migration.sql
@@ -1,0 +1,31 @@
+-- User-table hardening:
+--   1. CHECK constraints pin `role`/`status` to their domain enum values at the
+--      DB layer. The columns are plain text (Better Auth writes them directly),
+--      so a manual insert or a future bug could otherwise persist an invalid
+--      value the application would then choke on.
+--   2. pg_trgm GIN indexes back the case-insensitive email/name search
+--      (`ILIKE '%term%'`) the admin user list issues, so it stays off a full
+--      sequential scan as the users table grows.
+--
+-- Idempotent: ADD CONSTRAINT guarded by a pg_constraint lookup, CREATE
+-- EXTENSION / INDEX IF NOT EXISTS. CREATE INDEX CONCURRENTLY cannot run inside
+-- the migration transaction wrapper, so plain CREATE INDEX is used — acceptable
+-- for these table sizes on an initial bootstrap.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_role_chk') THEN
+    ALTER TABLE "users" ADD CONSTRAINT "users_role_chk"
+      CHECK ("role" IN ('ADMIN', 'USER'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_status_chk') THEN
+    ALTER TABLE "users" ADD CONSTRAINT "users_status_chk"
+      CHECK ("status" IN ('ACTIVE', 'INACTIVE', 'BANNED'));
+  END IF;
+END
+$$;
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS "users_email_trgm_idx" ON "users" USING gin ("email" gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS "users_name_trgm_idx" ON "users" USING gin ("name" gin_trgm_ops);

--- a/prisma/migrations/20260701100000_users_constraints_and_trgm_index/migration.sql
+++ b/prisma/migrations/20260701100000_users_constraints_and_trgm_index/migration.sql
@@ -14,11 +14,17 @@
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_role_chk') THEN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'users_role_chk' AND conrelid = '"users"'::regclass
+  ) THEN
     ALTER TABLE "users" ADD CONSTRAINT "users_role_chk"
       CHECK ("role" IN ('ADMIN', 'USER'));
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_status_chk') THEN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'users_status_chk' AND conrelid = '"users"'::regclass
+  ) THEN
     ALTER TABLE "users" ADD CONSTRAINT "users_status_chk"
       CHECK ("status" IN ('ACTIVE', 'INACTIVE', 'BANNED'));
   END IF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model Session {
   userId    String   @db.Uuid
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@index([userId])
   @@map("sessions")
 }
 
@@ -65,6 +66,7 @@ model Account {
   updatedAt             DateTime  @updatedAt
 
   @@unique([providerId, accountId])
+  @@index([userId])
   @@map("accounts")
 }
 


### PR DESCRIPTION
## Summary

Remediation of a deep multi-dimension code audit (DDD, security, error-handling, API contract, database, observability, code-quality, testing). Fixes **6 high** and **9 medium** findings; each was adversarially verified against the source before fixing. No critical findings existed.

Verified locally: `nx affected -t typecheck lint test build` (21 projects / 85 tasks) **green**, and `api:e2e` (42 tests on real Postgres/Redis via Testcontainers) **green**.

## High

- **Application boundary** — `get-user-profile` handler now throws `BusinessRuleException` instead of the HTTP `NotFoundException`, keeping the application layer transport-agnostic.
- **API contract** — dropped the `endingBefore` cursor field that was validated and OpenAPI-documented but silently ignored (broken public contract). Cursor lists are forward-only.
- **Outbox** — `OUTBOX_TX_TIMEOUT_MS` is now actually wired into the claim transaction (was documented everywhere but never read).
- **Database** — added missing indexes on `sessions.userId` / `accounts.userId` (Better Auth lookups + CASCADE delete were sequential-scanning).
- **Observability** — the scheduler process now bootstraps OpenTelemetry (was running cron jobs with no tracing).
- **WebSocket** — capped the Redis `retryStrategy` so a dead Redis no longer triggers an unbounded reconnect loop.

## Medium

- **Security** — removed `unsafe-eval` from the production CSP; masked 5xx error detail in production; rejected `MAIL_IGNORE_TLS=true` in production; aligned the Sentry sample-rate default; bound the observability stack ports to `127.0.0.1`.
- **Idempotency** — `auth-email` job id now uses a content fingerprint instead of `Date.now()`.
- **Database** — `CHECK` constraints on `users.role` / `users.status`; `pg_trgm` GIN index for case-insensitive search.
- **Observability** — enabled pino OTel instrumentation so logs carry `trace_id`/`span_id`; tagged Sentry events with `requestId`/`correlationId`.
- **Testing/CI** — added `BullMqHealthIndicator` unit tests; integration suite now also runs on push to protected branches.

## Deliberately deferred (with rationale)

- `ENABLE_METRICS` module-load read — a NestJS conditional-import constraint; restructuring to a dynamic module is high-cost for marginal benefit.
- upload-confirm happy-path e2e — the storage stub returns `null` from `head()` to serve the 404/422 paths; exercising the 200 branch needs test-infra work that risks the passing upload suite. Tracked as follow-up.
- `uuidv7()` extension — not an issue: the stack pins `postgres:18-alpine`, which ships `uuidv7()` natively.

## Notes

- New migrations: `20260701000000_session_account_fk_indexes`, `20260701100000_users_constraints_and_trgm_index`.
- The `endingBefore` removal regenerates an identical API client (the field was never in the generated SDK).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cursor-based pagination now operates forward-only with optimized query parameters

* **Bug Fixes**
  * Server error details now masked in production for security
  * Improved Redis reconnection strategy with exponential backoff
  * Enhanced email job idempotency to prevent duplicate processing

* **Security**
  * Removed unsafe inline script execution from Content-Security-Policy
  * Restricted observability dashboards to localhost access only
  * Added production validation for SMTP TLS requirements

* **Chores**
  * Optimized database performance with indexes and constraints
  * Enhanced distributed tracing initialization
  * Improved log correlation with trace IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->