### PR TITLE
ci: ignore orval 8.20.0 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,12 @@ updates:
       # Mercurius/@nestjs GraphQL packages ship graphql 17 support.
       - dependency-name: graphql
         update-types: [version-update:semver-major]
+      # orval 8.20.0 ships an ESM config bundle that does `import yaml from
+      # "js-yaml"`, but js-yaml's `.mjs` build exports named-only (no default),
+      # so `pnpm codegen` crashes. Pin the exact broken release — a future
+      # patched orval (8.20.1+) will be proposed again.
+      - dependency-name: orval
+        versions: ['8.20.0']
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
## Why

Dependabot PR #84 (orval 8.19.0 → 8.20.0) fails CI: the `main` job's `pnpm codegen` step crashes with:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
    import yaml from "js-yaml";
```

orval **8.20.0** (currently the latest on npm — no patched release exists) switched its config bundle to ESM and does `import yaml from "js-yaml"` (default import). `js-yaml`'s `exports` map resolves ESM consumers to its named-only `.mjs` build (no default export), so codegen aborts. orval 8.19.0 is unaffected because it `require()`s the CJS entry.

This is an upstream orval regression, not a repo misconfiguration — the `js-yaml >=4.2.0` override is not the cause (js-yaml 4.1.0 ships the same named-only ESM build).

## Change

Pin the exact broken release in `.github/dependabot.yml` so Dependabot stops reopening a red PR. A future patched orval (8.20.1+) will still be proposed.

## Follow-up

Closing #84.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to skip a problematic `orval` release, helping avoid disruptive dependency update proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->