### PR TITLE
chore(nx): finish vitest migration to inferred plugin + fix module generator

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -101,7 +101,11 @@ jobs:
       - uses: nrwl/nx-set-shas@v5
 
       - name: Integration tests
-        run: pnpm nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --testPathPattern=integration --parallel=1
+        # `integration` is a vitest positional filename filter (substring match) — the
+        # inferred @nx/vitest target runs vitest directly, which has no Jest-style
+        # `--testPathPattern`. Only `*.integration.ts` files match; unit-only projects
+        # match nothing and pass via `passWithNoTests`.
+        run: pnpm nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --parallel=1 -- integration
 
       - name: E2E tests
         run: pnpm nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --parallel=1

--- a/apps/api/e2e/global-setup.ts
+++ b/apps/api/e2e/global-setup.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { deployTestMigrations } from '@nestjs-fastify-nx/testing';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import { RedisContainer } from '@testcontainers/redis';
 import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
@@ -52,11 +52,7 @@ export async function setup(): Promise<void> {
   // every subsequent spec will time out against a broken schema — exit loud
   // immediately rather than letting Vitest proceed with phantom timeouts.
   try {
-    execSync('pnpm prisma migrate deploy', {
-      cwd: process.cwd(),
-      env: { ...process.env, DATABASE_URL: dbUrl },
-      stdio: 'inherit',
-    });
+    deployTestMigrations(dbUrl);
   } catch (err) {
     console.error('prisma migrate deploy failed — aborting e2e run', err);
     await stopContainers();

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -80,18 +80,10 @@
         }
       }
     },
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/apps/api"
-      }
-    },
     "e2e": {
-      "executor": "@nx/vitest:test",
+      "executor": "nx:run-commands",
       "options": {
-        "config": "apps/api/vite.e2e.config.ts",
-        "reportsDirectory": "coverage/apps/api-e2e"
+        "command": "vitest --run --config apps/api/vite.e2e.config.ts"
       }
     }
   }

--- a/apps/api/vite.e2e.config.ts
+++ b/apps/api/vite.e2e.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  // Test-file resolution (include, globalSetup) is anchored to this dir so it works
+  // regardless of the shell cwd. The app itself resolves i18n/asset paths from
+  // process.cwd(), which must stay the workspace root — the e2e target runs from
+  // there (no `cwd` override), matching how the app runs under nx serve / prod.
+  root: __dirname,
   plugins: [tsconfigPaths()],
   test: {
     globals: true,

--- a/apps/scheduler/project.json
+++ b/apps/scheduler/project.json
@@ -60,13 +60,6 @@
           "buildTarget": "scheduler:build:production"
         }
       }
-    },
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/apps/scheduler"
-      }
     }
   }
 }

--- a/apps/worker/project.json
+++ b/apps/worker/project.json
@@ -60,13 +60,6 @@
           "buildTarget": "worker:build:production"
         }
       }
-    },
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/apps/worker"
-      }
     }
   }
 }

--- a/docs/creating-a-module.md
+++ b/docs/creating-a-module.md
@@ -93,6 +93,29 @@ The `@nx/enforce-module-boundaries` rule enforces this: `scope:modules` libs can
 other, but `scope:composition` can import from `scope:modules`. If you find yourself needing
 cross-module imports inside a `scope:modules` lib, extract a composition lib instead.
 
