### PR TITLE
test(loadtest): add k6 load, spike and stress suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+# local load-test env copy (holds a throwaway admin password); the committed
+# template is scripts/loadtest/loadtest.env.example
+scripts/loadtest/loadtest.env
 
 vitest.config.*.timestamp*
 .nx/polygraph

--- a/scripts/loadtest/README.md
+++ b/scripts/loadtest/README.md
@@ -1,0 +1,89 @@
+# Load testing (k6)
+
+Measure how much the API stack actually handles — RPS, p95/p99 latency, error
+rate — against a locally booted Docker stack. Scenarios target representative
+paths: a public probe, a cookie-authenticated read, and the cursor-paginated
+admin list.
+
+## Why a dedicated env profile
+
+Two layers cap throughput by design and would otherwise dominate the results:
+
+- **`ThrottlerGuard`** — `THROTTLER_LIMIT=100` per `60s` per IP on every Nest
+  route. A single k6 box is one IP, so it hits HTTP 429 almost immediately.
+- **Auth rate-limit** — sign-in/sign-up are limited to `5 / 15 min`.
+
+`loadtest.env.example` disables the throttler and raises the auth limits **for
+load testing only**. Copy it, set a throwaway `SEED_ADMIN_PASSWORD`, and it also
+seeds an admin so the `admin/users` scenario can run.
+
+## Prerequisites
+
+- [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/) (`brew install k6`,
+  `choco install k6`, or `docker run grafana/k6`).
+- Docker (for the stack under test).
+
+## Boot the stack
+
+```bash
+cp scripts/loadtest/loadtest.env.example scripts/loadtest/loadtest.env
+# edit scripts/loadtest/loadtest.env → set a throwaway SEED_ADMIN_PASSWORD
+cat .env scripts/loadtest/loadtest.env > .env.bench
+docker compose --env-file .env.bench up -d --build --wait
+node prisma/seed.mjs   # creates the SEED_ADMIN_* user for the admin scenario
+```
+
+`loadtest.env` and `.env.bench` are gitignored (they hold your local password).
+
+The API listens on `http://localhost:3000` (override with `BASE_URL`).
+
+## Run
+
+```bash
+# 1. Sanity — one pass over every endpoint, must be 100% green first
+k6 run scripts/loadtest/smoke.js
+
+# 2. Sustained load — ramping VUs, the headline numbers (p95/p99, RPS, errors)
+k6 run scripts/loadtest/load.js
+VUS=200 SUSTAIN=5m k6 run scripts/loadtest/load.js
+
+# 3. Spike — sudden surge, checks recovery and error spillover
+PEAK=500 k6 run scripts/loadtest/spike.js
+
+# 4. Stress — climb until thresholds break; the breaching step is the ceiling
+STEP=50 STEPS=10 k6 run scripts/loadtest/stress.js
+```
+
+With the admin seeded:
+
+```bash
+SEED_ADMIN_EMAIL=admin@loadtest.invalid SEED_ADMIN_PASSWORD=AdminLoadTest123! \
+  k6 run scripts/loadtest/load.js
+```
+
+## Knobs
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `BASE_URL` | `http://localhost:3000` | Target host |
+| `VUS` | `50` | Peak virtual users (`load.js`) |
+| `RAMP` / `SUSTAIN` | `30s` / `2m` | Ramp + plateau duration (`load.js`) |
+| `PEAK` | `300` | Spike peak VUs (`spike.js`) |
+| `STEP` / `STEPS` | `50` / `8` | VU increment + number of steps (`stress.js`) |
+| `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` | — | Enables the admin scenario |
+
+## Reading results
+
+- **`http_reqs` rate** — sustained RPS the stack served.
+- **`http_req_duration` p95/p99** — tail latency; thresholds fail the run when
+  breached (per-endpoint via the `name` tag).
+- **`http_req_failed`** — error rate; > 1% under sustained load means the stack
+  is past its comfortable ceiling.
+
+## Interpreting the ceiling
+
+DB-bound endpoints are gated by `DATABASE_POOL_MAX` (20 connections/instance) and
+`(API_REPLICAS + 1) × DATABASE_POOL_MAX ≤ 80`. To push higher, scale replicas
+(`API_REPLICAS`) — for prod-parity multi-replica runs use
+`scripts/swarm-local-test.sh` — and ensure Postgres `max_connections` (or the
+pgbouncer pool) keeps up.

