### PR TITLE
feat(observability): harden tracing, metrics ownership, health probes + local stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,8 +228,16 @@ OTEL_SERVICE_NAMESPACE=app
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 # Comma-separated key=value pairs (e.g. for vendor auth tokens)
 OTEL_EXPORTER_OTLP_HEADERS=
-# 0..1 — fraction of traces to sample (1 = all, 0 = none)
+# 0..1 — fraction of NEW traces to sample (1 = all, 0 = none). Wrapped in a ParentBased sampler,
+# so child spans always honor the parent's decision. Prod at scale: use a low head ratio (e.g. 0.05)
+# plus tail-sampling in the OTel Collector to keep every error/slow trace — see docs/observability.md.
 OTEL_TRACES_SAMPLER_RATIO=1
+# Trust inbound W3C traceparent/baggage. false on a public edge (clients can't inject/collide trace
+# ids or force sampling); true only behind a trusted mesh/gateway that owns the root span.
+OTEL_TRUST_INBOUND_TRACEPARENT=false
+# Push OTLP metrics from this process. Keep false for the API (prom-client /metrics is the source of
+# truth — enabling both double-counts). Set true for worker/scheduler, which have no /metrics endpoint.
+OTEL_METRICS_EXPORT_ENABLED=false
 # Set to true to print SDK diagnostics to stderr while debugging
 OTEL_DEBUG=false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,8 @@ pnpm rm:project <name>             # remove a lib/app + clean refs/tags (nx work
 
   If events hang: check `OutboxRelayService` liveness, raise `OUTBOX_TX_TIMEOUT_MS` or shrink `OUTBOX_BATCH_SIZE` in `libs/infra/messaging`.
 
-- **Health readiness BullMQ probe**: `/health/ready` now includes a `BullMqHealthIndicator` that pings the email-notification queue (2s timeout). If queue is not bootstrapped before probe, readiness fails.
+- **Health probe split (correlated-outage guard)**: `/health/ready` (the K8s readiness probe) checks ONLY core serving deps — DB primary + Redis cache + Redis queue. The deep checks (`BullMqHealthIndicator`, `PgBouncerHealthIndicator`, `PrismaReplicationLagHealthIndicator`) live on `/health/dependencies` for dashboards/alerting and are NOT wired to any probe. Rationale: every replica shares the same Postgres/Redis, so putting replica-lag/queue-depth/pgbouncer on the readiness probe would flip all pods to NotReady at once on a single shared-dependency blip → cluster-wide outage. Do not move them back onto readiness.
+- **Global-state metrics are single-writer (`MetricsLeaderService`)**: `bullmq_*`, `bullmq_queue_depth`, `outbox_lag_seconds` are recorded only by the API replica that holds the Redis collector-leader lease — every replica observes the same QueueEvents broadcast / global gauge, so unguarded recording inflates counters by the replica count. When adding a metric derived from shared Redis/DB state, gate it on `leader.isLeader()`; per-replica series (`http_*`, `cqrs_*`) stay ungated. OTLP metric push is off in the API (`OTEL_METRICS_EXPORT_ENABLED=false`) — prom-client `/metrics` is the source of truth; enable OTLP push only in worker/scheduler.
 - **Metrics endpoint IP allowlist**: `MetricsIpAllowGuard` reads `METRICS_ALLOW_CIDRS` (comma-separated CIDR ranges) and uses `socket.remoteAddress` (not `req.ip`, which is spoofable via X-Forwarded-For). Empty list fails closed (no metrics). Kubernetes typically needs `127.0.0.1/32` or pod CIDR.
 - **Better Auth body parser collision**: NestJS global `ProblemDetailsValidationPipe` would consume the request body before Better Auth can read it. Solved via `reply.hijack()` in `main.ts`. If adding new `/api/auth/*` endpoints, bypass the NestJS pipeline the same way.
 
@@ -252,6 +253,7 @@ pnpm rm:project <name>             # remove a lib/app + clean refs/tags (nx work
 - `docs/deployment.md` — Docker, GHCR, Cosign, Coolify
 - `docs/security.md` — five-layer scan pipeline (Gitleaks, OSV, Semgrep, Trivy, Cosign)
 - `docs/observability.md` — logging, tracing, metrics, correlation-id design, resilience
+- `docs/observability-guide.md` — how to enable, explore, and extend observability (add a metric/span/log field/alert/dashboard)
 - `docs/troubleshooting.md` — known failure modes
 - `docs/runbook.md` — ops runbook (outbox stuck, DLQ full, stuck queue workers, performance)
 - `docs/code-standards.md` — coding conventions enforced (logging, error handling, DTOs, boundaries)

--- a/apps/api/e2e/health.e2e-spec.ts
+++ b/apps/api/e2e/health.e2e-spec.ts
@@ -69,6 +69,27 @@ describe('Health & Metrics E2E', () => {
     });
   });
 
