### PR TITLE
fix(deps): floor undici to 8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
       "launch-editor": ">=2.14.1",
       "js-yaml": ">=4.2.0",
       "http-proxy-middleware": "^3.0.6",
-      "@opentelemetry/core": ">=2.8.0"
+      "@opentelemetry/core": ">=2.8.0",
+      "undici": ">=8.5.0"
     },
     "onlyBuiltDependencies": [
       "@prisma/engines",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   js-yaml: '>=4.2.0'
   http-proxy-middleware: ^3.0.6
   '@opentelemetry/core': '>=2.8.0'
+  undici: '>=8.5.0'
 
 importers:
 
@@ -9027,8 +9028,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.4.1:
-    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -19243,7 +19244,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.7
-      undici: 8.4.1
+      undici: 8.5.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -19421,7 +19422,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.4.1: {}
+  undici@8.5.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
OSV published three `undici` advisories (GHSA-38rv-x7px-6hhq 7.5 High, GHSA-vmh5-mc38-953g 7.4 High, GHSA-pr7r-676h-xcf6 5.9) after #63 merged — fixed in 8.5.0. Adds a transitive floor override so `dep-scan` passes on main again.

Moving-target note: the `dep-scan` job fails on any OSV advisory across the full lockfile, so new advisories on transitive deps will keep surfacing; each is resolved by raising the corresponding floor.