### PR TITLE
ci(docker-smoke): assert migration service completes cleanly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,13 @@ jobs:
         run: cp .env.example .env
 
       # depends_on chains every service (infra + migration + minio-init), so this
-      # one command builds the images and boots the whole stack. --wait blocks on
-      # worker/scheduler healthchecks; a crash loop trips --wait-timeout and fails.
+      # one command builds all four app images and boots the whole stack. --wait
+      # blocks on worker/scheduler healthchecks and migration completing; a crash
+      # loop or failed migration trips --wait-timeout and fails.
       - name: Build images and boot stack
         run: |
           docker compose --env-file .env up -d --build --wait --wait-timeout 300 \
-            api worker scheduler
+            migration api worker scheduler
 
       - name: Smoke test — API health
         run: |
@@ -127,6 +128,18 @@ jobs:
             sleep 2
           done
           echo "API did not become healthy within 60s"; exit 1
+
+      # migration is a one-shot (prisma migrate deploy then exit); it won't appear
+      # in `ps -q`, so query stopped containers and assert a clean exit.
+      - name: Assert migration completed successfully
+        run: |
+          cid=$(docker compose --env-file .env ps -aq migration)
+          [ -n "$cid" ] || { echo "migration container not found"; exit 1; }
+          status=$(docker inspect -f '{{.State.Status}}' "$cid")
+          code=$(docker inspect -f '{{.State.ExitCode}}' "$cid")
+          echo "migration: status=$status exit=$code"
+          { [ "$status" = "exited" ] && [ "$code" -eq 0 ]; } \
+            || { echo "migration did not complete cleanly"; exit 1; }
 
       - name: Assert services are not crash-looping
         run: |


### PR DESCRIPTION
## What

Adds an explicit verification of the `migration` service to the `docker-smoke` CI job.

## Why

The smoke job already builds all four app images and boots `api`/`worker`/`scheduler`. `migration` was only verified **implicitly** via `depends_on: condition: service_completed_successfully` — a failed migration surfaced as a downstream `--wait` boot timeout rather than a clear error.

## Changes

- Boot command now lists `migration` explicitly alongside the long-running services.
- New step asserts the one-shot `migration` container exited with code 0 (queried via `ps -aq` since it's stopped after `prisma migrate deploy`).

All four services (`api`, `worker`, `scheduler`, `migration`) are now built and verified in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD smoke testing to validate database migrations during application stack startup alongside core services
  * Added automated verification confirming migrations complete successfully before deployment proceeds, improving release reliability and system readiness assurance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->