+  describe('GET /api/v1/health/dependencies', () => {
+    it('returns 200 with deep dependencies healthy (bullmq up; pgbouncer/replica no-op when unset)', async () => {
+      const res = await request(ctx.app.getHttpServer())
+        .get('/api/v1/health/dependencies')
+        .expect(200);
+
+      expect(res.body.status).toBe('ok');
+      expect(res.body.info.bullmq.status).toBe('up');
+    });
+
+    it('does NOT report the deep indicators on the readiness probe', async () => {
+      // Readiness must stay lean so a shared-dependency blip can't flip every replica to NotReady
+      // at once. bullmq/pgbouncer/replication_lag live on /dependencies only.
+      const res = await request(ctx.app.getHttpServer()).get('/api/v1/health/ready').expect(200);
+
+      expect(res.body.info.bullmq).toBeUndefined();
+      expect(res.body.info.pgbouncer).toBeUndefined();
+      expect(res.body.info.replication_lag).toBeUndefined();
+    });
+  });
+
   describe('GET /api/v1/health', () => {
     it('returns 200 with overall status ok', async () => {
       const res = await request(ctx.app.getHttpServer()).get('/api/v1/health').expect(200);

--- a/apps/api/src/common/health/health.controller.ts
+++ b/apps/api/src/common/health/health.controller.ts
@@ -46,7 +46,7 @@ class HealthCheckResultDto {
 
   @ApiProperty({
     description:
-      'Per-indicator status. Keys depend on the endpoint — `/health` reports `database`, `memory_heap`, `redis_cache`, `redis_queue`; `/health/ready` adds `bullmq`, `pgbouncer`, `replication_lag`.',
+      'Per-indicator status. Keys depend on the endpoint — `/health` reports `database`, `memory_heap`, `redis_cache`, `redis_queue`; `/health/ready` reports the subset a pod needs to serve traffic (`database`, `redis_cache`, `redis_queue`); `/health/dependencies` reports the deep checks (`bullmq`, `pgbouncer`, `replication_lag`).',
     type: 'object',
     additionalProperties: INDICATOR_STATUS_SCHEMA,
     example: { database: { status: 'up' }, memory_heap: { status: 'up' } },
@@ -124,17 +124,22 @@ export class HealthController {
   @Get('ready')
   @HealthCheck()
   @ApiOperation({
-    summary: 'Readiness probe (DB + Redis cache + Redis queue + BullMQ).',
+    summary: 'Readiness probe (DB primary + Redis cache + Redis queue).',
     description:
-      'Use as the Kubernetes readiness probe. Returns 503 when any critical dependency is unreachable so the orchestrator removes the pod from the load balancer.',
+      'Use as the Kubernetes readiness probe. Checks ONLY what this pod needs to serve its core traffic. ' +
+      'Shared-but-non-blocking dependencies (replica lag, queue depth, pgbouncer) are deliberately excluded: ' +
+      'because every replica shares the same Postgres/Redis, wiring them here would flip all pods to NotReady ' +
+      'at once on a single dependency blip — a correlated, cluster-wide outage even though the app is healthy. ' +
+      'Those live on /health/dependencies for dashboards/alerting instead. Returns 503 so the orchestrator ' +
+      'removes the pod from the load balancer when a core dependency is unreachable.',
   })
   @ApiOkResponse({
     type: HealthCheckResultDto,
-    description: 'All critical dependencies reachable.',
+    description: 'Core dependencies reachable — pod can serve traffic.',
   })
   @ApiResponse({
     status: HttpStatus.SERVICE_UNAVAILABLE,
-    description: 'A critical dependency is unreachable.',
+    description: 'A core dependency is unreachable.',
     content: {
       [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
     },
@@ -145,6 +150,29 @@ export class HealthController {
       () => this.prismaIndicator.isHealthy('database'),
       () => this.redisCache.isHealthy('redis_cache'),
       () => this.redisQueue.isHealthy('redis_queue'),
+    ]);
+  }
+
+  @Get('dependencies')
+  @HealthCheck()
+  @ApiOperation({
+    summary: 'Deep dependency check (BullMQ + pgbouncer + replica lag).',
+    description:
+      'Deep health of shared infrastructure — meant for dashboards and alerting, NOT for the Kubernetes ' +
+      'readiness/liveness probes. Wiring these into a probe would remove every replica from the load balancer ' +
+      'at once when a shared dependency degrades. Returns 503 when a deep check fails so alert rules can fire.',
+  })
+  @ApiOkResponse({ type: HealthCheckResultDto, description: 'All deep dependencies healthy.' })
+  @ApiResponse({
+    status: HttpStatus.SERVICE_UNAVAILABLE,
+    description: 'A deep dependency is degraded or unreachable.',
+    content: {
+      [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
+    },
+  })
+  @ApiCommonErrors({ auth: false, forbidden: false, validation: false })
+  dependencies() {
+    return this.health.check([
       () => this.bullmq.isHealthy('bullmq'),
       // no-op when DATABASE_DIRECT_URL unset
       () => this.pgbouncer.isHealthy('pgbouncer'),

--- a/apps/api/src/common/logging/correlation-id.middleware.ts
+++ b/apps/api/src/common/logging/correlation-id.middleware.ts
@@ -3,7 +3,7 @@ import { trace } from '@opentelemetry/api';
 import { ClsService } from 'nestjs-cls';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { REQUEST_CONTEXT_KEYS, type RequestContextStore } from '@nestjs-fastify-nx/core';
-import { activeTraceId, resolveRequestId } from './request-id';
+import { activeTraceId, resolveRequestId, sanitizeClientId } from './request-id';
 
 interface RequestWithIds extends IncomingMessage {
   correlationId?: string;
@@ -21,7 +21,7 @@ export class CorrelationIdMiddleware implements NestMiddleware {
     const requestId = this.cls.get(REQUEST_CONTEXT_KEYS.requestId) ?? resolveRequestId(req.headers);
     const correlationId =
       this.cls.get(REQUEST_CONTEXT_KEYS.correlationId) ??
-      (req.headers['x-correlation-id'] as string) ??
+      sanitizeClientId(req.headers['x-correlation-id']) ??
       requestId;
 
     req.correlationId = correlationId;

--- a/apps/api/src/common/logging/logging.module.ts
+++ b/apps/api/src/common/logging/logging.module.ts
@@ -5,7 +5,7 @@ import type { IncomingMessage } from 'http';
 import { buildPinoLoggerConfig } from '@nestjs-fastify-nx/infra-observability';
 import { REQUEST_CONTEXT_KEYS } from '@nestjs-fastify-nx/core';
 import { CorrelationIdMiddleware } from './correlation-id.middleware';
-import { resolveRequestId } from './request-id';
+import { resolveRequestId, sanitizeClientId } from './request-id';
 
 @Module({
   imports: [
@@ -20,21 +20,16 @@ import { resolveRequestId } from './request-id';
         mount: true,
         setup: (cls, req: IncomingMessage) => {
           const requestId = resolveRequestId(req.headers as Record<string, unknown>);
-          const correlationId = (req.headers['x-correlation-id'] as string) || requestId;
+          const correlationId = sanitizeClientId(req.headers['x-correlation-id']) ?? requestId;
           cls.set(REQUEST_CONTEXT_KEYS.requestId, requestId);
           cls.set(REQUEST_CONTEXT_KEYS.correlationId, correlationId);
         },
       },
     }),
-    LoggerModule.forRoot(
-      buildPinoLoggerConfig({
-        customProps: (req: IncomingMessage & { correlationId?: string; requestId?: string }) =>
-          ({
-            correlationId: req.correlationId,
-            requestId: req.requestId,
-          }) as Record<string, unknown>,
-      }),
-    ),
+    // No `customProps` for requestId/correlationId — the pino `mixin` in
+    // buildPinoLoggerConfig already injects them (from the CLS store) on every log
+    // line app-wide. Adding them here too duplicated the keys on each request log.
+    LoggerModule.forRoot(buildPinoLoggerConfig()),
   ],
 })
 export class LoggingModule implements NestModule {

--- a/apps/api/src/common/logging/request-id.spec.ts
+++ b/apps/api/src/common/logging/request-id.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRequestId, sanitizeClientId } from './request-id';
+
+describe('sanitizeClientId', () => {
+  it('accepts a well-formed opaque id', () => {
+    expect(sanitizeClientId('req_01HZY8ABCD.efgh-1234~xyz')).toBe('req_01HZY8ABCD.efgh-1234~xyz');
+  });
+
+  it('accepts a 32-hex trace id', () => {
+    const traceId = 'a'.repeat(32);
+    expect(sanitizeClientId(traceId)).toBe(traceId);
+  });
+
+  it.each([
+    ['newline (log-injection vector)', 'abc\nlevel=50 msg=forged'],
+    ['carriage return', 'abc\rdef'],
+    ['tab', 'abc\tdef'],
+    ['space', 'abc def'],
+    ['slash', 'abc/def'],
+    ['empty string', ''],
+  ])('rejects %s', (_label, value) => {
+    expect(sanitizeClientId(value)).toBeUndefined();
+  });
+
+  it('rejects an over-length id (> 128 chars) to bound log/trace storage', () => {
+    expect(sanitizeClientId('x'.repeat(129))).toBeUndefined();
+  });
+
+  it('accepts an id at the 128-char boundary', () => {
+    expect(sanitizeClientId('x'.repeat(128))).toHaveLength(128);
+  });
+
+  it.each([[undefined], [null], [42], [{}], [['a']]])('rejects non-string %s', (value) => {
+    expect(sanitizeClientId(value)).toBeUndefined();
+  });
+});
+
+describe('resolveRequestId', () => {
+  it('returns the client x-request-id when it is well-formed', () => {
+    expect(resolveRequestId({ 'x-request-id': 'req_valid-123' })).toBe('req_valid-123');
+  });
+
+  it('never returns a poisoned client id — mints a fresh one instead', () => {
+    const poisoned = 'abc\ninjected-log-line';
+    const resolved = resolveRequestId({ 'x-request-id': poisoned });
+
+    expect(resolved).not.toBe(poisoned);
+    expect(resolved).not.toContain('\n');
+    expect(resolved.length).toBeGreaterThan(0);
+  });
+
+  it('mints a fresh id when no client header is present', () => {
+    const a = resolveRequestId({});
+    const b = resolveRequestId({});
+
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/common/logging/request-id.ts
+++ b/apps/api/src/common/logging/request-id.ts
@@ -1,6 +1,17 @@
 import { isValidTraceId, trace } from '@opentelemetry/api';
 import { generateCorrelationId } from '@nestjs-fastify-nx/shared';
 
+// Bound any client-supplied id before it flows into every log line / span attribute:
+// printable URL-safe chars only (no newlines/control chars → blocks log injection) and a
+// hard length cap (blocks log/trace-storage bloat). A value outside this shape is dropped
+// and we mint our own id rather than trust the client. 128 covers a UUID, a 32-hex trace id,
+// or a Stripe-style opaque token with margin to spare.
+const SAFE_CLIENT_ID = /^[A-Za-z0-9._~-]{1,128}$/;
+
+export function sanitizeClientId(value: unknown): string | undefined {
+  return typeof value === 'string' && SAFE_CLIENT_ID.test(value) ? value : undefined;
+}
+
 // Trace id of the active span, or undefined when it is absent or all-zeros (unsampled/invalid
 // context). Guarding against INVALID_TRACEID stops every unsampled request sharing one id.
 export function activeTraceId(): string | undefined {
@@ -8,8 +19,7 @@ export function activeTraceId(): string | undefined {
   return id && isValidTraceId(id) ? id : undefined;
 }
 
-// Correlation id for a request: client header → active trace id → random hex.
+// Request id for a request: validated client header → active trace id → random hex.
 export function resolveRequestId(headers: Record<string, unknown>): string {
-  const header = headers['x-request-id'];
-  return (typeof header === 'string' && header) || activeTraceId() || generateCorrelationId();
+  return sanitizeClientId(headers['x-request-id']) ?? activeTraceId() ?? generateCorrelationId();
 }

--- a/apps/api/src/common/metrics/bullmq-metrics.listener.spec.ts
+++ b/apps/api/src/common/metrics/bullmq-metrics.listener.spec.ts
@@ -4,6 +4,7 @@ import {
   UploadVerificationMetricsListener,
 } from './bullmq-metrics.listener';
 import type { MetricsService } from './metrics.service';
+import type { MetricsLeaderService } from './metrics-leader.service';
 
 function makeMockMetrics(): MetricsService {
   return {
@@ -12,13 +13,32 @@ function makeMockMetrics(): MetricsService {
   } as unknown as MetricsService;
 }
 
+function makeLeader(isLeader: boolean): MetricsLeaderService {
+  return { isLeader: () => isLeader } as unknown as MetricsLeaderService;
+}
+
 describe('EmailNotificationMetricsListener', () => {
   let listener: EmailNotificationMetricsListener;
   let metrics: MetricsService;
 
   beforeEach(() => {
     metrics = makeMockMetrics();
-    listener = new EmailNotificationMetricsListener(metrics);
+    listener = new EmailNotificationMetricsListener(metrics, makeLeader(true));
+  });
+
+  describe('collector-leader gating', () => {
+    it('records nothing when this replica is not the leader', () => {
+      const follower = new EmailNotificationMetricsListener(metrics, makeLeader(false));
+
+      follower.onActive({ jobId: 'j' });
+      follower.onCompleted({ jobId: 'j', returnvalue: '', prev: 'active' });
+      follower.onFailed({ jobId: 'j', failedReason: 'x', prev: 'active' });
+      follower.onStalled({ jobId: 'j' });
+      follower.onDelayed();
+
+      expect(metrics.bullmqJobsTotal.inc).not.toHaveBeenCalled();
+      expect(metrics.bullmqJobDurationSeconds.observe).not.toHaveBeenCalled();
+    });
   });
 
   describe('job counter increments', () => {
@@ -122,7 +142,7 @@ describe('UploadVerificationMetricsListener', () => {
 
   beforeEach(() => {
     metrics = makeMockMetrics();
-    listener = new UploadVerificationMetricsListener(metrics);
+    listener = new UploadVerificationMetricsListener(metrics, makeLeader(true));
   });
 
   it('tags counters with upload-verification queue label', () => {

--- a/apps/api/src/common/metrics/bullmq-metrics.listener.ts
+++ b/apps/api/src/common/metrics/bullmq-metrics.listener.ts
@@ -2,6 +2,7 @@ import { OnQueueEvent, QueueEventsHost, QueueEventsListener } from '@nestjs/bull
 import { Injectable } from '@nestjs/common';
 import { QUEUE_NAMES } from '@nestjs-fastify-nx/shared';
 import { MetricsService } from './metrics.service';
+import { MetricsLeaderService } from './metrics-leader.service';
 
 interface ActiveEvent {
   jobId: string;
@@ -29,12 +30,15 @@ interface StalledEvent {
 const MAX_ACTIVE_AGE_MS = 60 * 60 * 1000;
 
 // @QueueEventsListener requires a literal name — one subclass per queue.
-// At API_REPLICAS > 1 every replica receives each event; divide counters in dashboards.
+// QueueEvents is a broadcast stream: at API_REPLICAS > 1 every replica receives every event, so
+// unguarded inc() would multiply counters by the replica count. Recording is gated on the collector
+// leader (single writer) so `sum()` over replicas equals the real job count.
 abstract class QueueMetricsListenerBase extends QueueEventsHost {
   private readonly activeAt = new Map<string, number>();
 
   constructor(
     private readonly metrics: MetricsService,
+    private readonly leader: MetricsLeaderService,
     private readonly queueLabel: string,
   ) {
     super();
@@ -42,23 +46,27 @@ abstract class QueueMetricsListenerBase extends QueueEventsHost {
 
   @OnQueueEvent('active')
   onActive(args: ActiveEvent): void {
+    if (!this.leader.isLeader()) return;
     this.activeAt.set(args.jobId, Date.now());
   }
 
   @OnQueueEvent('completed')
   onCompleted(args: CompletedEvent): void {
+    if (!this.leader.isLeader()) return;
     this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'completed' });
     this.observeDuration(args.jobId, 'completed');
   }
 
   @OnQueueEvent('failed')
   onFailed(args: FailedEvent): void {
+    if (!this.leader.isLeader()) return;
     this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'failed' });
     this.observeDuration(args.jobId, 'failed');
   }
 
   @OnQueueEvent('stalled')
   onStalled(args: StalledEvent): void {
+    if (!this.leader.isLeader()) return;
     this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'stalled' });
     // Stalled jobs get re-claimed elsewhere — drop the local active entry so it can't leak.
     this.activeAt.delete(args.jobId);
@@ -67,6 +75,7 @@ abstract class QueueMetricsListenerBase extends QueueEventsHost {
 
   @OnQueueEvent('delayed')
   onDelayed(): void {
+    if (!this.leader.isLeader()) return;
     this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'delayed' });
   }
 
@@ -94,15 +103,15 @@ abstract class QueueMetricsListenerBase extends QueueEventsHost {
 @QueueEventsListener(QUEUE_NAMES.EMAIL_NOTIFICATION)
 @Injectable()
 export class EmailNotificationMetricsListener extends QueueMetricsListenerBase {
-  constructor(metrics: MetricsService) {
-    super(metrics, QUEUE_NAMES.EMAIL_NOTIFICATION);
+  constructor(metrics: MetricsService, leader: MetricsLeaderService) {
+    super(metrics, leader, QUEUE_NAMES.EMAIL_NOTIFICATION);
   }
 }
 
 @QueueEventsListener(QUEUE_NAMES.UPLOAD_VERIFICATION)
 @Injectable()
 export class UploadVerificationMetricsListener extends QueueMetricsListenerBase {
-  constructor(metrics: MetricsService) {
-    super(metrics, QUEUE_NAMES.UPLOAD_VERIFICATION);
+  constructor(metrics: MetricsService, leader: MetricsLeaderService) {
+    super(metrics, leader, QUEUE_NAMES.UPLOAD_VERIFICATION);
   }
 }

--- a/apps/api/src/common/metrics/metrics-leader.service.spec.ts
+++ b/apps/api/src/common/metrics/metrics-leader.service.spec.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisMock = {
+  set: vi.fn(),
+  eval: vi.fn(),
+  on: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+vi.mock('ioredis', () => ({
+  // A constructor that returns an object replaces the `new` instance with our mock.
+  default: class {
+    constructor() {
+      return redisMock;
+    }
+  },
+}));
+
+import { MetricsLeaderService } from './metrics-leader.service';
+import type { ConfigService } from '@nestjs/config';
+import type { EnvConfig } from '../../config/env.validation';
+
+function makeConfig(): ConfigService<EnvConfig, true> {
+  return {
+    get: (key: string) => {
+      switch (key) {
+        case 'REDIS_QUEUE_PREFIX':
+          return 'bull';
+        case 'REDIS_QUEUE_HOST':
+          return 'localhost';
+        case 'REDIS_QUEUE_PORT':
+          return 6380;
+        default:
+          return undefined;
+      }
+    },
+  } as unknown as ConfigService<EnvConfig, true>;
+}
+
+const tick = (svc: MetricsLeaderService): Promise<void> =>
+  (svc as unknown as { tick(): Promise<void> }).tick();
+
+describe('MetricsLeaderService', () => {
+  let svc: MetricsLeaderService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new MetricsLeaderService(makeConfig());
+  });
+
+  it('starts as a follower before any tick', () => {
+    expect(svc.isLeader()).toBe(false);
+  });
+
+  it('becomes leader when the NX lease is acquired', async () => {
+    redisMock.set.mockResolvedValueOnce('OK');
+
+    await tick(svc);
+
+    expect(svc.isLeader()).toBe(true);
+    expect(redisMock.set).toHaveBeenCalledWith(
+      expect.stringContaining('metrics:collector-leader'),
+      expect.any(String),
+      'PX',
+      expect.any(Number),
+      'NX',
+    );
+  });
+
+  it('stays a follower when the lease is already held by another replica', async () => {
+    redisMock.set.mockResolvedValueOnce(null);
+
+    await tick(svc);
+
+    expect(svc.isLeader()).toBe(false);
+  });
+
+  it('renews via compare-and-extend while leader, without re-acquiring', async () => {
+    redisMock.set.mockResolvedValueOnce('OK');
+    await tick(svc);
+
+    redisMock.set.mockClear();
+    redisMock.eval.mockResolvedValueOnce(1);
+    await tick(svc);
+
+    expect(redisMock.eval).toHaveBeenCalled();
+    expect(redisMock.set).not.toHaveBeenCalled();
+    expect(svc.isLeader()).toBe(true);
+  });
+
+  it('relinquishes leadership when the renew shows the lease was lost', async () => {
+    redisMock.set.mockResolvedValueOnce('OK');
+    await tick(svc);
+
+    redisMock.eval.mockResolvedValueOnce(0);
+    redisMock.set.mockResolvedValueOnce(null);
+    await tick(svc);
+
+    expect(svc.isLeader()).toBe(false);
+  });
+
+  it('fails closed (drops leadership) when Redis errors', async () => {
+    redisMock.set.mockResolvedValueOnce('OK');
+    await tick(svc);
+
+    redisMock.eval.mockRejectedValueOnce(new Error('redis down'));
+    await tick(svc);
+
+    expect(svc.isLeader()).toBe(false);
+  });
+
+  it('releases only its own lease and disconnects on destroy', async () => {
+    redisMock.set.mockResolvedValueOnce('OK');
+    await tick(svc);
+
+    redisMock.eval.mockResolvedValueOnce(1);
+    await svc.onModuleDestroy();
+
+    expect(redisMock.eval).toHaveBeenCalledWith(
+      expect.stringContaining('del'),
+      1,
+      expect.any(String),
+      expect.any(String),
+    );
+    expect(redisMock.disconnect).toHaveBeenCalled();
+    expect(svc.isLeader()).toBe(false);
+  });
+});

--- a/apps/api/src/common/metrics/metrics-leader.service.ts
+++ b/apps/api/src/common/metrics/metrics-leader.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
+import Redis from 'ioredis';
+import type { EnvConfig } from '../../config/env.validation';
+
+// Global-state metrics (queue depth, outbox lag, BullMQ QueueEvents) describe ONE shared truth in
+// Redis/Postgres. Every API replica observes the same stream, so if all of them record, gauges read
+// N× the real value and counters inflate by the replica count. A single-writer lease fixes that:
+// exactly one replica is the "collector leader" at a time; the rest observe but do not record.
+//
+// This is a best-effort lease, not a correctness-critical lock. A brief split-brain (two leaders for
+// a few seconds during failover) only double-counts transiently — acceptable for metrics, so a single
+// Redis with a compare-and-extend lease is sufficient (no Redlock quorum needed).
+const LEASE_TTL_MS = 30_000;
+const RENEW_INTERVAL_MS = 10_000;
+
+// Extend only while we still own the lease — a stalled replica must never steal it back from a
+// successor that already acquired it.
+const RENEW_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('pexpire', KEYS[1], ARGV[2])
+end
+return 0`;
+
+// Release only our own lease on shutdown — never delete a lease a successor now holds.
+const RELEASE_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0`;
+
+@Injectable()
+export class MetricsLeaderService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(MetricsLeaderService.name);
+  private readonly redis: Redis;
+  private readonly key: string;
+  private readonly token = randomUUID();
+  private timer?: NodeJS.Timeout;
+  private leader = false;
+
+  constructor(config: ConfigService<EnvConfig, true>) {
+    this.key = `${config.get('REDIS_QUEUE_PREFIX', { infer: true })}:metrics:collector-leader`;
+    this.redis = new Redis({
+      host: config.get('REDIS_QUEUE_HOST', { infer: true }),
+      port: config.get('REDIS_QUEUE_PORT', { infer: true }),
+      lazyConnect: true,
+      maxRetriesPerRequest: 1,
+      retryStrategy: () => null,
+    });
+    // Surfaced as leader=false on the next failed tick — never crash the process on a Redis blip.
+    this.redis.on('error', () => undefined);
+  }
+
+  isLeader(): boolean {
+    return this.leader;
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, RENEW_INTERVAL_MS);
+    // Never keep the event loop alive just for the renew timer.
+    this.timer.unref();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    try {
+      if (this.leader) {
+        await this.redis.eval(RELEASE_SCRIPT, 1, this.key, this.token);
+      }
+    } catch {
+      // Lease self-expires via TTL — nothing to clean up if release fails.
+    } finally {
+      this.leader = false;
+      this.redis.disconnect();
+    }
+  }
+
+  private async tick(): Promise<void> {
+    try {
+      if (this.leader) {
+        const renewed = await this.redis.eval(
+          RENEW_SCRIPT,
+          1,
+          this.key,
+          this.token,
+          String(LEASE_TTL_MS),
+        );
+        this.leader = renewed === 1;
+        if (this.leader) return;
+      }
+      const acquired = await this.redis.set(this.key, this.token, 'PX', LEASE_TTL_MS, 'NX');
+      this.leader = acquired === 'OK';
+    } catch (err) {
+      // Fail closed: drop leadership so a healthy replica takes over and we never double-count
+      // while Redis is flaky. A metrics gap during an outage beats an N× overcount.
+      this.leader = false;
+      this.logger.warn(`collector leader election tick failed: ${String(err)}`);
+    }
+  }
+}

--- a/apps/api/src/common/metrics/metrics.module.ts
+++ b/apps/api/src/common/metrics/metrics.module.ts
@@ -16,6 +16,7 @@ import { MetricsIpAllowGuard } from './metrics-ip-allow.guard';
 import { QueueDepthCollector } from './queue-depth.collector';
 import { OutboxLagCollector } from './outbox-lag.collector';
 import { MetricsCqrsRecorderAdapter } from './cqrs-metrics-recorder.adapter';
+import { MetricsLeaderService } from './metrics-leader.service';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { MetricsCqrsRecorderAdapter } from './cqrs-metrics-recorder.adapter';
   controllers: [MetricsController],
   providers: [
     MetricsService,
+    MetricsLeaderService,
     HttpMetricsHook,
     EmailNotificationMetricsListener,
     UploadVerificationMetricsListener,

--- a/apps/api/src/common/metrics/outbox-lag.collector.spec.ts
+++ b/apps/api/src/common/metrics/outbox-lag.collector.spec.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OutboxLagCollector } from './outbox-lag.collector';
 import type { MetricsService } from './metrics.service';
+import type { MetricsLeaderService } from './metrics-leader.service';
 import type { PrismaService } from '@nestjs-fastify-nx/infra-database';
+
+function makeLeader(isLeader: boolean): MetricsLeaderService {
+  return { isLeader: () => isLeader } as unknown as MetricsLeaderService;
+}
 
 function makeMockPrisma(lagSeconds: number | null): PrismaService {
   return {
@@ -25,7 +30,16 @@ describe('OutboxLagCollector', () => {
   beforeEach(() => {
     prisma = makeMockPrisma(42.5);
     metrics = makeMockMetrics();
-    collector = new OutboxLagCollector(prisma, metrics);
+    collector = new OutboxLagCollector(prisma, metrics, makeLeader(true));
+  });
+
+  it('records nothing when this replica is not the collector leader', async () => {
+    collector = new OutboxLagCollector(prisma, metrics, makeLeader(false));
+
+    await collector.collect();
+
+    expect(prisma.db.$queryRawUnsafe).not.toHaveBeenCalled();
+    expect(metrics.outboxLagSeconds.set).not.toHaveBeenCalled();
   });
 
   it('sets the gauge to the lag_seconds returned by the query', async () => {
@@ -36,7 +50,7 @@ describe('OutboxLagCollector', () => {
 
   it('sets the gauge to 0 when lag_seconds is null (no unprocessed events)', async () => {
     prisma = makeMockPrisma(null);
-    collector = new OutboxLagCollector(prisma, metrics);
+    collector = new OutboxLagCollector(prisma, metrics, makeLeader(true));
 
     await collector.collect();
 

--- a/apps/api/src/common/metrics/outbox-lag.collector.ts
+++ b/apps/api/src/common/metrics/outbox-lag.collector.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Interval } from '@nestjs/schedule';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
 import { MetricsService } from './metrics.service';
+import { MetricsLeaderService } from './metrics-leader.service';
 
 @Injectable()
 export class OutboxLagCollector {
@@ -10,10 +11,15 @@ export class OutboxLagCollector {
   constructor(
     private readonly prisma: PrismaService,
     private readonly metrics: MetricsService,
+    private readonly leader: MetricsLeaderService,
   ) {}
 
   @Interval(30_000)
   async collect(): Promise<void> {
+    // Outbox lag is one global truth read from Postgres — only the leader records it, else every
+    // replica sets the same gauge to the same value.
+    if (!this.leader.isLeader()) return;
+
     try {
       const rows = await this.prisma.db.$queryRawUnsafe<[{ lag_seconds: number | null }]>(
         `SELECT EXTRACT(EPOCH FROM NOW() - MIN("createdAt"))::float AS lag_seconds

--- a/apps/api/src/common/metrics/queue-depth.collector.spec.ts
+++ b/apps/api/src/common/metrics/queue-depth.collector.spec.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueueDepthCollector } from './queue-depth.collector';
 import type { MetricsService } from './metrics.service';
+import type { MetricsLeaderService } from './metrics-leader.service';
 import type { Queue } from 'bullmq';
+
+function makeLeader(isLeader: boolean): MetricsLeaderService {
+  return { isLeader: () => isLeader } as unknown as MetricsLeaderService;
+}
 
 function makeMockQueue(name: string, counts: Record<string, number>): Queue {
   return {
@@ -32,7 +37,16 @@ describe('QueueDepthCollector', () => {
     emailQ = makeMockQueue('email-notification', EMAIL_COUNTS);
     uploadQ = makeMockQueue('upload-verification', UPLOAD_COUNTS);
     metrics = makeMockMetrics();
-    collector = new QueueDepthCollector(emailQ, uploadQ, metrics);
+    collector = new QueueDepthCollector(emailQ, uploadQ, metrics, makeLeader(true));
+  });
+
+  it('records nothing when this replica is not the collector leader', async () => {
+    collector = new QueueDepthCollector(emailQ, uploadQ, metrics, makeLeader(false));
+
+    await collector.collect();
+
+    expect(emailQ.getJobCounts).not.toHaveBeenCalled();
+    expect(metrics.bullmqQueueDepth.labels).not.toHaveBeenCalled();
   });
 
   it('calls getJobCounts for every requested state on both queues', async () => {

--- a/apps/api/src/common/metrics/queue-depth.collector.ts
+++ b/apps/api/src/common/metrics/queue-depth.collector.ts
@@ -4,6 +4,7 @@ import { InjectQueue } from '@nestjs/bullmq';
 import type { Queue } from 'bullmq';
 import { QUEUE_NAMES } from '@nestjs-fastify-nx/shared';
 import { MetricsService } from './metrics.service';
+import { MetricsLeaderService } from './metrics-leader.service';
 
 @Injectable()
 export class QueueDepthCollector {
@@ -13,10 +14,15 @@ export class QueueDepthCollector {
     @InjectQueue(QUEUE_NAMES.EMAIL_NOTIFICATION) private readonly emailQ: Queue,
     @InjectQueue(QUEUE_NAMES.UPLOAD_VERIFICATION) private readonly uploadQ: Queue,
     private readonly metrics: MetricsService,
+    private readonly leader: MetricsLeaderService,
   ) {}
 
   @Interval(30_000)
   async collect(): Promise<void> {
+    // Queue depth is one global truth read from Redis — only the leader records it, else every
+    // replica sets the same gauge and dashboards read N× the real depth.
+    if (!this.leader.isLeader()) return;
+
     for (const q of [this.emailQ, this.uploadQ]) {
       try {
         const counts = await q.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed');

--- a/apps/api/src/config/env.validation.spec.ts
+++ b/apps/api/src/config/env.validation.spec.ts
@@ -97,16 +97,35 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ ...baseProdEnv, MAIL_HOST: 'localhost' })).toThrow(/MAIL_HOST/);
   });
 
-  it('rejects MAIL_IGNORE_TLS=true in production', () => {
-    expect(() => validateConfig({ ...baseProdEnv, MAIL_IGNORE_TLS: 'true' })).toThrow(
-      /MAIL_IGNORE_TLS/,
-    );
+  it('rejects MAIL_IGNORE_TLS=true in production when MAIL_USER is set', () => {
+    expect(() =>
+      validateConfig({ ...baseProdEnv, MAIL_USER: 'smtp-user', MAIL_IGNORE_TLS: 'true' }),
+    ).toThrow(/MAIL_IGNORE_TLS/);
   });
 
-  it('requires MAIL_SECURE or MAIL_REQUIRE_TLS in production', () => {
+  it('requires MAIL_SECURE or MAIL_REQUIRE_TLS in production when MAIL_USER is set', () => {
     expect(() =>
-      validateConfig({ ...baseProdEnv, MAIL_SECURE: 'false', MAIL_REQUIRE_TLS: 'false' }),
+      validateConfig({
+        ...baseProdEnv,
+        MAIL_USER: 'smtp-user',
+        MAIL_SECURE: 'false',
+        MAIL_REQUIRE_TLS: 'false',
+      }),
     ).toThrow(/MAIL_REQUIRE_TLS/);
+  });
+
+  it('allows plaintext SMTP in production when MAIL_USER is unset (no credentials to leak)', () => {
+    // A no-auth relay (e.g. a local Mailpit in the prod-parity smoke) sends nothing
+    // secret in plaintext, so the TLS requirement does not apply.
+    expect(() =>
+      validateConfig({
+        ...baseProdEnv,
+        MAIL_USER: '',
+        MAIL_IGNORE_TLS: 'true',
+        MAIL_SECURE: 'false',
+        MAIL_REQUIRE_TLS: 'false',
+      }),
+    ).not.toThrow();
   });
 
   it('rejects default bull board password in production', () => {

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -9,7 +9,8 @@ const envSchema = z
     // Physical replica for read-only queries. When unset, dbRead aliases to db.
     DATABASE_REPLICA_URL: z.string().trim().min(1).optional(),
     DATABASE_REPLICA_POOL_MAX: z.coerce.number().int().min(1).max(1000).default(10),
-    // Flips /health/ready to 503 when exceeded. 30s suits most streaming replication topologies.
+    // Flips /health/dependencies to 503 when exceeded (NOT the readiness probe — see HealthController).
+    // 30s suits most streaming replication topologies.
     DB_REPLICATION_LAG_THRESHOLD_MS: z.coerce.number().int().min(1_000).default(30_000),
     DATABASE_POOL_MAX: z.coerce.number().int().min(1).max(1000).default(20),
     DATABASE_POOL_MIN: z.coerce.number().int().min(0).max(1000).default(0),
@@ -125,6 +126,20 @@ const envSchema = z
     OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default('http://localhost:4318'),
     OTEL_EXPORTER_OTLP_HEADERS: z.string().default(''),
     OTEL_TRACES_SAMPLER_RATIO: z.coerce.number().min(0).max(1).default(1),
+    // Trust inbound W3C traceparent/baggage. Keep false on a public edge so clients can't inject or
+    // collide trace ids / force sampling; set true only behind a trusted mesh/gateway that owns the
+    // root span. Read by startTracing() via process.env; declared here for .env.example parity.
+    OTEL_TRUST_INBOUND_TRACEPARENT: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
+    // Push OTLP metrics from this process. Keep false in the API — prom-client (/metrics) is the
+    // metrics source of truth, so enabling both would double-count. Enable only in processes with no
+    // prom-client scrape endpoint (worker, scheduler). Read by startTracing() via process.env.
+    OTEL_METRICS_EXPORT_ENABLED: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
 
     // Domain event publisher
     EVENT_PUBLISHER_DRIVER: z.enum(['inprocess', 'outbox']).default('inprocess'),
@@ -261,22 +276,28 @@ const envSchema = z
       });
     }
 
-    // SMTP runs in the worker, but api and worker share one .env in prod, so
-    // both validators enforce TLS to keep credentials off the wire.
-    if (data.MAIL_IGNORE_TLS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['MAIL_IGNORE_TLS'],
-        message:
-          'MAIL_IGNORE_TLS must be false in production — sending SMTP credentials without TLS exposes them in plaintext',
-      });
-    }
-    if (!data.MAIL_SECURE && !data.MAIL_REQUIRE_TLS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['MAIL_REQUIRE_TLS'],
-        message: 'Enable MAIL_SECURE or MAIL_REQUIRE_TLS in production so SMTP negotiates TLS',
-      });
+    // SMTP runs in the worker, but api and worker share one .env in prod, so both
+    // validators enforce TLS. The rule's intent is to keep CREDENTIALS off the wire,
+    // so it only applies when auth is actually used (MAIL_USER set). A relay without
+    // auth (e.g. a local mailpit in a prod-parity smoke) sends nothing secret in
+    // plaintext, so requiring TLS there adds no security — only friction.
+    if (data.MAIL_USER) {
+      if (data.MAIL_IGNORE_TLS) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['MAIL_IGNORE_TLS'],
+          message:
+            'MAIL_IGNORE_TLS must be false in production when MAIL_USER is set — sending SMTP credentials without TLS exposes them in plaintext',
+        });
+      }
+      if (!data.MAIL_SECURE && !data.MAIL_REQUIRE_TLS) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['MAIL_REQUIRE_TLS'],
+          message:
+            'Enable MAIL_SECURE or MAIL_REQUIRE_TLS in production when MAIL_USER is set so SMTP credentials negotiate TLS',
+        });
+      }
     }
 
     if (data.CORS_ORIGINS.length === 0) {

--- a/apps/worker/src/config/env.validation.ts
+++ b/apps/worker/src/config/env.validation.ts
@@ -67,6 +67,17 @@ const workerEnvSchema = z
     OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default('http://localhost:4318'),
     OTEL_EXPORTER_OTLP_HEADERS: z.string().default(''),
     OTEL_TRACES_SAMPLER_RATIO: z.coerce.number().min(0).max(1).default(1),
+    // See api validator. Worker has no public HTTP surface, but the flag stays for .env.example parity.
+    OTEL_TRUST_INBOUND_TRACEPARENT: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
+    // The worker has no prom-client /metrics endpoint, so OTLP push is how its runtime metrics leave
+    // the process — enable this (OTEL_METRICS_EXPORT_ENABLED=true) when OTEL_ENABLED is on in prod.
+    OTEL_METRICS_EXPORT_ENABLED: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
 
     // Outbox event retention (validated here for .env.example parity; only the
     // scheduler's purge cron is the runtime consumer).
@@ -81,19 +92,24 @@ const workerEnvSchema = z
   })
   .superRefine((data, ctx) => {
     // The worker owns the SMTP transport, so the production TLS guard belongs here.
-    if (data.NODE_ENV !== 'production') return;
+    // Enforced only when auth is used (MAIL_USER set): the rule protects credentials,
+    // and a no-auth relay (e.g. a local mailpit prod-parity smoke) leaks nothing in
+    // plaintext. Keeps prod secure without forcing TLS gymnastics against mailpit.
+    if (data.NODE_ENV !== 'production' || !data.MAIL_USER) return;
     if (data.MAIL_IGNORE_TLS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['MAIL_IGNORE_TLS'],
-        message: 'MAIL_IGNORE_TLS must be false in production — plaintext SMTP exposes credentials',
+        message:
+          'MAIL_IGNORE_TLS must be false in production when MAIL_USER is set — plaintext SMTP exposes credentials',
       });
     }
     if (!data.MAIL_SECURE && !data.MAIL_REQUIRE_TLS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['MAIL_REQUIRE_TLS'],
-        message: 'Enable MAIL_SECURE or MAIL_REQUIRE_TLS in production so SMTP negotiates TLS',
+        message:
+          'Enable MAIL_SECURE or MAIL_REQUIRE_TLS in production when MAIL_USER is set so SMTP credentials negotiate TLS',
       });
     }
   });

--- a/docker/compose.swarm-local-test.yml
+++ b/docker/compose.swarm-local-test.yml
@@ -11,8 +11,11 @@ services:
     image: axllent/mailpit:v1.27.11
     restart: unless-stopped
     ports:
-      - '${MAILPIT_SMTP_PORT:-1025}:1025'
-      - '${MAILPIT_HTTP_PORT:-8025}:8025'
+      # Loopback-only (matches the observability overlay): the UI is a dev convenience,
+      # never exposed host-wide. Override the port numbers if another local stack already
+      # binds 1025/8025 (e.g. another project's mailpit).
+      - '127.0.0.1:${MAILPIT_SMTP_PORT:-1025}:1025'
+      - '127.0.0.1:${MAILPIT_HTTP_PORT:-8025}:8025'
     healthcheck:
       test: ['CMD', '/mailpit', '--help']
       interval: 10s

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -85,6 +85,9 @@ services:
     restart: unless-stopped
     environment:
       TZ: ${TZ:-UTC}
+      # Self-identify in logs/metrics/traces. Without this the worker inherits the
+      # shared .env OTEL_SERVICE_NAME (nestjs-fastify-api) and mislabels itself as the API.
+      OTEL_SERVICE_NAME: nestjs-fastify-worker
     healthcheck:
       test:
         [
@@ -102,6 +105,8 @@ services:
     restart: unless-stopped
     environment:
       TZ: ${TZ:-UTC}
+      # Self-identify in logs/metrics/traces (see worker note above).
+      OTEL_SERVICE_NAME: nestjs-fastify-scheduler
     healthcheck:
       test:
         [

--- a/docker/otel-collector/config.yaml
+++ b/docker/otel-collector/config.yaml
@@ -7,6 +7,39 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  # First in every pipeline — sheds data before the collector OOMs under a
+  # traffic spike instead of being OOM-killed and losing everything.
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+
+  # Tail sampling decides AFTER seeing a whole trace, so it can keep every error
+  # and slow trace while sampling the rest — the signal head sampling in the app
+  # (OTEL_TRACES_SAMPLER_RATIO) can't preserve because it decides up front. In prod
+  # set a low head ratio (e.g. 0.05) and let this keep the interesting traces.
+  #
+  # NOTE: tail sampling needs all spans of a trace to reach the SAME collector. For a
+  # horizontally scaled collector, put a trace-id-aware loadbalancing exporter in front
+  # (a two-tier collector layout). Single-instance here, so no fan-in needed.
+  tail_sampling:
+    decision_wait: 10s
+    num_traces: 50000
+    expected_new_traces_per_sec: 1000
+    policies:
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: slow
+        type: latency
+        latency:
+          threshold_ms: 1000
+      - name: baseline
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: 5
+
   batch:
     timeout: 1s
     send_batch_size: 1024
@@ -31,10 +64,10 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, tail_sampling, batch]
       exporters: [otlp/jaeger, debug]
 
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [prometheus, debug]

--- a/docker/prometheus/alert_rules.yml
+++ b/docker/prometheus/alert_rules.yml
@@ -20,6 +20,17 @@ groups:
           summary: 'HTTP 5xx rate above 5%'
           description: '{{ $value | humanizePercentage }} of requests returned 5xx over the last 5m.'
 
+      - alert: HighRequestLatencyP95
+        # p95 across all replicas from the shared histogram. http_* is per-replica, so
+        # the le buckets sum correctly. 1s p95 is the latency SLO — tune per service.
+        expr: histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m]))) > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'API p95 latency above 1s'
+          description: 'p95 request latency is {{ $value | humanizeDuration }} over the last 5m — check DB/queue pressure and slow-query logs.'
+
   - name: outbox
     rules:
       - alert: OutboxLagHigh
@@ -37,8 +48,9 @@ groups:
   - name: bullmq
     rules:
       - alert: QueueBacklogHigh
-        # max by() not sum by() — every API replica reports the same queue depth via its
-        # QueueEvents subscription, so summing double-counts. See docs/runbook.md.
+        # bullmq_queue_depth is recorded only by the collector-leader replica
+        # (MetricsLeaderService), so it's a single series. `max by (queue)` is a safe
+        # collapse if leadership hands over mid-scrape. See docs/observability.md.
         expr: max by (queue) (bullmq_queue_depth{state="waiting"}) > 1000
         for: 10m
         labels:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -744,7 +744,9 @@ variable is the only action needed to enable replica routing.
 
 ### Health monitoring
 
-`PrismaReplicationLagHealthIndicator` is wired into `/health/ready`. When
+`PrismaReplicationLagHealthIndicator` is wired into `/health/dependencies` (a
+deep check for dashboards/alerting — **not** the readiness probe, so a replica-lag
+spike can't flip every pod out of the load balancer at once). When
 `DATABASE_REPLICA_URL` is set it queries `pg_last_xact_replay_timestamp()` on
 the replica and reports:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -210,11 +210,16 @@ to verify a signed tag locally with `cosign verify`.
 
 ## Health Checks
 
-| Endpoint                   | Description                           |
-| -------------------------- | ------------------------------------- |
-| `GET /api/v1/health`       | Full check: DB + memory + Redis       |
-| `GET /api/v1/health/ready` | Readiness: DB connectivity only       |
-| `GET /api/v1/health/live`  | Liveness: always 200 if process is up |
+| Endpoint                          | Description                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------ |
+| `GET /api/v1/health`              | Full check: DB + memory + Redis (cache & queue)                                |
+| `GET /api/v1/health/ready`        | **Readiness probe**: core serving deps only — DB primary + Redis               |
+| `GET /api/v1/health/live`         | **Liveness probe**: always 200 if process is up                                |
+| `GET /api/v1/health/dependencies` | Deep check (BullMQ + pgbouncer + replica lag) — dashboards/alerts, not a probe |
+
+> Wire the readiness/liveness probes to `/health/ready` and `/health/live` only. Never point a
+> Kubernetes probe at `/health/dependencies`: it checks shared infrastructure, so a single
+> dependency blip would flip every replica to NotReady at once (see `docs/observability.md`).
 
 Worker and scheduler use file-based liveness probes (`/tmp/worker-alive`, `/tmp/scheduler-alive`), refreshed every 30 seconds.
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -149,6 +149,8 @@ safe because command handlers roll back their transaction on error.
 | `MAIL_DEFAULT_EMAIL` | `noreply@example.com` | Yes (real address in prod) | Default `From:` address                              |
 | `MAIL_DEFAULT_NAME`  | `No Reply`            | No                         | Default `From:` display name                         |
 
+> **Prod TLS rule.** In production the env validator requires TLS (`MAIL_IGNORE_TLS=false` **and** one of `MAIL_SECURE`/`MAIL_REQUIRE_TLS`) **only when `MAIL_USER` is set** — the rule protects SMTP credentials, and a no-auth relay (e.g. a local Mailpit in the prod-parity smoke) sends nothing secret in plaintext. Set real credentials + TLS for any production SMTP that authenticates.
+
 ## Seeding
 
 | Variable              | Default | Required     | Description                                                                        |
@@ -177,21 +179,23 @@ safe because command handlers roll back their transaction on error.
 
 ## Observability
 
-| Variable                      | Default                 | Required | Description                                                          |
-| ----------------------------- | ----------------------- | -------- | -------------------------------------------------------------------- |
-| `LOG_LEVEL`                   | `info`                  | No       | pino log level: `trace`, `debug`, `info`, `warn`, `error`            |
-| `ENABLE_METRICS`              | `false`                 | No       | Expose `/metrics` for Prometheus (excluded from `api/v1` prefix)     |
-| `METRICS_ALLOW_CIDRS`         | —                       | No       | Comma-separated CIDR ranges allowed to hit `/metrics` (empty=closed) |
-| `OTEL_ENABLED`                | `false`                 | No       | Bootstrap the OpenTelemetry SDK                                      |
-| `OTEL_SERVICE_NAME`           | `nestjs-fastify-api`    | No       | Reported service name                                                |
-| `OTEL_SERVICE_NAMESPACE`      | `app`                   | No       | Reported service namespace                                           |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | No       | OTLP/HTTP collector endpoint                                         |
-| `OTEL_EXPORTER_OTLP_HEADERS`  | —                       | No       | Optional collector auth headers                                      |
-| `OTEL_TRACES_SAMPLER_RATIO`   | `1`                     | No       | Trace sampling ratio                                                 |
-| `OTEL_DEBUG`                  | `false`                 | No       | Verbose SDK logging                                                  |
-| `SENTRY_DSN`                  | —                       | No       | Sentry DSN; leave empty to disable                                   |
-| `SENTRY_TRACES_SAMPLE_RATE`   | `0.1`                   | No       | Sentry tracing sample rate                                           |
-| `SENTRY_ENVIRONMENT`          | `development`           | No       | Reported Sentry environment tag                                      |
+| Variable                         | Default                 | Required | Description                                                                                                                                                          |
+| -------------------------------- | ----------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOG_LEVEL`                      | `info`                  | No       | pino log level: `trace`, `debug`, `info`, `warn`, `error`                                                                                                            |
+| `ENABLE_METRICS`                 | `false`                 | No       | Expose `/metrics` for Prometheus (excluded from `api/v1` prefix)                                                                                                     |
+| `METRICS_ALLOW_CIDRS`            | —                       | No       | Comma-separated CIDR ranges allowed to hit `/metrics` (empty=closed)                                                                                                 |
+| `OTEL_ENABLED`                   | `false`                 | No       | Bootstrap the OpenTelemetry SDK                                                                                                                                      |
+| `OTEL_SERVICE_NAME`              | `nestjs-fastify-api`    | No       | Reported service name                                                                                                                                                |
+| `OTEL_SERVICE_NAMESPACE`         | `app`                   | No       | Reported service namespace                                                                                                                                           |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`    | `http://localhost:4318` | No       | OTLP/HTTP collector endpoint                                                                                                                                         |
+| `OTEL_EXPORTER_OTLP_HEADERS`     | —                       | No       | Optional collector auth headers                                                                                                                                      |
+| `OTEL_TRACES_SAMPLER_RATIO`      | `1`                     | No       | Head sampling ratio for **new** traces (wrapped in ParentBased — children honor the parent). Prod: low ratio + Collector tail sampling                               |
+| `OTEL_TRUST_INBOUND_TRACEPARENT` | `false`                 | No       | Trust client `traceparent`/`baggage`. Keep `false` on a public edge; `true` only behind a trusted mesh/gateway                                                       |
+| `OTEL_METRICS_EXPORT_ENABLED`    | `false`                 | No       | Push OTLP metrics from this process. Keep `false` for the API (prom-client `/metrics` is source of truth); `true` for worker/scheduler which have no scrape endpoint |
+| `OTEL_DEBUG`                     | `false`                 | No       | Verbose SDK logging                                                                                                                                                  |
+| `SENTRY_DSN`                     | —                       | No       | Sentry DSN; leave empty to disable                                                                                                                                   |
+| `SENTRY_TRACES_SAMPLE_RATE`      | `0.1`                   | No       | Sentry tracing sample rate                                                                                                                                           |
+| `SENTRY_ENVIRONMENT`             | `development`           | No       | Reported Sentry environment tag                                                                                                                                      |
 
 ## CI / Nx Cloud
 

--- a/docs/observability-guide.md
+++ b/docs/observability-guide.md
@@ -1,0 +1,175 @@
+# Observability guide — enable, explore, extend
+
+Practical how-to for the three signals (logs, traces, metrics) and the alerting/dashboard stack.
+For the design rationale (why ParentBased sampling, why single-writer metrics, why the health split),
+read [`observability.md`](./observability.md) first — this file is the operational companion.
+
+## 1. Enable the local stack
+
+Observability is **opt-in**. Two env flags gate it; both default off.
+
+```bash
+OTEL_ENABLED=true                                   # boots the OpenTelemetry SDK (traces)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+ENABLE_METRICS=true                                 # exposes /metrics for Prometheus
+METRICS_ALLOW_CIDRS=172.16.0.0/12                   # let the Prometheus container scrape /metrics
+```
+
+Bring the whole stack up (app + OTel Collector + Jaeger + Prometheus + Grafana), all UIs bound to
+`127.0.0.1` only:
+
+```bash
+./scripts/build-dev.sh --with-obs
+```
+
+UIs (SSH-tunnel them on a remote host):
+
+| UI         | URL                    | Notes                         |
+| ---------- | ---------------------- | ----------------------------- |
+| Jaeger     | http://localhost:16686 | traces                        |
+| Prometheus | http://localhost:9090  | metrics + `/alerts` for rules |
+| Grafana    | http://localhost:3001  | dashboards (admin / admin)    |
+
+> Metric export is a **separate** flag from tracing. `OTEL_METRICS_EXPORT_ENABLED` pushes OTLP
+> metrics and must stay **off in the API** (prom-client `/metrics` is the source of truth — two
+> pipelines double-count). Turn it on only for worker/scheduler, which have no scrape endpoint.
+
+## 2. Explore
+
+- **Trace → logs**: every log line carries `trace_id`/`span_id` (OTel pino instrumentation) plus
+  `requestId`/`correlationId`/`userId` (CLS mixin). Copy a `trace_id` from a log and paste it into
+  Jaeger's "Lookup by Trace ID".
+- **Search → span**: in Jaeger pick the service (`nestjs-fastify-api` / `-worker` / `-scheduler`),
+  "Find Traces", open one to see the HTTP → CQRS → `pg.query` / `ioredis` span tree.
+- **Metrics**: Prometheus → Graph → e.g. `sum by (route) (rate(http_requests_total[5m]))`. Alert
+  rules and their state live under `/alerts`.
+- **Dashboards**: Grafana ships **API Overview** (request rate by status, p99 latency per route,
+  5xx ratio, outbox lag) and **Queue Health**, both provisioned from
+  `docker/grafana/provisioning/`.
+
+## 3. Add a metric
+
+All series live on `MetricsService` (`apps/api/src/common/metrics/metrics.service.ts`). Register the
+collector once and record from where the event happens.
+
+```ts
+// metrics.service.ts — declare the series
+readonly widgetsBuilt = new Counter({
+  name: 'widgets_built_total',
+  help: 'Widgets built by outcome',
+  labelNames: ['outcome'] as const, // NEVER requestId/userId/raw path — unbounded cardinality
+  registers: [this.registry],
+});
+```
+
+```ts
+// where the work happens
+this.metrics.widgetsBuilt.inc({ outcome: 'ok' });
+```
+
+**Label rules**: bounded values only. HTTP `route` uses the **route template** (`/users/:id`), never
+the raw path (`http-metrics.hook.ts`). Put high-cardinality identifiers in logs/traces, not labels.
+
+### Global-state metric → gate on the leader
+
+If the metric describes one shared truth read from Redis/Postgres, or is driven by a BullMQ
+`QueueEvents` broadcast, every API replica would record it and inflate the value by the replica
+count. Gate recording on the collector leader:
+
+```ts
+constructor(/* … */ private readonly leader: MetricsLeaderService) {}
+
+@Interval(30_000)
+async collect(): Promise<void> {
+  if (!this.leader.isLeader()) return; // single writer — see queue-depth.collector.ts
+  // read shared state, set the gauge
+}
+```
+
+Per-replica series (`http_*`, `cqrs_*`) stay **ungated**. PromQL then aggregates normally:
+`sum(rate(...))` for counters, `max by (...)` for a leader-written gauge.
+
+## 4. Add a trace span
+
+HTTP, Postgres, ioredis, GraphQL and socket.io are auto-instrumented — you get those spans for free.
+For business logic, the CQRS bus (`libs/core`) already wraps every command/query in a
+`command.<Name>` / `query.<Name>` span. To trace anything else, use the OTel API:
+
+```ts
+import { trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('my-context');
+await tracer.startActiveSpan('rebuild-index', async (span) => {
+  try {
+    await doWork();
+  } catch (err) {
+    span.recordException(err as Error);
+    throw err;
+  } finally {
+    span.end(); // always end on every path
+  }
+});
+```
+
+Do **not** re-span HTTP/DB/redis (already auto-instrumented — you'd double-span).
+
+## 5. Add a structured log field
+
+Request-scoped fields flow through the CLS store, surfaced by the pino `mixin`
+(`libs/infra/observability/src/lib/pino-logger-config.ts`) on **every** log line in the request —
+handlers, repositories, listeners — not just the HTTP access log. Add a field to
+`RequestContextStore` + set it in the CLS setup (`logging.module.ts`); the mixin picks it up.
+
+**Never** log a raw client-supplied id without validation (`sanitizeClientId`, `request-id.ts`) —
+newlines enable log injection. Add sensitive keys to `SENSITIVE_REDACT_PATHS`
+(`libs/shared/src/lib/logger-redact.ts`); it is a **deny-list**, so a new secret field is logged in
+clear until its path is added.
+
+## 6. Add an alert rule
+
+Edit `docker/prometheus/alert_rules.yml`, then validate before committing:
+
+```bash
+docker run --rm --entrypoint promtool \
+  -v "$(pwd)/docker/prometheus/alert_rules.yml:/rules.yml:ro" \
+  prom/prometheus:v3.3.0 check rules /rules.yml
+```
+
+Reload Prometheus without a restart: `curl -X POST http://localhost:9090/-/reload`
+(`--web.enable-lifecycle` is already set). Wire an Alertmanager under `alerting:` to route to
+Slack/PagerDuty in a real deployment.
+
+## 7. Add / edit a Grafana dashboard
+
+Dashboards are provisioned JSON under `docker/grafana/provisioning/dashboards/`. Edit in the Grafana
+UI, export the JSON (Share → Export → Save to file), and commit it back. The `cqrs_commands_total` /
+`cqrs_queries_total` / `cqrs_duration_seconds` series are exported but not yet dashboarded — a good
+starting point for a per-use-case RED panel.
+
+## 8. Verify a change end-to-end
+
+Drive the real signal, don't just unit-test. After enabling the stack:
+
+```bash
+# metrics: route is a template, no PII labels
+curl -s localhost:3000/metrics | grep -E 'http_requests_total|route='
+# trace pipeline: traces reach Jaeger
+curl -s 'http://localhost:16686/api/traces?service=nestjs-fastify-api&limit=1' | grep traceID
+# leader lease (single-writer metrics) — redis-queue listens on 6380
+docker exec <project>-redis-queue-1 redis-cli -p 6380 GET bull:metrics:collector-leader
+# alert rules parse and evaluate
+curl -s http://localhost:9090/api/v1/rules | grep -o '"health":"[a-z]*"'
+```
+
+## 9. Production notes
+
+- **Sampling**: keep a low head ratio (`OTEL_TRACES_SAMPLER_RATIO`, e.g. `0.05`) and let the
+  Collector's `tail_sampling` keep 100% of error/slow traces (`docker/otel-collector/config.yaml`).
+  ParentBased is already wired, so child spans honor the parent's decision.
+- **Edge trust**: keep `OTEL_TRUST_INBOUND_TRACEPARENT=false` on a public edge so clients can't
+  inject or collide trace ids; set `true` only behind a trusted mesh/gateway.
+- **Retention & PII**: `userId`/IP appear in logs (personal data). Set retention at the backend
+  (logs 14–30d, traces ~7d + error traces longer, metrics ~15mo) — the app does not enforce it.
+- **Health probes**: point Kubernetes readiness/liveness at `/health/ready` and `/health/live`
+  **only**. `/health/dependencies` is a deep check for dashboards/alerting — never a probe, or a
+  shared-dependency blip flips every replica to NotReady at once.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,18 +2,28 @@
 
 How the API emits logs, traces and metrics, and how they correlate. Three signals, one id.
 
+> **Operational how-to** (enable the local stack, explore the UIs, add a metric/span/log
+> field/alert/dashboard, verify end-to-end) lives in [`observability-guide.md`](./observability-guide.md).
+> This file covers the design and rationale.
+
 ## The correlation id
 
 Every request is identified by one id shared across all three signals and the HTTP boundary:
 
 - **`X-Request-Id`** (response header + `requestId` in error bodies) defaults to the active
   **OpenTelemetry trace id** (W3C 128-bit hex). So the value in a client's response header is
-  the same id you search for in the trace backend and in the logs — no mapping table.
-- Precedence: client-supplied `X-Request-Id` → active `trace_id` → random 128-bit hex
-  (`generateCorrelationId()`, when no valid trace id is available). Set in `CorrelationIdMiddleware`
-  and mirrored by `fastify-error-handler` for Fastify-level failures.
-- **`X-Correlation-Id`** spans a client journey (multiple requests). It defaults to the
-  request id when the client omits it; a client that wants to tie several calls together sends
+  the same id you search for in the trace backend and in the logs — no mapping table. It is a
+  **search key only** — it never controls the trace context (that is owned by OTel; see tracing).
+- Precedence: **validated** client-supplied `X-Request-Id` → active `trace_id` → random 128-bit
+  hex (`generateCorrelationId()`, when no valid trace id is available). Set in
+  `CorrelationIdMiddleware` / the CLS setup and mirrored by `fastify-error-handler` for
+  Fastify-level failures.
+- **Client ids are sanitized at the boundary** (`sanitizeClientId`, `request-id.ts`): only
+  `[A-Za-z0-9._~-]{1,128}` is accepted. Anything with a newline/control char (log-injection
+  vector) or over the length cap (log/trace-storage bloat) is discarded and a fresh id is minted —
+  the raw client value never reaches a log line or span attribute.
+- **`X-Correlation-Id`** spans a client journey (multiple requests). Same sanitization; defaults to
+  the request id when the client omits it. A client that wants to tie several calls together sends
   its own stable value.
 
 > UUIDv7 (`generateId()`) is used for **database primary keys** — its time ordering keeps
@@ -54,8 +64,17 @@ Every request is identified by one id shared across all three signals and the HT
 patches `http`/`pg`/`ioredis` before they load. Enabled by `OTEL_ENABLED=true`.
 
 - **Resource**: `service.name`, `service.namespace`, `service.version`, `deployment.environment`.
-- **Exporters**: OTLP/HTTP for traces and metrics (`OTEL_EXPORTER_OTLP_ENDPOINT`).
-- **Sampling**: `TraceIdRatioBasedSampler` via `OTEL_TRACES_SAMPLER_RATIO` (default `1`).
+- **Exporters**: OTLP/HTTP for traces (`OTEL_EXPORTER_OTLP_ENDPOINT`). OTLP **metric** push is
+  opt-in via `OTEL_METRICS_EXPORT_ENABLED` (see Metrics — off in the API, on in worker/scheduler).
+- **Sampling**: `ParentBasedSampler(root = TraceIdRatioBasedSampler(OTEL_TRACES_SAMPLER_RATIO))`.
+  ParentBased is deliberate: the ratio only decides for a **new** root trace; a child span always
+  **honors the parent's sampled flag**, so cross-service traces don't come back with holes (a bare
+  ratio sampler lets a downstream service drop spans its parent kept). Default ratio `1`.
+- **Inbound trace context is not trusted by default** (`OTEL_TRUST_INBOUND_TRACEPARENT=false`).
+  On a public edge the propagator still **injects** our context downstream but **ignores** any
+  inbound `traceparent`/`baggage`, so external callers can't inject or collide trace ids, force the
+  sampling decision, or smuggle baggage. Set `true` only behind a trusted mesh/gateway that owns the
+  root span; then the ParentBased sampler honors the upstream decision as intended.
 - **Auto-instrumentation**: HTTP, Postgres, ioredis, GraphQL, socket.io, pino (log injection).
   `fs` is disabled.
 - **CQRS use-case spans** — auto-instrumentation stops at the framework boundary (HTTP/DB/redis),
@@ -66,31 +85,103 @@ patches `http`/`pg`/`ioredis` before they load. Enabled by `OTEL_ENABLED=true`.
   when tracing is off (the OTel API's default no-op tracer).
 - Graceful shutdown on `SIGTERM`/`SIGINT`.
 
+### Sampling strategy per environment
+
+Head sampling (the ratio above) decides **before** a request is known to be slow or failing, so a
+low ratio silently drops the traces you most want. Keep a low head ratio in prod and recover the
+interesting traces with **tail sampling in the OTel Collector**, which decides after seeing the whole
+trace:
+
+| Env         | `OTEL_TRACES_SAMPLER_RATIO` | Collector tail sampling        |
+| ----------- | --------------------------- | ------------------------------ |
+| development | `1` (all)                   | none                           |
+| staging     | `0.25`–`0.5`                | optional                       |
+| production  | `0.01`–`0.1` (head)         | keep 100% of error/slow traces |
+
+```yaml
+# otel-collector: keep every error + slow trace, sample the rest
+processors:
+  tail_sampling:
+    policies:
+      - { name: errors, type: status_code, status_code: { status_codes: [ERROR] } }
+      - { name: slow, type: latency, latency: { threshold_ms: 1000 } }
+      - { name: baseline, type: probabilistic, probabilistic: { sampling_percentage: 5 } }
+```
+
 Local stack: `docker compose -f docker/compose.yml -f docker/compose.dev.yml -f docker/compose.observability.yml up`
 brings up OTel Collector + Jaeger + Prometheus + Grafana (all bound to `127.0.0.1`).
 
 ## Metrics (Prometheus)
 
-`prom-client` registry exposed at `/metrics`, guarded by `MetricsIpAllowGuard`
-(`METRICS_ALLOW_CIDRS`, reads `socket.remoteAddress`, fails closed). Key series:
+**Source of truth is the `prom-client` pull endpoint** (`/metrics`), guarded by `MetricsIpAllowGuard`
+(`METRICS_ALLOW_CIDRS`, reads `socket.remoteAddress`, fails closed) — the standard Prometheus scrape
+model for Kubernetes. The OTLP metric push in `start-tracing` is **off in the API**
+(`OTEL_METRICS_EXPORT_ENABLED=false`) so the same series aren't counted by two pipelines; enable it
+only for worker/scheduler, which have no `/metrics` endpoint. Key series:
 
-- `http_requests_total`, `http_request_duration_seconds` (labels: method, route, status_code)
+- `http_requests_total`, `http_request_duration_seconds` (labels: method, **route template**,
+  status_code — the route is `routeOptions.url` (`/api/v1/users/:id`), never the raw path, so
+  label cardinality stays bounded)
 - `bullmq_jobs_total`, `bullmq_job_duration_seconds`, `bullmq_queue_depth`
 - `outbox_lag_seconds` — age of the oldest unprocessed outbox event
 - `cqrs_commands_total`, `cqrs_queries_total` (labels: name, status), `cqrs_duration_seconds` —
   per-use-case RED metrics recorded by the traced bus above (present only when `ENABLE_METRICS=true`)
 
+**Global-state metrics are single-writer.** `bullmq_*`, `bullmq_queue_depth`, and `outbox_lag_seconds`
+describe one shared truth in Redis/Postgres that every API replica observes (the QueueEvents stream is
+a broadcast). Recording them on every replica would inflate counters by the replica count and set each
+gauge N times to the same value. `MetricsLeaderService` (Redis lease, `SET NX PX` + compare-and-extend)
+elects one collector leader; only the leader records these series. Consequence for PromQL: because
+there is a single writer, aggregate normally — `sum by (queue, status) (rate(bullmq_jobs_total[5m]))`
+for counters, `max by (queue, state) (bullmq_queue_depth)` for the depth gauge. Per-replica series
+(`http_*`, `cqrs_*`) are genuinely local — `sum` across replicas for those.
+
+> **Never label a metric with `requestId`/`userId`/raw path** — unbounded cardinality melts
+> Prometheus. Those identifiers belong in logs and traces, not metric labels.
+
 Alert rules ship in `docker/prometheus/alert_rules.yml`; dashboards in
-`docker/grafana/provisioning/dashboards/`. Because every API replica observes the same
-BullMQ QueueEvents stream, aggregate counter/gauge series with `max by (...)`, not `sum`.
+`docker/grafana/provisioning/dashboards/`.
 
 ## Health
 
 Split for Kubernetes (`apps/api/.../health.controller.ts`):
 
-- `GET /api/v1/health/live` — process only, no dependencies.
-- `GET /api/v1/health/ready` — DB + Redis (cache & queue) + BullMQ + PgBouncer + replication lag.
-- `GET /api/v1/health` — full dependency check.
+- `GET /api/v1/health/live` — **liveness probe**. Process only, no dependencies. A failure here
+  restarts the pod, so it must never depend on anything external.
+- `GET /api/v1/health/ready` — **readiness probe**. Only what this pod needs to serve core traffic:
+  DB primary + Redis (cache & queue). Deliberately **excludes** replica lag, queue depth, and
+  pgbouncer.
+- `GET /api/v1/health/dependencies` — **deep check for dashboards/alerting, NOT a probe**: BullMQ +
+  pgbouncer + replication lag.
+- `GET /api/v1/health` — full dependency check (DB + memory + Redis cache & queue).
+
+> **Why the deep dependencies are off the readiness probe.** Every replica shares the same
+> Postgres/Redis, so a shared-dependency blip (a 2 s replica-lag spike, a queue Redis reconnect)
+> would flip **all** pods to NotReady at the same instant — Kubernetes then pulls every pod from the
+> Service and you get a correlated, cluster-wide outage even though the app is perfectly able to
+> serve. Readiness must answer only "can _this_ pod serve its core traffic?"; "is the wider system
+> healthy?" is an alerting question, answered by `/health/dependencies`. Give the readiness probe a
+> `failureThreshold` (e.g. 3) so a single slow check doesn't flap the pod out of rotation.
+
+## Privacy & retention
+
+Logs and traces carry personal data and cost money to store — both need an explicit policy, not
+unbounded accumulation.
+
+- **PII in logs**: `userId` (opaque UUID) and `req.remoteAddress` (an IP — personal data under GDPR)
+  appear on request-scoped lines. Keep `userId` an **opaque id only** — never log email/username at
+  top level (explicit-DTO mapping already keeps them out of response bodies; keep them out of logs
+  too). Both fall in scope for DSAR/erasure, so they must live under a bounded retention window.
+- **Retention** (set at the backend, the app does not enforce it): logs 14–30 days; traces ~7 days
+  with error/slow traces kept longer via the Collector tail-sampling policy above; metrics ~15
+  months downsampled. Without a retention policy, log/trace storage grows without bound and a breach
+  exposes an ever-larger history.
+- **Log volume**: probe noise is already dropped (`autoLogging.ignore`). At high RPS, raise the
+  prod `LOG_LEVEL` (e.g. `warn`) or sample access logs — every-request `info` logging is the usual
+  cause of log explosion.
+- **Redaction is a deny-list** (`SENSITIVE_REDACT_PATHS`): it only censors known paths, so a newly
+  added sensitive field is logged in clear until its path is added. Audit the list when new
+  request/response shapes carry secrets.
 
 ## Resilience
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -285,9 +285,11 @@ docker compose config | grep -A5 'migration:'
 # Should show DATABASE_DIRECT_URL pointing at postgres:5432, not pgbouncer:6432
 ```
 
-### `/health/ready` returns 503 — pgbouncer probe failing
+### `/health/dependencies` returns 503 — pgbouncer probe failing
 
-Symptom: `GET /api/v1/health/ready` returns 503 with `pgbouncer: { status: 'down' }`.
+Symptom: `GET /api/v1/health/dependencies` returns 503 with `pgbouncer: { status: 'down' }`.
+(The pgbouncer check lives on `/health/dependencies`, not the readiness probe — see
+`docs/observability.md` for why deep dependencies are kept off `/health/ready`.)
 
 Cause: pgbouncer is unreachable on `DATABASE_URL`. The `PgBouncerHealthIndicator`
 opens an ephemeral pg Client to the pooler endpoint and reports unhealthy on any

--- a/libs/api-client/src/generated/api.schemas.ts
+++ b/libs/api-client/src/generated/api.schemas.ts
@@ -485,6 +485,78 @@ export type HealthReadiness503 = {
   details?: HealthReadiness503Details;
 };
 
+/**
+ * @nullable
+ */
+export type HealthDependencies200Info = {
+  [key: string]: {
+    status: string;
+    [key: string]: unknown;
+  };
+} | null;
+
+/**
+ * @nullable
+ */
+export type HealthDependencies200Error = {
+  [key: string]: {
+    status: string;
+    [key: string]: unknown;
+  };
+} | null;
+
+export type HealthDependencies200Details = {
+  [key: string]: {
+    status: string;
+    [key: string]: unknown;
+  };
+};
+
+export type HealthDependencies200 = {
+  status?: string;
+  /** @nullable */
+  info?: HealthDependencies200Info;
+  /** @nullable */
+  error?: HealthDependencies200Error;
+  details?: HealthDependencies200Details;
+};
+
+/**
+ * @nullable
+ */
+export type HealthDependencies503Info = {
+  [key: string]: {
+    status: string;
+    [key: string]: unknown;
+  };
+} | null;
+
+/**
+ * @nullable
+ */
+export type HealthDependencies503Error = {
+  [key: string]: {
+    status: string;
+    [key: string]: unknown;
+  };
+} | null;
+
+export type HealthDependencies503Details = {
+  [key: string]: {
+    status: string;
+    [key: string]: unknown;
+  };
+};
+
+export type HealthDependencies503 = {
+  status?: string;
+  /** @nullable */
+  info?: HealthDependencies503Info;
+  /** @nullable */
+  error?: HealthDependencies503Error;
+  details?: HealthDependencies503Details;
+};
+
 export type AdminUsersListParams = {
   /**
    * Items per page (1–100).

--- a/libs/api-client/src/generated/health.ts
+++ b/libs/api-client/src/generated/health.ts
@@ -18,7 +18,12 @@
  * Every response carries an `X-Request-Id` header (also mirrored as `requestId` in error bodies). Quote it when filing support tickets.
  * OpenAPI spec version: 1.0.0
  */
-import type { HealthCheck200, HealthReadiness200, LivenessResponseDto } from './api.schemas';
+import type {
+  HealthCheck200,
+  HealthDependencies200,
+  HealthReadiness200,
+  LivenessResponseDto,
+} from './api.schemas';
 
 import { customAxiosInstance } from '../lib/axios-instance';
 
@@ -31,11 +36,21 @@ export const getHealth = () => {
     return customAxiosInstance<HealthCheck200>({ url: `/api/v1/health`, method: 'GET' });
   };
   /**
-   * Use as the Kubernetes readiness probe. Returns 503 when any critical dependency is unreachable so the orchestrator removes the pod from the load balancer.
-   * @summary Readiness probe (DB + Redis cache + Redis queue + BullMQ).
+   * Use as the Kubernetes readiness probe. Checks ONLY what this pod needs to serve its core traffic. Shared-but-non-blocking dependencies (replica lag, queue depth, pgbouncer) are deliberately excluded: because every replica shares the same Postgres/Redis, wiring them here would flip all pods to NotReady at once on a single dependency blip — a correlated, cluster-wide outage even though the app is healthy. Those live on /health/dependencies for dashboards/alerting instead. Returns 503 so the orchestrator removes the pod from the load balancer when a core dependency is unreachable.
+   * @summary Readiness probe (DB primary + Redis cache + Redis queue).
    */
   const healthReadiness = () => {
     return customAxiosInstance<HealthReadiness200>({ url: `/api/v1/health/ready`, method: 'GET' });
+  };
+  /**
+   * Deep health of shared infrastructure — meant for dashboards and alerting, NOT for the Kubernetes readiness/liveness probes. Wiring these into a probe would remove every replica from the load balancer at once when a shared dependency degrades. Returns 503 when a deep check fails so alert rules can fire.
+   * @summary Deep dependency check (BullMQ + pgbouncer + replica lag).
+   */
+  const healthDependencies = () => {
+    return customAxiosInstance<HealthDependencies200>({
+      url: `/api/v1/health/dependencies`,
+      method: 'GET',
+    });
   };
   /**
    * Use as the Kubernetes liveness probe. Does not check dependencies.
@@ -44,13 +59,16 @@ export const getHealth = () => {
   const healthLiveness = () => {
     return customAxiosInstance<LivenessResponseDto>({ url: `/api/v1/health/live`, method: 'GET' });
   };
-  return { healthCheck, healthReadiness, healthLiveness };
+  return { healthCheck, healthReadiness, healthDependencies, healthLiveness };
 };
 export type HealthCheckResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getHealth>['healthCheck']>>
 >;
 export type HealthReadinessResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getHealth>['healthReadiness']>>
+>;
+export type HealthDependenciesResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getHealth>['healthDependencies']>>
 >;
 export type HealthLivenessResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getHealth>['healthLiveness']>>

--- a/libs/infra/observability/src/lib/start-tracing.ts
+++ b/libs/infra/observability/src/lib/start-tracing.ts
@@ -1,9 +1,20 @@
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import {
+  diag,
+  DiagConsoleLogger,
+  DiagLogLevel,
+  type Context,
+  type TextMapPropagator,
+} from '@opentelemetry/api';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
-import { TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-base';
+import { ParentBasedSampler, TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-base';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
   ATTR_SERVICE_NAME,
@@ -39,6 +50,18 @@ function bool(value: string | undefined): boolean {
   return value === 'true';
 }
 
+// Public-edge default: keep injecting our trace context into downstream calls, but IGNORE any
+// inbound traceparent/baggage so external callers cannot inject or collide trace ids, force the
+// sampling decision, or smuggle baggage into our pipeline. Flip OTEL_TRUST_INBOUND_TRACEPARENT=true
+// only when the service sits behind a trusted mesh/gateway that owns the root span.
+function injectOnly(delegate: TextMapPropagator): TextMapPropagator {
+  return {
+    inject: (ctx, carrier, setter) => delegate.inject(ctx, carrier, setter),
+    extract: (ctx: Context) => ctx,
+    fields: () => delegate.fields(),
+  };
+}
+
 // Call before any other import so the SDK patches native modules (http, pg, etc.) first.
 export function startTracing(options: StartTracingOptions = {}): NodeSDK | null {
   if (!bool(process.env['OTEL_ENABLED'])) return null;
@@ -47,10 +70,33 @@ export function startTracing(options: StartTracingOptions = {}): NodeSDK | null 
     diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
   }
 
-  const endpoint = process.env['OTEL_EXPORTER_OTLP_ENDPOINT'] ?? 'http://localhost:4318';
+  const endpoint = (process.env['OTEL_EXPORTER_OTLP_ENDPOINT'] ?? 'http://localhost:4318').replace(
+    /\/$/,
+    '',
+  );
   const headers = parseHeaders(process.env['OTEL_EXPORTER_OTLP_HEADERS'] ?? '');
   const ratio = Number.parseFloat(process.env['OTEL_TRACES_SAMPLER_RATIO'] ?? '1');
-  const sampler = new TraceIdRatioBasedSampler(Number.isFinite(ratio) ? ratio : 1);
+
+  // ParentBased, not a bare ratio sampler: the root sampler only decides for a NEW trace; a child
+  // span MUST honor the parent's sampled flag, otherwise cross-service traces come back with holes
+  // (a downstream service dropping spans its parent kept). Client-forced sampling is still blocked
+  // because injectOnly() strips the inbound parent on the public edge — see textMapPropagator below.
+  const sampler = new ParentBasedSampler({
+    root: new TraceIdRatioBasedSampler(Number.isFinite(ratio) ? ratio : 1),
+  });
+
+  const basePropagator = new CompositePropagator({
+    propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+  });
+  const textMapPropagator = bool(process.env['OTEL_TRUST_INBOUND_TRACEPARENT'])
+    ? basePropagator
+    : injectOnly(basePropagator);
+
+  // Prometheus (prom-client pull, /metrics) is the metrics source of truth for the API. This OTLP
+  // push reader is opt-in — enable it only where there is no prom-client scrape endpoint (worker,
+  // scheduler) so those processes still export runtime metrics. Leaving it on in the API would
+  // double-count the same series across two pipelines.
+  const metricsExportEnabled = bool(process.env['OTEL_METRICS_EXPORT_ENABLED']);
 
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]:
@@ -63,17 +109,20 @@ export function startTracing(options: StartTracingOptions = {}): NodeSDK | null 
   const sdk = new NodeSDK({
     resource,
     sampler,
+    textMapPropagator,
     traceExporter: new OTLPTraceExporter({
-      url: `${endpoint.replace(/\/$/, '')}/v1/traces`,
+      url: `${endpoint}/v1/traces`,
       headers,
     }),
-    metricReader: new PeriodicExportingMetricReader({
-      exporter: new OTLPMetricExporter({
-        url: `${endpoint.replace(/\/$/, '')}/v1/metrics`,
-        headers,
-      }),
-      exportIntervalMillis: 60_000,
-    }),
+    metricReader: metricsExportEnabled
+      ? new PeriodicExportingMetricReader({
+          exporter: new OTLPMetricExporter({
+            url: `${endpoint}/v1/metrics`,
+            headers,
+          }),
+          exportIntervalMillis: 60_000,
+        })
+      : undefined,
     instrumentations: [
       getNodeAutoInstrumentations({
         '@opentelemetry/instrumentation-fs': { enabled: false },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@nestjs/websockets": "^11.1.28",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
+    "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
     "@opentelemetry/resources": "^2.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.78.0
         version: 0.78.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+      '@opentelemetry/core':
+        specifier: '>=2.8.0'
+        version: 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http':
         specifier: ^0.220.0
         version: 0.220.0(@opentelemetry/api@1.9.1)

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -85,6 +85,8 @@ BUILD_FLAGS=()
 if [[ "${NO_CACHE:-0}" = "1" ]]; then
   BUILD_FLAGS+=(--no-cache)
 fi
+# Expand BUILD_FLAGS via `"${arr[@]+"${arr[@]}"}"` below — expanding an empty array
+# under `set -u` is an "unbound variable" error on bash < 4.4 (macOS ships 3.2).
 
 # Skip BuildKit attestations (provenance + sbom) for dev images. Each one
 # adds a parallel manifest that has to be exported and unpacked, doubling
@@ -98,12 +100,12 @@ BUILD_START=$(date +%s)
 # Override with BUILD_PARALLEL=1 if the host has enough headroom.
 if [[ "${BUILD_PARALLEL:-0}" = "1" ]]; then
   # shellcheck disable=SC2086
-  docker compose $COMPOSE_BASE build "${BUILD_FLAGS[@]}" "${SERVICES[@]}"
+  docker compose $COMPOSE_BASE build "${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"}" "${SERVICES[@]}"
 else
   for svc in "${SERVICES[@]}"; do
     sec::log "  → $svc"
     # shellcheck disable=SC2086
-    docker compose $COMPOSE_BASE build "${BUILD_FLAGS[@]}" "$svc"
+    docker compose $COMPOSE_BASE build "${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"}" "$svc"
   done
 fi
 BUILD_END=$(date +%s)
@@ -125,7 +127,10 @@ export COMPOSE_PROJECT_NAME
 docker compose $COMPOSE_BASE rm -sf "${SERVICES[@]}" 2>/dev/null || true
 for svc in "${SERVICES[@]}"; do
   # Match all replicas, not just -1, in case API_REPLICAS / WORKER_REPLICAS > 1.
-  stale=$(docker ps -aq --filter "name=^${COMPOSE_PROJECT_NAME}-${svc}-[0-9]\+$" 2>/dev/null || true)
+  # Docker's --filter name uses Go RE2, where `+` is the quantifier — GNU BRE's
+  # `\+` would match a literal '+' here and silently never match a real container.
+  stale=$(docker ps -aq --filter "name=^${COMPOSE_PROJECT_NAME}-${svc}-[0-9]+$" 2>/dev/null || true)
+  # shellcheck disable=SC2086  # intentional word-split: $stale is a space-separated id list
   [[ -n "$stale" ]] && docker rm -f $stale 2>/dev/null || true
 done
 

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -75,7 +75,10 @@ build() {
   [[ -n "$target" ]] && target_args=(--target "$target")
   echo ""
   echo "--- ${app} ---"
-  docker buildx build -f "$dockerfile" "${target_args[@]}" \
+  # `"${arr[@]+"${arr[@]}"}"` — expanding an empty array under `set -u` is an
+  # "unbound variable" error on bash < 4.4 (macOS ships 3.2). This idiom is a
+  # no-op on modern bash and safe everywhere.
+  docker buildx build -f "$dockerfile" "${target_args[@]+"${target_args[@]}"}" \
     --load -t "${PREFIX}/${app}:${IMAGE_TAG}" .
 }
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -51,8 +51,12 @@ version_gte() {
   local actual="$1" required="$2"
   # Strip leading 'v' if present.
   actual="${actual#v}"; required="${required#v}"
-  # Use sort -V (version sort) to compare.
-  [[ "$(printf '%s\n%s' "$required" "$actual" | sort -V | head -1)" == "$required" ]]
+  # Numeric field sort on MAJ.MIN.PATCH — portable across BSD (macOS) and GNU.
+  # `sort -V` is GNU-only and aborts on stock macOS `sort`, which would crash every
+  # Node/pnpm version check on a Mac without coreutils installed.
+  local lowest
+  lowest="$(printf '%s\n%s\n' "$required" "$actual" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)"
+  [[ "$lowest" == "$required" ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/security/scan-sast.sh
+++ b/scripts/security/scan-sast.sh
@@ -58,7 +58,7 @@ sec::docker_run --rm \
   -w /src \
   "${SEMGREP_IMAGE}" semgrep scan \
   "${RULES[@]}" \
-  "${GATE[@]}" \
+  "${GATE[@]+"${GATE[@]}"}" \
   --metrics=off \
   --exclude=node_modules \
   --exclude=dist \

--- a/scripts/security/sign-images.sh
+++ b/scripts/security/sign-images.sh
@@ -40,8 +40,11 @@ PREFIX="${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_NAMESPACE:?IMAGE_NAMESPACE required}"
 TAG="${IMAGE_TAG:-latest}"
 ACTION="${1:-verify}"
 shift || true
-APPS=("${@:-api worker scheduler migration}")
-read -r -a APPS <<< "${APPS[*]}"
+if [[ $# -gt 0 ]]; then
+  APPS=("$@")
+else
+  APPS=(api worker scheduler migration)
+fi
 
 cosign() { sec::docker_run --rm -e COSIGN_EXPERIMENTAL=1 "${COSIGN_IMAGE}" "$@"; }
 

--- a/scripts/smoke-expanded.sh
+++ b/scripts/smoke-expanded.sh
@@ -7,6 +7,12 @@ BASE="${BASE_URL:-http://localhost:3000}"
 PASS_COUNT=0
 FAIL_COUNT=0
 
+# Per-run temp dir (mktemp -d is portable across BSD/macOS + GNU). Hardcoded
+# /tmp/*.json paths collide between concurrent runs and multi-user hosts and
+# never get cleaned up; a trap removes this on every exit path.
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
 check() {
   local name="$1" expected="$2" actual="$3"
   if [ "$actual" = "$expected" ]; then
@@ -59,7 +65,7 @@ CP=$(curl -s -o /dev/null --max-time 10 -w '%{http_code}' -X POST "$BASE/api/aut
   -d "{\"currentPassword\":\"$PASS\",\"newPassword\":\"$NEW_PASS\"}")
 check "POST /api/auth/change-password" "200" "$CP"
 
-LS=$(curl -s -o /tmp/ls.json --max-time 10 -w '%{http_code}' -H "Cookie: $COOKIE" "$BASE/api/auth/list-sessions")
+LS=$(curl -s -o "$TMP_DIR/ls.json" --max-time 10 -w '%{http_code}' -H "Cookie: $COOKIE" "$BASE/api/auth/list-sessions")
 check "GET /api/auth/list-sessions" "200" "$LS"
 
 UU=$(curl -s -o /dev/null --max-time 10 -w '%{http_code}' -X POST "$BASE/api/auth/update-user" \
@@ -100,12 +106,12 @@ RESI=$(curl -s -i --max-time 10 -X POST "$BASE/api/auth/sign-in/email" \
   -d "{\"email\":\"$EMAIL\",\"password\":\"$NEW_PASS\"}")
 COOKIE=$(echo "$RESI" | grep -i '^set-cookie:' | sed -E 's/^[Ss]et-[Cc]ookie: ([^;]+);.*/\1/' | paste -sd '; ' -)
 
-GQL_ME=$(curl -s -o /tmp/gql-me.json --max-time 10 -w '%{http_code}' -X POST "$BASE/graphql" \
+GQL_ME=$(curl -s -o "$TMP_DIR/gql-me.json" --max-time 10 -w '%{http_code}' -X POST "$BASE/graphql" \
   -H "Content-Type: application/json" -H "Cookie: $COOKIE" \
   -d '{"query":"query { me { id email name role status } }"}')
 check "POST /graphql query me (cookie)" "200" "$GQL_ME"
 
-GQL_USERS=$(curl -s -o /tmp/gql-users.json --max-time 10 -w '%{http_code}' -X POST "$BASE/graphql" \
+GQL_USERS=$(curl -s -o "$TMP_DIR/gql-users.json" --max-time 10 -w '%{http_code}' -X POST "$BASE/graphql" \
   -H "Content-Type: application/json" -H "Cookie: $COOKIE" \
   -d '{"query":"query { users(page:1,pageSize:5) { data { id email } meta { page pageSize total } } }"}')
 check "POST /graphql query users (USER cookie)" "200" "$GQL_USERS"
@@ -114,7 +120,7 @@ echo "=== BATCH D: Socket.io WebSocket ==="
 # Gateway is mounted at `/ws` (notification.gateway.ts:50), not the default
 # `/socket.io/`. The engine.io polling handshake therefore lives at /ws/.
 
-WS_OK=$(curl -s -o /tmp/ws-ok.txt --max-time 10 -w '%{http_code}' \
+WS_OK=$(curl -s -o "$TMP_DIR/ws-ok.txt" --max-time 10 -w '%{http_code}' \
   -H "Cookie: $COOKIE" "$BASE/ws/?EIO=4&transport=polling")
 check "GET /ws/ handshake (cookie)" "200" "$WS_OK"
 

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -71,7 +71,7 @@ if [[ -f .env ]]; then
   ENV_FILE_ARGS=(--env-file .env)
 fi
 
-docker compose "${ENV_FILE_ARGS[@]}" \
+docker compose "${ENV_FILE_ARGS[@]+"${ENV_FILE_ARGS[@]}"}" \
   -f docker/compose.yml \
   -f "${OVERLAY}" \
   down "${DOWN_FLAGS[@]}"


### PR DESCRIPTION
## Summary

Hardens the observability tier to production/large-system standards, fixes several real bugs found along the way, and adds an operational how-to guide. Verified end-to-end against the real stack (OTel Collector + Jaeger + Prometheus + Grafana) via browser automation.

## Tracing (`libs/infra/observability/start-tracing.ts`)
- **ParentBased sampler** wrapping `TraceIdRatioBased` — child spans honor the parent decision, so cross-service traces stop coming back with holes.
- **Inbound `traceparent` not trusted by default** (`OTEL_TRUST_INBOUND_TRACEPARENT=false`) — a public edge can't inject/collide trace ids or force sampling. Set `true` only behind a trusted mesh/gateway.
- **OTLP metric push gated** (`OTEL_METRICS_EXPORT_ENABLED`, off in the API) — prom-client `/metrics` is the single source of truth; no double-counting.

## Metrics ownership (`apps/api/src/common/metrics/*`)
- **Single-writer via Redis lease** (`MetricsLeaderService`): global-state series (queue depth, outbox lag, BullMQ `QueueEvents`) are recorded only by the collector-leader replica, so `N` replicas stop inflating counters/gauges. Per-replica series (`http_*`, `cqrs_*`) stay ungated.
- **Per-app `OTEL_SERVICE_NAME`** so worker/scheduler stop mislabeling themselves as the API.

## Health probes (`apps/api/src/common/health/health.controller.ts`)
- Split lean **`/health/ready`** (core serving deps only) from a new deep **`/health/dependencies`** (bullmq, pgbouncer, replica lag). Wiring shared deps into readiness would flip every replica to NotReady on a single blip → correlated cluster-wide outage.

## Logging & config
- **Sanitize client `X-Request-Id`/`X-Correlation-Id`** (blocks log injection via newlines / caps length) and drop duplicated `requestId`/`correlationId` log props.
- **SMTP TLS required in prod only when `MAIL_USER` is set** — the rule protects credentials; a no-auth relay leaks nothing in plaintext (also unblocks the local prod-parity smoke against Mailpit).

## Local stack & alerting
- OTel Collector: add **`tail_sampling`** (keep 100% of error/slow traces + 5% baseline) and **`memory_limiter`**.
- Prometheus: add **p95 latency SLO alert** (`HighRequestLatencyP95`).

## Scripts (macOS/BSD compatibility)
- Guard empty-array expansion under `set -u` (crashes on the bash 3.2 macOS ships), replace GNU-only `sort -V`, fix a Docker `--filter` RE2 regex, and route smoke-test temp files through `mktemp` + `trap`.

## Docs
- New **`docs/observability-guide.md`** — enable, explore, and extend each signal (add a metric/span/log field/alert/dashboard) + an end-to-end verify recipe. Synced observability/environment/architecture/deployment/troubleshooting docs and the new env vars.

## Verification
- typecheck / lint / build (webpack prod, all 4 apps) / unit tests — green.
- Browser e2e against the live stack: Jaeger (20 traces, HTTP + pg spans, multi-service), Prometheus (6 alert rules healthy, target up, p95 query), Grafana (datasource OK, dashboards render real data). Real BullMQ loop: worker processes jobs → Mailpit receives mail → `bullmq_jobs_total{completed}` recorded by the leader.
- OTel Collector config validated (`otelcol validate`) and alert rules validated (`promtool check rules`, 6 rules).

> Note: Testcontainers-backed integration/e2e suites were not runnable on the dev host (pre-existing `P1001` DB-reachability quirk, unrelated to this diff); they run in CI with proper Docker networking.