+## Targets are inferred — no config to edit
+
+The generator writes **no explicit targets** into `project.json`. `build`/`typecheck` (from
+`tsconfig.lib.json`), `lint` (from the workspace ESLint config), and `test` (from
+`vitest.config.mts`) are all inferred by the workspace Nx plugins. A freshly generated module is
+picked up automatically — you never hand-edit `nx.json` or add a `test` target. Run `nx test <name>`,
+`nx lint <name>`, etc. immediately.
+
+## Infrastructure & generic libraries
+
+There is **no `gen:infra`** command — `libs/infra/*` are technical adapters (auth, database, redis,
+storage…), not DDD bounded contexts, so the DDD module generator doesn't apply (it only accepts
+`--directory=modules|composition`). To add one:
+
+- **Preferred:** copy the closest existing infra lib (e.g. `libs/infra/redis`) and rename — it already
+  matches the workspace conventions (inferred targets, `vite-tsconfig-paths` in the vitest config,
+  `scope:infra` tag).
+- `pnpm gen:lib` / `pnpm gen:app` are raw `@nx/js:library` / `@nx/nest:application` passthroughs.
+  Their Nx-default output drifts from this repo (it emits an explicit `build` target and the
+  deprecated `nxViteTsPaths`/`nxCopyAssetsPlugin` vite plugins), so align it afterwards: delete the
+  explicit targets and swap the vitest plugins to `vite-tsconfig-paths`. Also add the correct
+  `scope:*` / `type:*` tags so `@nx/enforce-module-boundaries` applies.
+
 ## After Generating
 
 1. **Add Prisma model** to `prisma/schema.prisma`

--- a/libs/composition/admin/project.json
+++ b/libs/composition/admin/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/composition/admin/src",
   "projectType": "library",
   "tags": ["scope:composition", "type:feature"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/composition/admin"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/contracts/project.json
+++ b/libs/contracts/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/contracts/src",
   "projectType": "library",
   "tags": ["scope:contracts"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/contracts"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/core/project.json
+++ b/libs/core/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/core/src",
   "projectType": "library",
   "tags": ["scope:core"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/core"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/infra/auth/project.json
+++ b/libs/infra/auth/project.json
@@ -9,13 +9,6 @@
       "options": {
         "args": ["**/*.ts"]
       }
-    },
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/auth"
-      }
     }
   }
 }

--- a/libs/infra/auth/vitest.config.mts
+++ b/libs/infra/auth/vitest.config.mts
@@ -13,6 +13,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     setupFiles: ['../../../vitest.setup.ts'],
+    passWithNoTests: true,
     coverage: {
       reportsDirectory: '../../../coverage/libs/infra/auth',
       provider: 'v8' as const,

--- a/libs/infra/database/project.json
+++ b/libs/infra/database/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/infra/database/src",
   "projectType": "library",
   "tags": ["scope:infra"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/database"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/infra/i18n/project.json
+++ b/libs/infra/i18n/project.json
@@ -9,13 +9,6 @@
       "options": {
         "args": ["**/*.ts"]
       }
-    },
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/i18n"
-      }
     }
   }
 }