--- a/scripts/loadtest/lib/helpers.js
+++ b/scripts/loadtest/lib/helpers.js
@@ -1,0 +1,55 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+export const API = `${BASE_URL}/api/v1`;
+export const AUTH = `${BASE_URL}/api/auth`;
+
+const SESSION_COOKIE = 'better-auth.session_token';
+
+// Spread sign-up across unique emails so the IP+email auth rate-limit bucket
+// (5 / 15 min) never trips during setup, even without the load-test env profile.
+export function uniqueEmail(prefix = 'load') {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e9)}@loadtest.invalid`;
+}
+
+function sessionCookie(res) {
+  const jar = res.cookies[SESSION_COOKIE];
+  return jar && jar.length ? `${SESSION_COOKIE}=${jar[0].value}` : null;
+}
+
+export function signUp(email, password = 'password123', name = 'Load Test') {
+  const res = http.post(`${AUTH}/sign-up/email`, JSON.stringify({ email, password, name }), {
+    headers: { 'Content-Type': 'application/json' },
+    tags: { name: 'auth:sign-up' },
+  });
+  check(res, { 'sign-up 200': (r) => r.status === 200 });
+  return sessionCookie(res);
+}
+
+export function signIn(email, password) {
+  const res = http.post(`${AUTH}/sign-in/email`, JSON.stringify({ email, password }), {
+    headers: { 'Content-Type': 'application/json' },
+    tags: { name: 'auth:sign-in' },
+  });
+  check(res, { 'sign-in 200': (r) => r.status === 200 });
+  return sessionCookie(res);
+}
+
+// Cookie for a fresh USER-role session; null only if the API is unreachable.
+export function newUserSession() {
+  return signUp(uniqueEmail());
+}
+
+// Cookie for the seeded ADMIN; null when SEED_ADMIN_* are not provided, so the
+// caller can skip admin-only scenarios instead of flooding the logs with 403s.
+export function adminSession() {
+  const email = __ENV.SEED_ADMIN_EMAIL;
+  const password = __ENV.SEED_ADMIN_PASSWORD;
+  if (!email || !password) return null;
+  return signIn(email, password);
+}
+
+export function authParams(cookie, name) {
+  return { headers: { Cookie: cookie }, tags: { name } };
+}

--- a/scripts/loadtest/load.js
+++ b/scripts/loadtest/load.js
@@ -1,0 +1,61 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+import { API, newUserSession, adminSession, authParams } from './lib/helpers.js';
+
+const VUS = Number(__ENV.VUS || 50);
+const RAMP = __ENV.RAMP || '30s';
+const SUSTAIN = __ENV.SUSTAIN || '2m';
+
+const publicLatency = new Trend('latency_public', true);
+const authedLatency = new Trend('latency_authed', true);
+const adminLatency = new Trend('latency_admin', true);
+
+const ramping = (peak) => ({
+  executor: 'ramping-vus',
+  startVUs: 0,
+  stages: [
+    { duration: RAMP, target: peak },
+    { duration: SUSTAIN, target: peak },
+    { duration: RAMP, target: 0 },
+  ],
+});
+
+export const options = {
+  scenarios: {
+    public_read: { ...ramping(VUS), exec: 'publicRead' },
+    authed_read: { ...ramping(VUS), exec: 'authedRead' },
+    admin_list: { ...ramping(Math.ceil(VUS / 2)), exec: 'adminList' },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    'http_req_duration{name:health:live}': ['p(95)<200'],
+    'http_req_duration{name:users:me}': ['p(95)<500', 'p(99)<1000'],
+    'http_req_duration{name:admin:list}': ['p(95)<800', 'p(99)<1500'],
+    checks: ['rate>0.99'],
+  },
+};
+
+export function setup() {
+  return { user: newUserSession(), admin: adminSession() };
+}
+
+export function publicRead() {
+  const res = http.get(`${API}/health/live`, { tags: { name: 'health:live' } });
+  publicLatency.add(res.timings.duration);
+  check(res, { 'live 200': (r) => r.status === 200 });
+}
+
+export function authedRead(data) {
+  if (!data.user) return;
+  const res = http.get(`${API}/users/me`, authParams(data.user, 'users:me'));
+  authedLatency.add(res.timings.duration);
+  check(res, { 'me 200': (r) => r.status === 200 });
+}
+
+export function adminList(data) {
+  if (!data.admin) return;
+  const res = http.get(`${API}/admin/users?limit=20`, authParams(data.admin, 'admin:list'));
+  adminLatency.add(res.timings.duration);
+  check(res, { 'admin list 200': (r) => r.status === 200 });
+}

--- a/scripts/loadtest/loadtest.env.example
+++ b/scripts/loadtest/loadtest.env.example
@@ -1,0 +1,19 @@
+# Overrides to layer on top of .env when booting the stack for load testing.
+# Without these the rate limiters cap throughput and k6 mostly measures HTTP 429s
+# instead of real capacity. NEVER use this profile in production.
+#
+#   cp scripts/loadtest/loadtest.env.example scripts/loadtest/loadtest.env
+#   # set SEED_ADMIN_PASSWORD in the copy, then:
+#   cat .env scripts/loadtest/loadtest.env > .env.bench
+#   docker compose --env-file .env.bench up -d --build
+#
+# A seeded admin lets the admin/users (cursor pagination) scenario run.
+
+THROTTLER_ENABLED=false
+AUTH_RATE_LIMIT_MAX=100000
+AUTH_SESSION_RATE_LIMIT_MAX=100000
+METRICS_ALLOW_CIDRS=0.0.0.0/0
+
+SEED_ADMIN_EMAIL=admin@loadtest.invalid
+# Set your own throwaway value locally — do not commit a real one.
+SEED_ADMIN_PASSWORD=replace-with-your-own

--- a/scripts/loadtest/smoke.js
+++ b/scripts/loadtest/smoke.js
@@ -1,0 +1,37 @@
+import http from 'k6/http';
+import { check, group } from 'k6';
+import { API, newUserSession, adminSession, authParams } from './lib/helpers.js';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export function setup() {
+  return { user: newUserSession(), admin: adminSession() };
+}
+
+export default function (data) {
+  group('public', () => {
+    const live = http.get(`${API}/health/live`, { tags: { name: 'health:live' } });
+    check(live, { 'live 200': (r) => r.status === 200 });
+
+    const ready = http.get(`${API}/health/ready`, { tags: { name: 'health:ready' } });
+    check(ready, { 'ready 200|503': (r) => r.status === 200 || r.status === 503 });
+  });
+
+  group('authenticated', () => {
+    if (!data.user) return;
+    const me = http.get(`${API}/users/me`, authParams(data.user, 'users:me'));
+    check(me, { 'me 200': (r) => r.status === 200 });
+  });
+
+  group('admin', () => {
+    if (!data.admin) return;
+    const list = http.get(`${API}/admin/users?limit=20`, authParams(data.admin, 'admin:list'));
+    check(list, { 'admin list 200': (r) => r.status === 200 });
+  });
+}

--- a/scripts/loadtest/spike.js
+++ b/scripts/loadtest/spike.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { API, newUserSession, authParams } from './lib/helpers.js';
+
+const PEAK = Number(__ENV.PEAK || 300);
+
+export const options = {
+  scenarios: {
+    spike: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '10s', target: 10 },
+        { duration: '10s', target: PEAK },
+        { duration: '30s', target: PEAK },
+        { duration: '10s', target: 10 },
+        { duration: '20s', target: 0 },
+      ],
+      exec: 'hit',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    'http_req_duration{name:users:me}': ['p(95)<1500'],
+  },
+};
+
+export function setup() {
+  return { user: newUserSession() };
+}
+
+export function hit(data) {
+  if (data.user && Math.random() < 0.5) {
+    const me = http.get(`${API}/users/me`, authParams(data.user, 'users:me'));
+    check(me, { 'me ok': (r) => r.status === 200 });
+    return;
+  }
+  const live = http.get(`${API}/health/live`, { tags: { name: 'health:live' } });
+  check(live, { 'live ok': (r) => r.status === 200 });
+}

--- a/scripts/loadtest/stress.js
+++ b/scripts/loadtest/stress.js
@@ -1,0 +1,39 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { API, newUserSession, authParams } from './lib/helpers.js';
+
+const STEP = Number(__ENV.STEP || 50);
+const STEPS = Number(__ENV.STEPS || 8);
+
+// Climb in equal VU steps until latency/errors blow past the thresholds — the
+// first step that breaches them marks the breaking point.
+const stages = [];
+for (let i = 1; i <= STEPS; i++) {
+  stages.push({ duration: '20s', target: STEP * i });
+  stages.push({ duration: '40s', target: STEP * i });
+}
+stages.push({ duration: '20s', target: 0 });
+
+export const options = {
+  scenarios: {
+    stress: { executor: 'ramping-vus', startVUs: 0, stages, exec: 'hit' },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<1000'],
+  },
+};
+
+export function setup() {
+  return { user: newUserSession() };
+}
+
+export function hit(data) {
+  if (!data.user) {
+    const live = http.get(`${API}/health/live`, { tags: { name: 'health:live' } });
+    check(live, { 'live ok': (r) => r.status === 200 });
+    return;
+  }
+  const me = http.get(`${API}/users/me`, authParams(data.user, 'users:me'));
+  check(me, { 'me ok': (r) => r.status === 200 });
+}


### PR DESCRIPTION
## What

Adds `scripts/loadtest/` — a k6 load-testing suite to measure the API's real capacity (RPS, p95/p99 latency, error rate).

## Scenarios

| File | Purpose |
| --- | --- |
| `smoke.js` | 1 VU sanity pass over every endpoint (must be 100% green first) |
| `load.js` | Ramping VUs — public probe + authenticated read + cursor-paginated admin list, with per-endpoint p95/p99 + error thresholds |
| `spike.js` | Sudden surge to test recovery / error spillover |
| `stress.js` | Step-climb until thresholds break — finds the ceiling |

## Notes

- Auth is Better Auth cookie sessions: `setup()` signs up a fresh user (and signs in the seeded admin when `SEED_ADMIN_*` is set) and the cookie is reused across VUs.
- `loadtest.env.example` disables `ThrottlerGuard` and raises the auth rate-limits **for load testing only** — otherwise a single k6 box (one IP) just measures HTTP 429s. The local copy (`loadtest.env`) and `.env.bench` are gitignored.
- No production code touched; nothing wired into CI.

See `scripts/loadtest/README.md` for prerequisites and run commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for running k6 load tests with scenario descriptions and configuration details

* **Chores**
  * Added k6 load testing suite including smoke, spike, stress, and sustained-load test scenarios
  * Added load testing helper utilities and environment configuration template

<!-- end of auto-generated comment: release notes by coderabbit.ai -->