--- a/libs/infra/messaging/project.json
+++ b/libs/infra/messaging/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/infra/messaging/src",
   "projectType": "library",
   "tags": ["scope:infra"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/messaging"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/infra/observability/project.json
+++ b/libs/infra/observability/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/infra/observability/src",
   "projectType": "library",
   "tags": ["scope:infra"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/observability"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/infra/redis/project.json
+++ b/libs/infra/redis/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/infra/redis/src",
   "projectType": "library",
   "tags": ["scope:infra"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/redis"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/infra/storage/project.json
+++ b/libs/infra/storage/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/infra/storage/src",
   "projectType": "library",
   "tags": ["scope:infra"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/infra/storage"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/modules/audit-log/project.json
+++ b/libs/modules/audit-log/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/modules/audit-log/src",
   "projectType": "library",
   "tags": ["scope:modules"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/modules/audit-log"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/modules/audit-log/src/infrastructure/repositories/prisma-audit-log.repository.integration.ts
+++ b/libs/modules/audit-log/src/infrastructure/repositories/prisma-audit-log.repository.integration.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { execSync } from 'child_process';
-import { createTestContainers, DatabaseCleaner } from '@nestjs-fastify-nx/testing';
+import {
+  createTestContainers,
+  DatabaseCleaner,
+  deployTestMigrations,
+} from '@nestjs-fastify-nx/testing';
 import type { TestContainers } from '@nestjs-fastify-nx/testing';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
 import { PrismaAuditLogRepository } from './prisma-audit-log.repository';
@@ -18,10 +21,7 @@ describe('PrismaAuditLogRepository (integration)', () => {
 
     process.env['DATABASE_URL'] = dbUrl;
 
-    execSync('pnpm prisma migrate deploy', {
-      cwd: process.cwd(),
-      env: { ...process.env, DATABASE_URL: dbUrl },
-    });
+    deployTestMigrations(dbUrl);
 
     prismaService = new PrismaService();
     await prismaService.onModuleInit();

--- a/libs/modules/upload/project.json
+++ b/libs/modules/upload/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/modules/upload/src",
   "projectType": "library",
   "tags": ["scope:modules", "type:feature"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/modules/upload"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/modules/users/project.json
+++ b/libs/modules/users/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/modules/users/src",
   "projectType": "library",
   "tags": ["scope:modules"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/modules/users"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.integration.ts
+++ b/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.integration.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { execSync } from 'child_process';
-import { createTestContainers, DatabaseCleaner } from '@nestjs-fastify-nx/testing';
+import {
+  createTestContainers,
+  DatabaseCleaner,
+  deployTestMigrations,
+} from '@nestjs-fastify-nx/testing';
 import type { TestContainers } from '@nestjs-fastify-nx/testing';
 import { encodeCursor } from '@nestjs-fastify-nx/shared';
 import { UserFactory } from '../../testing/user.factory';
@@ -19,10 +22,7 @@ describe('PrismaUserRepository (integration)', () => {
 
     process.env['DATABASE_URL'] = dbUrl;
 
-    execSync('pnpm prisma migrate deploy', {
-      cwd: process.cwd(),
-      env: { ...process.env, DATABASE_URL: dbUrl },
-    });
+    deployTestMigrations(dbUrl);
 
     prismaService = new PrismaService();
     await prismaService.onModuleInit();

--- a/libs/shared/project.json
+++ b/libs/shared/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/shared/src",
   "projectType": "library",
   "tags": ["scope:shared"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/shared"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/testing/project.json
+++ b/libs/testing/project.json
@@ -4,13 +4,5 @@
   "sourceRoot": "libs/testing/src",
   "projectType": "library",
   "tags": ["scope:testing"],
-  "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "coverage/libs/testing"
-      }
-    }
-  }
+  "targets": {}
 }

--- a/libs/testing/src/index.ts
+++ b/libs/testing/src/index.ts
@@ -1,3 +1,4 @@
 export { createTestContainers } from './lib/containers/test-containers';
 export type { TestContainers } from './lib/containers/test-containers';
 export { DatabaseCleaner } from './lib/helpers/database-cleaner';
+export { deployTestMigrations } from './lib/helpers/deploy-test-migrations';

--- a/libs/testing/src/lib/helpers/deploy-test-migrations.ts
+++ b/libs/testing/src/lib/helpers/deploy-test-migrations.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+// The inferred @nx/vitest target runs vitest with cwd = projectRoot (not the
+// workspace root the old executor used), so `prisma migrate deploy` can no longer
+// find prisma/schema.prisma via the current directory. Walk up from cwd to the
+// directory that actually holds the schema and run the migration there, so the
+// call works regardless of which project's test suite invokes it.
+function resolveWorkspaceRoot(): string {
+  let dir = process.cwd();
+  while (!existsSync(join(dir, 'prisma', 'schema.prisma'))) {
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error('Could not locate prisma/schema.prisma above the current working directory');
+    }
+    dir = parent;
+  }
+  return dir;
+}
+
+export function deployTestMigrations(databaseUrl: string): void {
+  execSync('pnpm prisma migrate deploy', {
+    cwd: resolveWorkspaceRoot(),
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    stdio: 'inherit',
+  });
+}

--- a/nx.json
+++ b/nx.json
@@ -35,10 +35,6 @@
     "e2e": {
       "cache": true,
       "inputs": ["default", "^production"]
-    },
-    "@nx/vitest:test": {
-      "cache": true,
-      "inputs": ["default", "^production"]
     }
   },
   "sync": {
@@ -81,6 +77,12 @@
         "buildDepsTargetName": "build-deps",
         "watchDepsTargetName": "watch-deps",
         "serveStaticTargetName": "serve-static"
+      }
+    },
+    {
+      "plugin": "@nx/vitest",
+      "options": {
+        "testTargetName": "test"
       }
     }
   ],

--- a/tools/generators/project.json
+++ b/tools/generators/project.json
@@ -5,14 +5,6 @@
   "projectType": "library",
   "tags": ["scope:tools"],
   "targets": {
-    "test": {
-      "executor": "@nx/vitest:test",
-      "outputs": ["{workspaceRoot}/coverage/tools/generators"],
-      "options": {
-        "reportsDirectory": "../../coverage/tools/generators",
-        "passWithNoTests": true
-      }
-    },
     "lint": {
       "options": {
         "args": ["**/*.ts"]

--- a/tools/generators/src/generators/module/files/src/application/commands/create-__fileName__/create-__fileName__.handler.ts__template__
+++ b/tools/generators/src/generators/module/files/src/application/commands/create-__fileName__/create-__fileName__.handler.ts__template__
@@ -1,7 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Create<%= className %>Command } from './create-<%= fileName %>.command';
-import { <%= constantName %>_REPOSITORY, <%= className %>RepositoryPort } from '../../domain';
-import { <%= className %> } from '../../domain';
+import { <%= constantName %>_REPOSITORY } from '../../../domain';
+import type { <%= className %>RepositoryPort } from '../../../domain';
+import { <%= className %> } from '../../../domain';
 
 @Injectable()
 export class Create<%= className %>Handler {

--- a/tools/generators/src/generators/module/files/tsconfig.spec.json__template__
+++ b/tools/generators/src/generators/module/files/tsconfig.spec.json__template__
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": ["vitest/globals", "vitest/importMeta", "node", "vitest"]
+    "types": ["vitest/globals", "vitest/importMeta", "node", "vitest"],
+    "declaration": true
   },
   "include": [
     "vite.config.ts",

--- a/tools/generators/src/generators/module/files/vitest.config.mts__template__
+++ b/tools/generators/src/generators/module/files/vitest.config.mts__template__
@@ -1,11 +1,10 @@
 import { defineConfig } from 'vitest/config';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(() => ({
   root: __dirname,
   cacheDir: '<%= offsetFromRoot %>node_modules/.vite/<%= projectRoot %>',
-  plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  plugins: [tsconfigPaths()],
   test: {
     name: 'modules-<%= fileName %>',
     watch: false,
@@ -15,6 +14,7 @@ export default defineConfig(() => ({
     testTimeout: 60_000,
     hookTimeout: 60_000,
     reporters: ['default'],
+    setupFiles: ['<%= offsetFromRoot %>vitest.setup.ts'],
     passWithNoTests: true,
     coverage: {
       reportsDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>',

--- a/tools/generators/src/generators/module/generator.spec.ts
+++ b/tools/generators/src/generators/module/generator.spec.ts
@@ -22,7 +22,9 @@ describe('module generator', () => {
     expect(config.tags).toContain('scope:modules');
     expect(config.tags).toContain('type:feature');
     expect(config.tags).not.toContain('module:orders');
-    expect(config.targets?.['test']?.executor).toBe('@nx/vitest:test');
+    // No explicit targets — build/typecheck/lint/test are all inferred by the
+    // workspace plugins from tsconfig/eslint/vitest configs.
+    expect(config.targets?.['test']).toBeUndefined();
   });
 
   it('emits tsconfig and vitest config so build/typecheck targets are inferred', async () => {

--- a/tools/generators/src/generators/module/generator.ts
+++ b/tools/generators/src/generators/module/generator.ts
@@ -46,25 +46,17 @@ export async function moduleGenerator(tree: Tree, options: ModuleGeneratorSchema
   const projectName = `${rawDir}-${moduleNames.fileName}`;
   const scopeTag = `scope:${rawDir}`;
 
-  // `build` and `typecheck` targets are auto-inferred by `@nx/js/typescript`
-  // from `tsconfig.lib.json`; `lint` is inferred by `@nx/eslint/plugin` from
-  // the workspace eslint config. We only need to declare the test target
-  // explicitly because the executor takes module-specific options.
+  // All targets are inferred from config files by the workspace plugins:
+  // `build`/`typecheck` by `@nx/js/typescript` (tsconfig.lib.json), `lint` by
+  // `@nx/eslint/plugin`, and `test` by `@nx/vitest` (vitest.config.mts — see the
+  // template in files/). No explicit target is declared, so the module needs no
+  // hand-maintained `nx.json` include entry.
   addProjectConfiguration(tree, projectName, {
     root: projectRoot,
     projectType: 'library',
     sourceRoot: `${projectRoot}/src`,
     tags: [scopeTag, `type:feature`],
-    targets: {
-      test: {
-        executor: '@nx/vitest:test',
-        outputs: ['{options.reportsDirectory}'],
-        options: {
-          passWithNoTests: true,
-          reportsDirectory: `coverage/${projectRoot}`,
-        },
-      },
-    },
+    targets: {},
   });
 
   // Import path mirrors the project name so consumers can tell at a glance

--- a/tools/generators/vitest.config.mts
+++ b/tools/generators/vitest.config.mts
@@ -13,6 +13,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     setupFiles: ['../../vitest.setup.ts'],
+    passWithNoTests: true,
     coverage: {
       reportsDirectory: '../../coverage/tools/generators',
       provider: 'v8' as const,


### PR DESCRIPTION
## Summary

Completes the Nx-deprecation cleanup started in #97 by migrating the **`@nx/vitest:test` executor** to the inferred `@nx/vitest` plugin, and fixes several pre-existing bugs in the module generator that this surfaced.

## Vitest → inferred plugin
- Register **one global `@nx/vitest` plugin** (no `include` list): every project's `test` target is inferred from its `vitest.config.mts`, so **new libs are covered automatically — no `nx.json` edit**. This is the clean version the `convert-to-inferred` generator couldn't produce (it dropped `apps/api`'s unit `test` target and required hand-maintained includes).
- Removed the explicit `@nx/vitest:test` target from every `project.json` and the executor `targetDefault` from `nx.json`.
- **`apps/api` dual config**: the plugin's glob only matches `vite/vitest.config.*`, so `vite.e2e.config.ts` is *not* inferred. api's unit `test` is inferred like everything else; its `e2e` becomes an `nx:run-commands` target running vitest against the e2e config.
- **CI**: the inferred target runs vitest directly (no Jest-style `--testPathPattern`), so the integration job now passes `integration` as a vitest positional filename filter.

## Module generator fixes
Running the generator end-to-end (its own tests only assert file existence, never compile the output) surfaced pre-existing drift that **never compiled**:
- create-command **handler** imported the domain barrel at the wrong depth (`../../domain` → `../../../domain`) and imported the repository **port** (an interface) as a value into an `@Inject` signature (TS1272 under `isolatedModules`) → `import type`.
- `tsconfig.spec.json` template missing `declaration: true` → TS5069 on `tsc --build --emitDeclarationOnly`.
- `vitest.config` template missing `setupFiles` and still on the deprecated `nxViteTsPaths`/`nxCopyAssetsPlugin`.
- Generated `project.json` no longer writes an explicit `test` target (inferred now).

Verified a freshly generated `modules-*` **and** `composition-*` project passes typecheck, build, lint, and test.

## Docs
`creating-a-module.md`: note that all targets are inferred (no config editing), and that there is **no `gen:infra`** — infra libs are technical adapters, not DDD modules (copy an existing infra lib; `gen:lib`/`gen:app` are raw Nx passthroughs whose output drifts).

## Verification (CI-equivalent, local)
- `lint` + `typecheck` + `build` — 21 projects, green, **no deprecation warnings** anywhere.
- Unit tests green; generator's own 18 tests green. Testcontainers integration/e2e run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test discovery and execution.
  * Standardized end-to-end test execution through Vitest.
  * Test configuration is now inferred automatically where supported.

* **Documentation**
  * Added guidance on generated project configuration and infrastructure module creation.

* **Developer Experience**
  * Updated module templates with improved path resolution, shared test setup, and declaration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->