### PR TITLE
fix: codebase audit — resilience, contracts, and doc accuracy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,9 +94,11 @@ STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS=3600
 # App
 NODE_ENV=development
 PORT=3000
-# Base URL used by the generated Axios client during SSR/Node execution.
-# Browser builds use globalThis.__API_URL__ and otherwise fall back to /api/v1.
-API_BASE_URL=http://localhost:3000/api/v1
+# Origin the generated Axios client targets during SSR/Node execution. ORIGIN ONLY — every
+# generated operation already carries its full path (/api/v1/users/me, /api/auth/get-session), and
+# axios concatenates, so adding /api/v1 here sends it twice and 404s every call.
+# Browser builds read globalThis.__API_URL__, defaulting to same-origin.
+API_BASE_URL=http://localhost:3000
 
 # Timezone — applied to all containers (api, worker, scheduler, migration, postgres,
 # redis, minio, mailpit). Default UTC keeps logs, audit timestamps, BullMQ delayed

--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,16 @@ OUTBOX_RETENTION_DAYS=7
 OUTBOX_PURGE_BATCH_SIZE=1000
 OUTBOX_PURGE_MAX_BATCHES=200
 
+# Verification token retention — Better Auth only deletes a `verifications` row when the
+# link is actually consumed, so abandoned password-reset / email-verification tokens would
+# otherwise accumulate forever. The scheduler purges expired ones daily at 03:45 UTC.
+# Rows are kept for a grace window PAST expiry, not deleted on the expiry boundary: Better
+# Auth distinguishes "expired token" from "unknown token", and purging at the boundary would
+# downgrade a user clicking a just-stale link to a generic "invalid token" error.
+VERIFICATION_PURGE_GRACE_DAYS=1
+VERIFICATION_PURGE_BATCH_SIZE=1000
+VERIFICATION_PURGE_MAX_BATCHES=200
+
 # Scheduler cleanup policies and per-run throughput caps.
 DLQ_ALERT_THRESHOLD=10
 INACTIVE_USER_RETENTION_DAYS=90

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -21,14 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      # SHA-pinned like every other workflow here: a moving tag lets an upstream compromise run
+      # with this job's token without any change landing in the repo.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           # Pinned to match package.json `packageManager` and the Dockerfiles.
           version: 10.33.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -32,7 +32,10 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          # Matches package.json engines (>=24), the Dockerfile base, and the other workflows.
+          # `engine-strict` is off, so a mismatch here does not fail — it just quietly validates the
+          # whole workspace against a Node major the project does not ship on.
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,8 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/docs/deployment.md
 
-      # Build into the runner's local daemon only — nothing is published yet. Trivy gates the push
-      # below, so an image with a fixable CRITICAL/HIGH CVE never reaches GHCR and never gets
-      # cosign-signed. Scanning after the push would leave a vulnerable, signed `latest` on the
-      # registry for any deploy automation to pull, with nothing to retract it.
+      # Local daemon only — nothing is published until Trivy passes below, so a vulnerable image
+      # never reaches GHCR and never gets signed. Scanning after the push has nothing to retract.
       - name: Build image for scanning (${{ matrix.app }})
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -139,8 +137,8 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
-      # always() so a failing gate still reports its findings to the Security tab. The push step
-      # below has no such condition, so it stays skipped when the scan fails.
+      # always() so a failing gate still reports. The push step below has no such condition, so it
+      # stays skipped when the scan fails.
       - name: Upload Trivy results to GitHub Security
         if: always()
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
@@ -148,9 +146,8 @@ jobs:
           sarif_file: trivy-${{ matrix.app }}.sarif
           category: trivy-${{ matrix.app }}
 
-      # Reached only when Trivy passed. Every layer is already in the gha cache from the scan build,
-      # so this is a cache hit, not a rebuild — it re-exports through buildkit to attach SBOM +
-      # provenance, which the local `load` exporter cannot produce.
+      # Cache hit on the scan build's layers, not a rebuild — it re-exports through buildkit to
+      # attach SBOM + provenance, which the local `load` exporter cannot produce.
       - name: Push Docker image (${{ matrix.app }})
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
       # Required by docker/build-push-action when emitting provenance/SBOM
       # attestations alongside the image (provenance: mode=max).
       id-token: write
+      # The Trivy gate below uploads its SARIF from this job.
+      security-events: write
 
     strategy:
       fail-fast: false
@@ -105,7 +107,51 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/docs/deployment.md
 
-      - name: Build and push Docker image (${{ matrix.app }})
+      # Build into the runner's local daemon only — nothing is published yet. Trivy gates the push
+      # below, so an image with a fixable CRITICAL/HIGH CVE never reaches GHCR and never gets
+      # cosign-signed. Scanning after the push would leave a vulnerable, signed `latest` on the
+      # registry for any deploy automation to pull, with nothing to retract it.
+      - name: Build image for scanning (${{ matrix.app }})
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: false
+          load: true
+          # linux/amd64 only by default — flip to `linux/amd64,linux/arm64`
+          # if multi-arch is needed; QEMU is already available for that.
+          # Note: `load` cannot carry multi-arch, so going multi-arch means scanning per platform.
+          platforms: linux/amd64
+          tags: scan-candidate/${{ matrix.app }}:${{ github.sha }}
+          cache-from: |
+            type=gha,scope=production-build
+            type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}
+
+      - name: Trivy security scan (${{ matrix.app }})
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9af4af0408e91440ef0
+        with:
+          image-ref: scan-candidate/${{ matrix.app }}:${{ github.sha }}
+          format: sarif
+          output: trivy-${{ matrix.app }}.sarif
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      # always() so a failing gate still reports its findings to the Security tab. The push step
+      # below has no such condition, so it stays skipped when the scan fails.
+      - name: Upload Trivy results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          sarif_file: trivy-${{ matrix.app }}.sarif
+          category: trivy-${{ matrix.app }}
+
+      # Reached only when Trivy passed. Every layer is already in the gha cache from the scan build,
+      # so this is a cache hit, not a rebuild — it re-exports through buildkit to attach SBOM +
+      # provenance, which the local `load` exporter cannot produce.
+      - name: Push Docker image (${{ matrix.app }})
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -113,8 +159,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
           push: true
-          # linux/amd64 only by default — flip to `linux/amd64,linux/arm64`
-          # if multi-arch is needed; QEMU is already available for that.
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -125,7 +169,6 @@ jobs:
           cache-from: |
             type=gha,scope=production-build
             type=gha,scope=${{ matrix.app }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.app }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -138,51 +181,6 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.app }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
-
-  security-scan:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - app: api
-          - app: worker
-          - app: scheduler
-          - app: migration
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Trivy security scan (${{ matrix.app }})
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9af4af0408e91440ef0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.app }}:${{ github.ref_name }}
-          format: sarif
-          output: trivy-${{ matrix.app }}.sarif
-          exit-code: '1'
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-
-      - name: Upload Trivy results to GitHub Security
-        if: always()
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
-        with:
-          sarif_file: trivy-${{ matrix.app }}.sarif
-          category: trivy-${{ matrix.app }}
 
   static-analysis:
     needs: build-and-push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,13 @@ Initial public release of the boilerplate.
 #### Core platform
 
 - **Four runnable apps** — `api`, `worker`, `scheduler`, `migration` — sharing one Nx workspace and one pnpm lockfile
-- **Nx 22** monorepo with `@nx/enforce-module-boundaries` enforcing DDD layering via `scope:*` tags (api, worker, scheduler, migration, modules, composition, infra, core, shared, contracts, testing)
+- **Nx 23** monorepo with `@nx/enforce-module-boundaries` enforcing DDD layering via `scope:*` tags (api, worker, scheduler, migration, modules, composition, infra, core, shared, contracts, testing)
 - **Webpack 5** bundler wired with `tsc` compiler so NestJS decorator metadata resolves correctly in production builds
 - **TypeScript project references** kept in sync via `nx sync`
 
 #### API surfaces (single Fastify instance)
 
-- **REST** with `@nestjs/swagger` — auto-mounted at `/api/docs` outside production, deterministic `operationId` factory consumed by Orval codegen
+- **REST** with `@nestjs/swagger` — auto-mounted at `/docs` (Scalar) outside production, deterministic `operationId` factory consumed by Orval codegen
 - **GraphQL** via `@nestjs/mercurius` — schema-first, GraphiQL exposed at `/graphiql` in dev
 - **Socket.io 4** with `@socket.io/redis-adapter` for cross-pod broadcast; WebSocket upgrades reuse the Better Auth cookie via a custom adapter
 - **OpenAPI codegen** — Orval emits a typed REST client into `libs/api-client` from the live spec exported by `CodegenAppModule`
@@ -121,7 +121,7 @@ Initial public release of the boilerplate.
 - **GitHub Actions**:
   - `ci.yml` — lint, typecheck, unit tests, build, secret scan, dep scan
   - `integration.yml` — Vitest integration suite with Testcontainers services
-  - `release.yml` — buildx + SBOM + provenance, Trivy gate, Semgrep gate, Cosign sign, migrate-and-deploy via Coolify webhook
+  - `release.yml` — buildx + SBOM + provenance, Trivy gate BEFORE push, Cosign sign, Semgrep gate. Stops at a signed image — deploy is deployment-specific and not wired here
 - **Vitest 4** + **Testcontainers** (real Postgres + Redis) + **Supertest** for unit, integration, and HTTP e2e suites
 
 [1.0.0]: https://github.com/chuanghiduoc/nestjs-fastify-nx/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ pnpm rm:project <name>             # remove a lib/app + clean refs/tags (nx work
 - `docs/creating-a-module.md` — DDD generator walkthrough
 - `docs/domain-module-anatomy.md` — every file type in a module explained (what/why/when/how, beginner walkthrough)
 - `docs/environment.md` — every env var, defaults, validation
-- `docs/deployment.md` — Docker, GHCR, Cosign, Coolify
+- `docs/deployment.md` — Docker, GHCR, Cosign, rollout options
 - `docs/security.md` — five-layer scan pipeline (Gitleaks, OSV, Semgrep, Trivy, Cosign)
 - `docs/observability.md` — logging, tracing, metrics, correlation-id design, resilience
 - `docs/observability-guide.md` — how to enable, explore, and extend observability (add a metric/span/log field/alert/dashboard)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Respond to the maintainer in chat in **Vietnamese by default** — reviews, expl
 
 ## Stack quick reference
 
-- **Runtime**: Node 22, pnpm 10.33, TypeScript 6
+- **Runtime**: Node 24, pnpm 10.33, TypeScript 6
 - **Framework**: NestJS 11 + Fastify 5
 - **ORM**: Prisma 7 with `@prisma/adapter-pg`; schema at `prisma/schema.prisma`
 - **Auth**: Better Auth 1.6 — **NOT** JWT. Cookie name is `better-auth.session_token`. Mounted at `/api/auth/*` by `BetterAuthModule` (in `libs/infra/auth`). The auth surface is published at `/api/auth/reference`.
@@ -46,14 +46,17 @@ Respond to the maintainer in chat in **Vietnamese by default** — reviews, expl
 The monorepo enforces DDD layering via Nx tags + `@nx/enforce-module-boundaries` (see `eslint.config.mjs`):
 
 ```
-scope:api / scope:worker / scope:scheduler
+scope:api
   → modules, composition, infra, core, shared, contracts
+
+scope:worker / scope:scheduler
+  → modules, infra, core, shared, contracts     # NO composition — api owns the HTTP surface
 
 scope:migration
   → empty allow-list (intentional — migration is a thin prisma deploy wrapper)
 
 scope:composition  (cross-cutting modules, e.g. admin)
-  → modules, infra, core, shared, contracts
+  → modules, composition, infra, core, shared, contracts
 
 scope:modules  (bounded contexts: users, audit-log, …)
   → infra, core, shared, contracts        # NEVER another scope:modules
@@ -63,6 +66,15 @@ scope:infra
 
 scope:core / scope:contracts
   → shared
+
+scope:shared / scope:tools
+  → empty allow-list (leaves of the graph)
+
+scope:client  (libs/api-client — orval output)
+  → shared, contracts
+
+scope:testing
+  → modules, infra, core, shared, contracts
 ```
 
 **Key invariant**: `scope:modules` cannot depend on another `scope:modules`. Cross-context aggregation goes through `scope:composition` (one-way: composition → modules, never reverse). Do not "fix" lint errors by adding cross-module imports — extract a composition lib instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Welcome. This guide gets you from clone → first PR in under 30 minutes.
 ## Prerequisites
 
 - Docker Desktop / Docker Engine with Compose v2+
-- Node 22+, pnpm 10+
+- Node 24+, pnpm 10+
 - Git with conventional commits awareness
 - 2 GB free disk (for containers + node_modules)
 
@@ -19,7 +19,7 @@ pnpm install
 ./scripts/build-dev.sh             # 🚀 boots full dev stack
 
 # 2. Access the API
-open http://localhost:3000/api/docs
+open http://localhost:3000/docs
 ```
 
 Check the logs in another terminal:
@@ -107,7 +107,7 @@ Integration tests use real Postgres via Testcontainers (no mocks).
 ### 10. Verify boundaries
 
 ```bash
-pnpm nx affected -t lint --base=main
+pnpm nx affected -t lint --base=origin/main
 ```
 
 Full walkthrough: [docs/creating-a-module.md](./docs/creating-a-module.md)
@@ -123,8 +123,8 @@ Full walkthrough: [docs/creating-a-module.md](./docs/creating-a-module.md)
 | Scaffold composition | `pnpm gen:composition <name>`                     |
 | Remove a project     | `pnpm rm:project <name>`                          |
 | Run tests for module | `pnpm nx test modules-payments`                   |
-| Run all tests        | `pnpm nx affected -t test --base=main`            |
-| Check lint           | `pnpm nx affected -t lint --base=main`            |
+| Run all tests        | `pnpm nx affected -t test --base=origin/main`     |
+| Check lint           | `pnpm nx affected -t lint --base=origin/main`     |
 | Create migration     | `pnpm db:migrate --name add_field`                |
 | View DB              | `pnpm db:studio`                                  |
 | Seed DB              | `pnpm db:seed`                                    |
@@ -152,8 +152,8 @@ Enforced by ESLint + Lefthook + CI.
 ## Pull Request Checklist
 
 - [ ] Tests added/updated (`pnpm nx test`)
-- [ ] Lint pass (`pnpm nx affected -t lint --base=main`)
-- [ ] Build pass (`pnpm nx affected -t build --base=main`)
+- [ ] Lint pass (`pnpm nx affected -t lint --base=origin/main`)
+- [ ] Build pass (`pnpm nx affected -t build --base=origin/main`)
 - [ ] API docs updated (if endpoints changed)
 - [ ] CHANGELOG.md updated (if user-facing)
 - [ ] No TODOs in code
@@ -175,7 +175,7 @@ Enforced by ESLint + Lefthook + CI.
 ## Getting Help
 
 - **Architecture** → [docs/architecture.md](./docs/architecture.md)
-- **Environment / API** → [docs/environment.md](./docs/environment.md), `/api/docs` (Swagger)
+- **Environment / API** → [docs/environment.md](./docs/environment.md), `/docs` (Scalar API reference)
 - **Operations** → [docs/runbook.md](./docs/runbook.md)
 - **Known issues** → [docs/troubleshooting.md](./docs/troubleshooting.md)
 - **Security** → [docs/security.md](./docs/security.md)
@@ -186,8 +186,12 @@ Enforced by ESLint + Lefthook + CI.
 
 Push to `main`, tag with `v*.*.*`, GitHub Actions:
 
-- Builds multi-platform images
-- Signs with Cosign + SBOM
-- Deploys via Coolify webhook
+- Builds each image for `linux/amd64` (multi-arch is a one-line change in `release.yml`, not the default)
+- Gates on a Trivy scan **before** pushing — a fixable CRITICAL/HIGH publishes nothing
+- Pushes to GHCR with SBOM + SLSA provenance attestations, then signs the digest with Cosign
+
+The release **stops at a signed image on GHCR — it does not deploy.** Rollout is
+deployment-specific and intentionally left out of CI; pull the published tag, run the migration
+image against your database, then restart the services. See `docs/deployment.md`.
 
 See `.github/workflows/release.yml` for details.

--- a/README.md
+++ b/README.md
@@ -93,32 +93,32 @@ If you've ever shipped a Node service to production, you've written this code al
 
 ## Stack
 
-| Layer          | Technology                                                         |
-| -------------- | ------------------------------------------------------------------ |
-| Runtime        | Node.js 24, pnpm 10.33, TypeScript 6                               |
-| Framework      | NestJS 11 + Fastify 5                                              |
-| ORM            | Prisma 7 (driver adapter `@prisma/adapter-pg`)                     |
-| Database       | PostgreSQL 18 (native `uuidv7()`, async I/O via io_uring)          |
-| Cache          | Redis 8 + `cache-manager` + Keyv                                   |
-| Queues         | BullMQ + `@nestjs/bullmq`, Bull Board UI                           |
-| Authentication | Better Auth 1.6 (cookie sessions, argon2)                          |
-| API surfaces   | REST (`@nestjs/swagger`), GraphQL (`@nestjs/mercurius`), Socket.io |
-| Realtime       | Socket.io 4 + `@socket.io/redis-adapter`                           |
-| Object storage | AWS S3 SDK v3 + presigned URLs (MinIO compatible in dev)           |
-| Email          | Nodemailer (SMTP) — Mailpit in dev                                 |
-| Validation     | Zod 4 + class-validator + class-transformer                        |
-| Observability  | OpenTelemetry SDK + Sentry NestJS + Prometheus (`prom-client`)     |
-| Logging        | nestjs-pino (structured JSON, pino-http)                           |
-| Scheduling     | `@nestjs/schedule` + cron in the dedicated `scheduler` app         |
-| Monorepo       | Nx 23 (`@nx/nest`, `@nx/webpack`, `@nx/vite`, `@nx/vitest`)        |
-| Bundler        | Webpack 5 (NestJS-correct decorator metadata via `tsc` compiler)   |
-| Test runner    | Vitest 4 + Testcontainers + Supertest                              |
-| API codegen    | Orval 8 → `libs/api-client`                                        |
-| Lint / format  | ESLint 10 + typescript-eslint, Prettier 3.6                        |
-| Git hygiene    | Lefthook + commitlint (Conventional Commits)                       |
-| Container      | Multi-stage Alpine, Buildx, SBOM + SLSA provenance                 |
-| Security       | Gitleaks + OSV-Scanner + Semgrep + Trivy + Cosign                  |
-| CI / CD        | GitHub Actions, GHCR, Coolify webhook                              |
+| Layer          | Technology                                                          |
+| -------------- | ------------------------------------------------------------------- |
+| Runtime        | Node.js 24, pnpm 10.33, TypeScript 6                                |
+| Framework      | NestJS 11 + Fastify 5                                               |
+| ORM            | Prisma 7 (driver adapter `@prisma/adapter-pg`)                      |
+| Database       | PostgreSQL 18 (native `uuidv7()`, async I/O via io_uring)           |
+| Cache          | Redis 8 + `cache-manager` + Keyv                                    |
+| Queues         | BullMQ + `@nestjs/bullmq`, Bull Board UI                            |
+| Authentication | Better Auth 1.6 (cookie sessions, argon2)                           |
+| API surfaces   | REST (`@nestjs/swagger`), GraphQL (`@nestjs/mercurius`), Socket.io  |
+| Realtime       | Socket.io 4 + `@socket.io/redis-adapter`                            |
+| Object storage | AWS S3 SDK v3 + presigned URLs (MinIO compatible in dev)            |
+| Email          | Nodemailer (SMTP) — Mailpit in dev                                  |
+| Validation     | Zod 4 + class-validator + class-transformer                         |
+| Observability  | OpenTelemetry SDK + Sentry NestJS + Prometheus (`prom-client`)      |
+| Logging        | nestjs-pino (structured JSON, pino-http)                            |
+| Scheduling     | `@nestjs/schedule` + cron in the dedicated `scheduler` app          |
+| Monorepo       | Nx 23 (`@nx/nest`, `@nx/webpack`, `@nx/vite`, `@nx/vitest`)         |
+| Bundler        | Webpack 5 (NestJS-correct decorator metadata via `tsc` compiler)    |
+| Test runner    | Vitest 4 + Testcontainers + Supertest                               |
+| API codegen    | Orval 8 → `libs/api-client`                                         |
+| Lint / format  | ESLint 10 + typescript-eslint, Prettier 3.6                         |
+| Git hygiene    | Lefthook + commitlint (Conventional Commits)                        |
+| Container      | Multi-stage Alpine, Buildx, SBOM + SLSA provenance                  |
+| Security       | Gitleaks + OSV-Scanner + Semgrep + Trivy + Cosign                   |
+| CI / CD        | GitHub Actions → GHCR (deploy is yours to wire — see deployment.md) |
 
 ## Architecture
 
@@ -342,7 +342,7 @@ Full flow: [docs/deployment.md](docs/deployment.md).
 - [Domain Module Anatomy](docs/domain-module-anatomy.md) — every file in a module explained file-by-file (beginner-friendly)
 - [Creating a Module](docs/creating-a-module.md) — DDD/CQRS scaffold walkthrough
 - [Environment Variables](docs/environment.md) — every env var, defaults, validation
-- [Deployment](docs/deployment.md) — Docker, GHCR, Coolify, migrations
+- [Deployment](docs/deployment.md) — Docker, GHCR, Cosign verification, migrations
 - [Security Scanning](docs/security.md) — five-layer pipeline, local + CI parity
 - [Troubleshooting](docs/troubleshooting.md) — known issues, debug tips
 - [Runbook](docs/runbook.md) — ops runbook: health, metrics, outbox, BullMQ, performance

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
-  <img src=".github/assets/banner.png" alt="nestjs-fastify-nx — Production-grade NestJS + Fastify + Nx 22 monorepo boilerplate" width="100%" />
+  <img src=".github/assets/banner.png" alt="nestjs-fastify-nx — Production-grade NestJS + Fastify + Nx 23 monorepo boilerplate" width="100%" />
 </div>
 
 <h1 align="center">nestjs-fastify-nx</h1>
 
 <p align="center">
-  <strong>Production-grade NestJS 11 + Fastify 5 + Nx 22 monorepo boilerplate.</strong><br/>
+  <strong>Production-grade NestJS 11 + Fastify 5 + Nx 23 monorepo boilerplate.</strong><br/>
   DDD · CQRS · Better Auth · GraphQL · Socket.io · BullMQ · OpenTelemetry · Sentry — wired and tested.
 </p>
 
@@ -22,9 +22,9 @@
 <p align="center">
   <img alt="NestJS" src="https://img.shields.io/badge/NestJS-11-E0234E?logo=nestjs&logoColor=white&style=flat-square" />
   <img alt="Fastify" src="https://img.shields.io/badge/Fastify-5-000000?logo=fastify&logoColor=white&style=flat-square" />
-  <img alt="Nx" src="https://img.shields.io/badge/Nx-22-143055?logo=nx&logoColor=white&style=flat-square" />
+  <img alt="Nx" src="https://img.shields.io/badge/Nx-23-143055?logo=nx&logoColor=white&style=flat-square" />
   <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white&style=flat-square" />
-  <img alt="Node" src="https://img.shields.io/badge/Node.js-22-339933?logo=node.js&logoColor=white&style=flat-square" />
+  <img alt="Node" src="https://img.shields.io/badge/Node.js-24-339933?logo=node.js&logoColor=white&style=flat-square" />
   <img alt="pnpm" src="https://img.shields.io/badge/pnpm-10.33-F69220?logo=pnpm&logoColor=white&style=flat-square" />
   <img alt="Prisma" src="https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white&style=flat-square" />
   <img alt="PostgreSQL" src="https://img.shields.io/badge/PostgreSQL-18-336791?logo=postgresql&logoColor=white&style=flat-square" />
@@ -95,7 +95,7 @@ If you've ever shipped a Node service to production, you've written this code al
 
 | Layer          | Technology                                                         |
 | -------------- | ------------------------------------------------------------------ |
-| Runtime        | Node.js 22, pnpm 10.33, TypeScript 6                               |
+| Runtime        | Node.js 24, pnpm 10.33, TypeScript 6                               |
 | Framework      | NestJS 11 + Fastify 5                                              |
 | ORM            | Prisma 7 (driver adapter `@prisma/adapter-pg`)                     |
 | Database       | PostgreSQL 18 (native `uuidv7()`, async I/O via io_uring)          |
@@ -110,7 +110,7 @@ If you've ever shipped a Node service to production, you've written this code al
 | Observability  | OpenTelemetry SDK + Sentry NestJS + Prometheus (`prom-client`)     |
 | Logging        | nestjs-pino (structured JSON, pino-http)                           |
 | Scheduling     | `@nestjs/schedule` + cron in the dedicated `scheduler` app         |
-| Monorepo       | Nx 22 (`@nx/nest`, `@nx/webpack`, `@nx/vite`, `@nx/vitest`)        |
+| Monorepo       | Nx 23 (`@nx/nest`, `@nx/webpack`, `@nx/vite`, `@nx/vitest`)        |
 | Bundler        | Webpack 5 (NestJS-correct decorator metadata via `tsc` compiler)   |
 | Test runner    | Vitest 4 + Testcontainers + Supertest                              |
 | API codegen    | Orval 8 → `libs/api-client`                                        |
@@ -270,7 +270,7 @@ Defense-in-depth across five layers — every layer runs locally and gates CI:
 
 | Layer          | Tool          | Local                             | CI                            |
 | -------------- | ------------- | --------------------------------- | ----------------------------- |
-| Secrets        | Gitleaks      | lefthook pre-commit + pre-push    | `ci.yml` (`secret-scan`)      |
+| Secrets        | Gitleaks      | lefthook pre-push (full history)  | `ci.yml` (`secret-scan`)      |
 | Dependencies   | OSV-Scanner   | `scripts/security/scan-deps.sh`   | `ci.yml` (`dep-scan`)         |
 | SAST           | Semgrep       | `scripts/security/scan-sast.sh`   | `release.yml`                 |
 | Container CVEs | Trivy         | `scripts/security/scan-images.sh` | `release.yml`                 |
@@ -311,13 +311,19 @@ pnpm nx run-many -t test --parallel=3
 git tag v1.2.3 && git push origin v1.2.3
 ```
 
-Triggers `release.yml`, which:
+Triggers `release.yml`, which per app:
 
-1. Builds + pushes 4 images to GHCR with SBOM + SLSA provenance.
-2. Signs each image with Cosign (keyless Fulcio OIDC).
-3. Gates on Trivy (HIGH/CRITICAL, fixable only) + Semgrep (ERROR).
-4. Runs the migration container against the production DB.
-5. Hits the Coolify webhook to roll out the new tag.
+1. Builds the image into the runner's local daemon — nothing published yet.
+2. Gates on Trivy (HIGH/CRITICAL, fixable only). A failing scan publishes nothing, so a
+   vulnerable image never reaches GHCR and is never signed.
+3. Pushes to GHCR with SBOM + SLSA provenance, then signs the digest with Cosign
+   (keyless Fulcio OIDC).
+4. Runs Semgrep (ERROR) as a separate job.
+
+**It stops there — the release does not deploy.** Running migrations and rolling out are
+deployment-specific (your environment owns its DB credentials and rollout mechanism), so they are
+deliberately not wired into CI: pull the published tag, run the migration image against your
+database, then restart the services. See [docs/deployment.md](./docs/deployment.md).
 
 Verify a published tag locally:
 
@@ -349,7 +355,7 @@ Contributions are very welcome — bug reports, feature requests, and pull reque
 
 1. Fork → feature branch from `main`.
 2. Use [Conventional Commits](https://www.conventionalcommits.org/) — enforced by commitlint (`feat:`, `fix:`, `refactor:`, `docs:`, …).
-3. Lefthook runs lint-staged + Gitleaks on commit; full Gitleaks history scan on push.
+3. Lefthook runs lint-staged + typecheck on commit, commitlint on the message, and a full Gitleaks history scan on push.
 4. CI must be green: lint, typecheck, unit tests, build, secret + dep scans.
 5. Open a PR — describe the _why_, link the issue, include a test plan.
 

--- a/apps/api/e2e/global-setup.ts
+++ b/apps/api/e2e/global-setup.ts
@@ -1,8 +1,7 @@
 import { createTestContainers, deployTestMigrations } from '@nestjs-fastify-nx/testing';
 import type { TestContainers } from '@nestjs-fastify-nx/testing';
 
-// Vitest loads this module once and calls both hooks on it, so module scope is enough to hand the
-// handle from setup to teardown. Specs read the endpoints from process.env, not from here.
+// Vitest calls both hooks on one module instance, so module scope carries the handle across.
 let containers: TestContainers | undefined;
 
 async function stopContainers(): Promise<void> {
@@ -27,8 +26,6 @@ export async function setup(): Promise<void> {
     return;
   }
 
-  // Shared helper rather than a local Promise.all: it starts the containers sequentially and stops
-  // the first one if the second fails, so a half-started pair can't leak past this process.
   containers = await createTestContainers();
 
   // Stop containers on SIGINT/SIGTERM (CI cancel, Ctrl-C) so Docker resources

--- a/apps/api/e2e/global-setup.ts
+++ b/apps/api/e2e/global-setup.ts
@@ -1,16 +1,13 @@
-import { deployTestMigrations } from '@nestjs-fastify-nx/testing';
-import { PostgreSqlContainer } from '@testcontainers/postgresql';
-import { RedisContainer } from '@testcontainers/redis';
-import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
-import type { StartedRedisContainer } from '@testcontainers/redis';
+import { createTestContainers, deployTestMigrations } from '@nestjs-fastify-nx/testing';
+import type { TestContainers } from '@nestjs-fastify-nx/testing';
 
-declare global {
-  var __E2E_POSTGRES__: StartedPostgreSqlContainer;
-  var __E2E_REDIS__: StartedRedisContainer;
-}
+// Vitest loads this module once and calls both hooks on it, so module scope is enough to hand the
+// handle from setup to teardown. Specs read the endpoints from process.env, not from here.
+let containers: TestContainers | undefined;
 
 async function stopContainers(): Promise<void> {
-  await Promise.all([globalThis.__E2E_POSTGRES__?.stop(), globalThis.__E2E_REDIS__?.stop()]);
+  await containers?.teardown().catch(() => undefined);
+  containers = undefined;
 }
 
 export async function setup(): Promise<void> {
@@ -30,15 +27,9 @@ export async function setup(): Promise<void> {
     return;
   }
 
-  const [postgresContainer, redisContainer] = await Promise.all([
-    new PostgreSqlContainer('postgres:18-alpine').start(),
-    new RedisContainer('redis:8-alpine').start(),
-  ]);
-
-  // Expose via globalThis so createTestApp() can read them without re-importing
-  // containers package in each spec file.
-  globalThis.__E2E_POSTGRES__ = postgresContainer;
-  globalThis.__E2E_REDIS__ = redisContainer;
+  // Shared helper rather than a local Promise.all: it starts the containers sequentially and stops
+  // the first one if the second fails, so a half-started pair can't leak past this process.
+  containers = await createTestContainers();
 
   // Stop containers on SIGINT/SIGTERM (CI cancel, Ctrl-C) so Docker resources
   // are not leaked when Vitest's teardown export is bypassed by process kill.
@@ -48,11 +39,11 @@ export async function setup(): Promise<void> {
   process.once('SIGINT', handleSignal);
   process.once('SIGTERM', handleSignal);
 
-  const dbUrl = postgresContainer.getConnectionUri();
+  const dbUrl = containers.postgres.getConnectionUri();
   configureTestEnvironment(
     dbUrl,
-    redisContainer.getHost(),
-    String(redisContainer.getFirstMappedPort()),
+    containers.redis.getHost(),
+    String(containers.redis.getFirstMappedPort()),
   );
 
   // Run migrations once against the shared container. Any failure here means

--- a/apps/api/e2e/test-app.ts
+++ b/apps/api/e2e/test-app.ts
@@ -15,6 +15,7 @@ import { AppModule } from '../src/app/app.module';
 import { registerIdempotency } from '../src/common/idempotency/register-idempotency';
 import { ProblemDetailsValidationPipe } from '../src/common/pipes';
 import { applyFastifyProblemDetailsHook } from '../src/common/filters/fastify-error-handler';
+import { buildProblemDetails } from '../src/common/filters/problem-details.helper';
 
 // In-process stub — e2e covers controller logic, not the S3 wire format.
 // Real S3 paths are unit-tested in s3-storage.adapter.spec.ts.
@@ -156,12 +157,16 @@ export async function createTestApp(): Promise<TestAppContext> {
       const email = body && typeof body['email'] === 'string' ? body['email'].toLowerCase() : '';
       return `${req.ip}:${email}`;
     },
-    errorResponseBuilder: (_req, context) => ({
-      type: 'https://tools.ietf.org/html/rfc6585#section-4',
-      title: 'Too Many Requests',
-      status: HttpStatus.TOO_MANY_REQUESTS,
-      code: ERROR_CODES.RATE_LIMITED,
-      detail: `Rate limit exceeded. Try again in ${Math.ceil(context.ttl / 1000)} seconds.`,
+    // Same builder main.ts uses — a hand-rolled body here would let e2e pass against a shape
+    // production does not emit.
+    errorResponseBuilder: (req, context) => ({
+      ...buildProblemDetails({
+        status: HttpStatus.TOO_MANY_REQUESTS,
+        title: 'Too Many Requests',
+        detail: `Rate limit exceeded. Try again in ${Math.ceil(context.ttl / 1000)} seconds.`,
+        code: ERROR_CODES.RATE_LIMITED,
+        instance: req.url,
+      }),
       retryAfter: Math.ceil(context.ttl / 1000),
     }),
   });

--- a/apps/api/src/assets/i18n/en/errors.json
+++ b/apps/api/src/assets/i18n/en/errors.json
@@ -32,5 +32,8 @@
     "delete_failed": "Storage delete failed",
     "commit_failed": "Storage commit failed",
     "read_range_failed": "Storage readRange failed"
+  },
+  "pagination": {
+    "invalid_cursor": "startingAfter is not a valid cursor"
   }
 }

--- a/apps/api/src/assets/i18n/vi/errors.json
+++ b/apps/api/src/assets/i18n/vi/errors.json
@@ -32,5 +32,8 @@
     "delete_failed": "Xóa đối tượng thất bại",
     "commit_failed": "Commit đối tượng thất bại",
     "read_range_failed": "Đọc dải byte thất bại"
+  },
+  "pagination": {
+    "invalid_cursor": "startingAfter không phải là con trỏ hợp lệ"
   }
 }

--- a/apps/api/src/common/filters/global-exception.filter.ts
+++ b/apps/api/src/common/filters/global-exception.filter.ts
@@ -161,7 +161,6 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 interface HttpExceptionResponseObject {
   message?: string | string[];
   error?: string;
-  statusCode?: number;
   code?: string;
   title?: string;
   messageKey?: string;

--- a/apps/api/src/common/filters/global-exception.filter.ts
+++ b/apps/api/src/common/filters/global-exception.filter.ts
@@ -28,6 +28,7 @@ import {
   HTTP_STATUS_CODES,
   HTTP_STATUS_TITLES,
   PROBLEM_CONTENT_TYPE,
+  type HealthChecks,
 } from './problem-details.helper';
 import { resolveFastifyCode, resolveFastifyStatus } from './fastify-error-handler';
 
@@ -40,6 +41,7 @@ interface NormalizedError {
   code: string;
   args?: Record<string, unknown>;
   errors?: ValidationErrorItemDto[];
+  checks?: HealthChecks;
 }
 
 // Maps the HTTP status → i18n key used when a NestJS built-in exception ships only a raw English `message`.
@@ -118,6 +120,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
           instance: request.url,
           requestId: raw.requestId,
           errors: normalized.errors,
+          checks: normalized.checks,
         }),
       );
   }
@@ -229,6 +232,17 @@ function normalizeException(exception: unknown): NormalizedError {
     return { status, title: defaultTitle, detail: res, code: defaultCode };
   }
 
+  const healthChecks = extractFailingHealthChecks(res);
+  if (healthChecks) {
+    return {
+      status,
+      title: defaultTitle,
+      detail: `Unhealthy dependencies: ${Object.keys(healthChecks).join(', ')}`,
+      code: defaultCode,
+      checks: healthChecks,
+    };
+  }
+
   const body = res as HttpExceptionResponseObject;
   const title = typeof body.title === 'string' ? body.title : defaultTitle;
   const code = typeof body.code === 'string' ? body.code : defaultCode;
@@ -253,6 +267,18 @@ function normalizeException(exception: unknown): NormalizedError {
       : exception.message;
 
   return { status, title, detail, code, args: body.args };
+}
+
+// @nestjs/terminus throws ServiceUnavailableException whose response is the HealthCheckResult
+// ({ status, info, error, details }). Returns its failing indicators so the filter can surface them
+// as a `checks` extension instead of flattening the 503 to a bare "Service Unavailable".
+export function extractFailingHealthChecks(res: unknown): HealthChecks | undefined {
+  if (!res || typeof res !== 'object') return undefined;
+  const candidate = res as { status?: unknown; error?: unknown };
+  if (candidate.status !== 'error') return undefined;
+  if (!candidate.error || typeof candidate.error !== 'object') return undefined;
+  const error = candidate.error as HealthChecks;
+  return Object.keys(error).length > 0 ? error : undefined;
 }
 
 function isFastifyLevelError(exception: unknown): exception is FastifyError {

--- a/apps/api/src/common/filters/global-exception.filter.ts
+++ b/apps/api/src/common/filters/global-exception.filter.ts
@@ -174,7 +174,9 @@ function normalizeException(exception: unknown): NormalizedError {
     const body = exception.getResponse() as HttpExceptionResponseObject;
     return {
       status: exception.getStatus(),
-      title: body.title ?? I18N_KEYS.common.unprocessable_entity,
+      // No fallback: the constructor always sets a title, so one here would be unreachable and
+      // would imply a default that does not exist.
+      title: body.title as string,
       detail: body.messageKey ?? (typeof body.message === 'string' ? body.message : undefined),
       code: exception.code,
       args: body.args,

--- a/apps/api/src/common/filters/health-checks-extraction.spec.ts
+++ b/apps/api/src/common/filters/health-checks-extraction.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { extractFailingHealthChecks } from './global-exception.filter';
+
+describe('extractFailingHealthChecks', () => {
+  it('returns the failing indicators from a terminus HealthCheckResult', () => {
+    const result = {
+      status: 'error',
+      info: { database: { status: 'up' }, redis_queue: { status: 'up' } },
+      error: { redis_cache: { status: 'down', message: 'redis_cache check failed' } },
+      details: {
+        database: { status: 'up' },
+        redis_queue: { status: 'up' },
+        redis_cache: { status: 'down', message: 'redis_cache check failed' },
+      },
+    };
+
+    expect(extractFailingHealthChecks(result)).toEqual({
+      redis_cache: { status: 'down', message: 'redis_cache check failed' },
+    });
+  });
+
+  it('returns undefined for a healthy result', () => {
+    expect(
+      extractFailingHealthChecks({ status: 'ok', info: {}, error: {}, details: {} }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the error map is empty despite an error status', () => {
+    expect(extractFailingHealthChecks({ status: 'error', error: {} })).toBeUndefined();
+  });
+
+  it('returns undefined for a non-health exception body', () => {
+    expect(extractFailingHealthChecks({ message: 'nope', code: 'bad_request' })).toBeUndefined();
+    expect(extractFailingHealthChecks('a string')).toBeUndefined();
+    expect(extractFailingHealthChecks(null)).toBeUndefined();
+  });
+});

--- a/apps/api/src/common/filters/problem-details.helper.ts
+++ b/apps/api/src/common/filters/problem-details.helper.ts
@@ -39,6 +39,11 @@ export const HTTP_STATUS_CODES: Record<number, string> = {
   [HttpStatus.GATEWAY_TIMEOUT]: ERROR_CODES.REQUEST_TIMEOUT,
 };
 
+// Per-dependency health breakdown carried on a 503 from the health probes. RFC 9457 extension
+// member — without it the filter would flatten a health failure to a bare "Service Unavailable"
+// and the caller could not tell which dependency is down.
+export type HealthChecks = Record<string, { status: string; message?: string }>;
+
 export interface ProblemDetailsArgs {
   status: number;
   title: string;
@@ -47,6 +52,7 @@ export interface ProblemDetailsArgs {
   instance?: string;
   requestId?: string;
   errors?: ValidationErrorItemDto[];
+  checks?: HealthChecks;
 }
 
 export interface ProblemDetailsBody {
@@ -59,6 +65,7 @@ export interface ProblemDetailsBody {
   requestId?: string;
   timestamp: string;
   errors?: ValidationErrorItemDto[];
+  checks?: HealthChecks;
 }
 
 export function buildProblemDetails(args: ProblemDetailsArgs): ProblemDetailsBody {
@@ -74,6 +81,9 @@ export function buildProblemDetails(args: ProblemDetailsArgs): ProblemDetailsBod
   };
   if (args.errors && args.errors.length > 0) {
     body.errors = args.errors;
+  }
+  if (args.checks && Object.keys(args.checks).length > 0) {
+    body.checks = args.checks;
   }
   return body;
 }

--- a/apps/api/src/common/health/bullmq-health.indicator.ts
+++ b/apps/api/src/common/health/bullmq-health.indicator.ts
@@ -3,6 +3,7 @@ import type { HealthIndicatorResult } from '@nestjs/terminus';
 import { HealthIndicatorService } from '@nestjs/terminus';
 import { ConfigService } from '@nestjs/config';
 import { Queue } from 'bullmq';
+import { redisReconnectStrategy } from '@nestjs-fastify-nx/shared';
 import type { EnvConfig } from '../../config/env.validation';
 import { QUEUE_NAMES } from '../../app/constants/queue.constants';
 
@@ -34,7 +35,9 @@ export class BullMqHealthIndicator implements OnModuleDestroy {
         port: config.get('REDIS_QUEUE_PORT', { infer: true }),
         maxRetriesPerRequest: 1,
         connectTimeout: PROBE_TIMEOUT_MS,
-        retryStrategy: () => null,
+        // A number, not null: null makes ioredis give up reconnecting for good, so one Redis blip
+        // would leave this probe reporting down forever. The timeouts above bound each probe call.
+        retryStrategy: redisReconnectStrategy,
         lazyConnect: true,
       },
       prefix: config.get('REDIS_QUEUE_PREFIX', { infer: true }),

--- a/apps/api/src/common/health/health.controller.ts
+++ b/apps/api/src/common/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpStatus } from '@nestjs/common';
+import { applyDecorators, Controller, Get, HttpStatus } from '@nestjs/common';
 import { HealthCheck, HealthCheckService, MemoryHealthIndicator } from '@nestjs/terminus';
 import { SkipThrottle } from '@nestjs/throttler';
 import { ApiOkResponse, ApiOperation, ApiProperty, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -80,6 +80,20 @@ class LivenessResponseDto {
 
 const PROBLEM_JSON = 'application/problem+json';
 
+// A health failure is a ServiceUnavailableException the global filter renders as problem+json with
+// a `checks` map. @HealthCheck's own swagger is turned off so it cannot document the other shape.
+function ApiServiceUnavailableProblem(description: string) {
+  return applyDecorators(
+    ApiResponse({
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+      description,
+      content: {
+        [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
+      },
+    }),
+  );
+}
+
 @ApiTags('health')
 @SkipThrottle()
 @Public()
@@ -97,20 +111,14 @@ export class HealthController {
   ) {}
 
   @Get()
-  @HealthCheck()
+  @ApiServiceUnavailableProblem('One or more dependencies are unhealthy.')
+  @HealthCheck({ noCache: true, swaggerDocumentation: false })
   @ApiOperation({
     summary: 'Full health check (DB + memory + Redis cache + Redis queue).',
     description:
-      'Returns 200 with the per-indicator breakdown when everything is up; 503 with a Problem Details payload when at least one critical dependency is down.',
+      'Returns 200 with the per-indicator breakdown when everything is up; 503 problem+json (with a `checks` map of the failing dependencies) when at least one critical dependency is down.',
   })
   @ApiOkResponse({ type: HealthCheckResultDto, description: 'All systems healthy.' })
-  @ApiResponse({
-    status: HttpStatus.SERVICE_UNAVAILABLE,
-    description: 'One or more dependencies are unhealthy.',
-    content: {
-      [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
-    },
-  })
   @ApiCommonErrors({ auth: false, forbidden: false, validation: false })
   check() {
     return this.health.check([
@@ -122,7 +130,8 @@ export class HealthController {
   }
 
   @Get('ready')
-  @HealthCheck()
+  @ApiServiceUnavailableProblem('A core dependency is unreachable.')
+  @HealthCheck({ noCache: true, swaggerDocumentation: false })
   @ApiOperation({
     summary: 'Readiness probe (DB primary + Redis cache + Redis queue).',
     description:
@@ -137,13 +146,6 @@ export class HealthController {
     type: HealthCheckResultDto,
     description: 'Core dependencies reachable — pod can serve traffic.',
   })
-  @ApiResponse({
-    status: HttpStatus.SERVICE_UNAVAILABLE,
-    description: 'A core dependency is unreachable.',
-    content: {
-      [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
-    },
-  })
   @ApiCommonErrors({ auth: false, forbidden: false, validation: false })
   readiness() {
     return this.health.check([
@@ -154,7 +156,8 @@ export class HealthController {
   }
 
   @Get('dependencies')
-  @HealthCheck()
+  @ApiServiceUnavailableProblem('A deep dependency is degraded or unreachable.')
+  @HealthCheck({ noCache: true, swaggerDocumentation: false })
   @ApiOperation({
     summary: 'Deep dependency check (BullMQ + pgbouncer + replica lag).',
     description:
@@ -163,13 +166,6 @@ export class HealthController {
       'at once when a shared dependency degrades. Returns 503 when a deep check fails so alert rules can fire.',
   })
   @ApiOkResponse({ type: HealthCheckResultDto, description: 'All deep dependencies healthy.' })
-  @ApiResponse({
-    status: HttpStatus.SERVICE_UNAVAILABLE,
-    description: 'A deep dependency is degraded or unreachable.',
-    content: {
-      [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
-    },
-  })
   @ApiCommonErrors({ auth: false, forbidden: false, validation: false })
   dependencies() {
     return this.health.check([

--- a/apps/api/src/common/health/redis.health.ts
+++ b/apps/api/src/common/health/redis.health.ts
@@ -35,13 +35,11 @@ abstract class BaseRedisHealthIndicator implements OnModuleDestroy {
       port: target.port,
       lazyConnect: true,
       connectTimeout: PROBE_TIMEOUT_MS,
-      // Fail the *probe* fast, but keep the client alive: one retry per command, a short connect
-      // timeout, and withTimeout() below already bound how long isHealthy() can block.
+      // Bounds how long a single probe blocks. Killing the client is NOT how to fail fast:
+      // ioredis reads a non-number from retryStrategy as "stop reconnecting for good", so one
+      // Redis blip would leave this probe reporting down forever and every replica NotReady
+      // until a human restarts it.
       maxRetriesPerRequest: 1,
-      // Never return a non-number. ioredis reads that as "stop reconnecting for good", so a Redis
-      // blip would kill this probe client permanently — the probe then reports down forever, long
-      // after Redis is healthy again, and every replica stays NotReady until someone restarts it.
-      // That turns a seconds-long blip into an outage that only ends by hand.
       retryStrategy: (times: number) =>
         Math.min(times * PROBE_RECONNECT_STEP_MS, PROBE_RECONNECT_CAP_MS),
     });

--- a/apps/api/src/common/health/redis.health.ts
+++ b/apps/api/src/common/health/redis.health.ts
@@ -6,6 +6,8 @@ import Redis from 'ioredis';
 import type { EnvConfig } from '../../config/env.validation';
 
 const PROBE_TIMEOUT_MS = 2_000;
+const PROBE_RECONNECT_STEP_MS = 200;
+const PROBE_RECONNECT_CAP_MS = 2_000;
 
 interface RedisTarget {
   readonly host: string;
@@ -33,8 +35,15 @@ abstract class BaseRedisHealthIndicator implements OnModuleDestroy {
       port: target.port,
       lazyConnect: true,
       connectTimeout: PROBE_TIMEOUT_MS,
+      // Fail the *probe* fast, but keep the client alive: one retry per command, a short connect
+      // timeout, and withTimeout() below already bound how long isHealthy() can block.
       maxRetriesPerRequest: 1,
-      retryStrategy: () => null,
+      // Never return a non-number. ioredis reads that as "stop reconnecting for good", so a Redis
+      // blip would kill this probe client permanently — the probe then reports down forever, long
+      // after Redis is healthy again, and every replica stays NotReady until someone restarts it.
+      // That turns a seconds-long blip into an outage that only ends by hand.
+      retryStrategy: (times: number) =>
+        Math.min(times * PROBE_RECONNECT_STEP_MS, PROBE_RECONNECT_CAP_MS),
     });
     this.redis.on('error', () => {
       // swallow connection errors — surfaced via isHealthy()

--- a/apps/api/src/common/idempotency/register-idempotency.spec.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.spec.ts
@@ -134,9 +134,6 @@ describe('registerIdempotency', () => {
     expect(callCount()).toBe(1);
   });
 
-  // A 2xx with an empty body is a completed mutation. Gating completion on the payload being a
-  // string sent it down the failure path instead, releasing the lock so a retry re-ran the very
-  // side effect the key exists to protect.
   it('completes and replays a 2xx that has no body, running the handler once', async () => {
     const { app, callCount } = await buildApp(redis);
 

--- a/apps/api/src/common/idempotency/register-idempotency.spec.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.spec.ts
@@ -76,6 +76,19 @@ async function buildApp(redis: Redis): Promise<AppSetup> {
     calls += 1;
     return reply.status(504).send({ calls, timeout: true });
   });
+  // A 2xx that carries no body — the shape a DELETE endpoint returns.
+  app.post('/api/v1/nocontent', async (_req, reply) => {
+    calls += 1;
+    return reply.status(204).send();
+  });
+  // A 2xx whose payload reaches onSend as a Buffer rather than a string.
+  app.post('/api/v1/binary', async (_req, reply) => {
+    calls += 1;
+    return reply
+      .status(200)
+      .header('content-type', 'application/octet-stream')
+      .send(Buffer.from('binary-payload'));
+  });
 
   registerIdempotency(app, {
     redis,
@@ -119,6 +132,54 @@ describe('registerIdempotency', () => {
     expect(second.headers['x-request-id']).toMatch(/^[a-f0-9]{32}$/);
     expect(second.headers['x-correlation-id']).toBe(second.headers['x-request-id']);
     expect(callCount()).toBe(1);
+  });
+
+  // A 2xx with an empty body is a completed mutation. Gating completion on the payload being a
+  // string sent it down the failure path instead, releasing the lock so a retry re-ran the very
+  // side effect the key exists to protect.
+  it('completes and replays a 2xx that has no body, running the handler once', async () => {
+    const { app, callCount } = await buildApp(redis);
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/nocontent',
+      headers: KEY_HEADER,
+      payload: { a: 1 },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/nocontent',
+      headers: KEY_HEADER,
+      payload: { a: 1 },
+    });
+
+    expect(first.statusCode).toBe(204);
+    expect(second.statusCode).toBe(204);
+    expect(second.headers['idempotent-replayed']).toBe('true');
+    expect(callCount()).toBe(1);
+  });
+
+  it('keeps the key pending for a 2xx body it cannot replay, so a duplicate conflicts instead of re-running', async () => {
+    const { app, callCount, errors } = await buildApp(redis);
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/binary',
+      headers: KEY_HEADER,
+      payload: { a: 1 },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/binary',
+      headers: KEY_HEADER,
+      payload: { a: 1 },
+    });
+
+    expect(first.statusCode).toBe(200);
+    // 409, not a second execution: releasing the lock here would let the mutation run twice.
+    expect(second.statusCode).toBe(409);
+    expect(callCount()).toBe(1);
+    expect(errors.some((e) => e.includes('cannot replay'))).toBe(true);
   });
 
   it('treats JSON objects with different key order as the same payload', async () => {

--- a/apps/api/src/common/idempotency/register-idempotency.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.ts
@@ -82,9 +82,8 @@ function sendProblem(
 ): FastifyReply {
   const requestId = resolveRequestId(req.headers);
   (req.raw as { requestId?: string }).requestId = requestId;
-  // Same builder the global filter uses. Hand-rolling the body here is how this plugin ended up
-  // answering `type: 'about:blank'` while every Nest-side error answered `/errors/<code>`, for a
-  // field the DTO documents as having one convention.
+  // Same builder the global filter uses — this plugin runs before the Nest pipeline, so nothing
+  // else would give it the shared shape.
   return reply
     .status(status)
     .header('content-type', PROBLEM_CONTENT_TYPE)

--- a/apps/api/src/common/idempotency/register-idempotency.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.ts
@@ -3,6 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type Redis from 'ioredis';
 import { ERROR_CODES } from '@nestjs-fastify-nx/contracts';
+import { buildProblemDetails, PROBLEM_CONTENT_TYPE } from '../filters/problem-details.helper';
 import { resolveCorrelationId, resolveRequestId } from '../logging/request-id';
 import { IdempotencyStore, type AcquireResult } from './idempotency-store';
 
@@ -19,7 +20,6 @@ const REPLAYED_HEADER = 'idempotent-replayed';
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 const SCOPED_PATH_PREFIX = '/api/v1/';
 const MAX_KEY_LENGTH = 255;
-const PROBLEM_CONTENT_TYPE = 'application/problem+json';
 
 interface IdempotencyContext {
   storeKey: string;
@@ -82,20 +82,14 @@ function sendProblem(
 ): FastifyReply {
   const requestId = resolveRequestId(req.headers);
   (req.raw as { requestId?: string }).requestId = requestId;
+  // Same builder the global filter uses. Hand-rolling the body here is how this plugin ended up
+  // answering `type: 'about:blank'` while every Nest-side error answered `/errors/<code>`, for a
+  // field the DTO documents as having one convention.
   return reply
     .status(status)
     .header('content-type', PROBLEM_CONTENT_TYPE)
     .header('x-request-id', requestId)
-    .send({
-      type: 'about:blank',
-      title,
-      status,
-      code,
-      detail,
-      instance: req.url,
-      requestId,
-      timestamp: new Date().toISOString(),
-    });
+    .send(buildProblemDetails({ status, title, detail, code, instance: req.url, requestId }));
 }
 
 // Adds the idempotency hooks directly to the root Fastify instance (NOT via register(), whose

--- a/apps/api/src/common/idempotency/register-idempotency.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.ts
@@ -185,15 +185,28 @@ export function registerIdempotency(fastify: FastifyInstance, options: Idempoten
 
     try {
       const status = reply.statusCode;
-      if (status >= 200 && status < 300 && typeof payload === 'string') {
-        const completed = await store.complete(ctx.storeKey, ctx.ownerToken, {
-          fingerprint: ctx.fingerprint,
-          status,
-          contentType: String(reply.getHeader('content-type') ?? 'application/json'),
-          body: payload,
-        });
-        if (!completed) {
-          reportError('idempotency completion skipped because request no longer owns the lock');
+      const isSuccess = status >= 200 && status < 300;
+      // Branch on status first: a 2xx is a completed mutation regardless of body shape. Gating on
+      // `typeof payload === 'string'` would send an empty-bodied success (204) down the failure
+      // path and release the lock, letting a retry re-run the side effect it already performed.
+      if (isSuccess) {
+        const body = replayableBody(payload);
+        if (body === undefined) {
+          // Streams/Buffers can't be captured for byte-exact replay without consuming them. Leave
+          // the record pending so a duplicate gets 409 rather than re-executing the mutation.
+          reportError(
+            `idempotency cannot replay a non-text ${status} body; leaving key pending until TTL`,
+          );
+        } else {
+          const completed = await store.complete(ctx.storeKey, ctx.ownerToken, {
+            fingerprint: ctx.fingerprint,
+            status,
+            contentType: String(reply.getHeader('content-type') ?? 'application/json'),
+            body,
+          });
+          if (!completed) {
+            reportError('idempotency completion skipped because request no longer owns the lock');
+          }
         }
       } else if (status === HttpStatus.GATEWAY_TIMEOUT) {
         // Timeout cannot cancel the underlying promise. Retain the pending record until its TTL so
@@ -208,4 +221,12 @@ export function registerIdempotency(fastify: FastifyInstance, options: Idempoten
 
     return payload;
   });
+}
+
+// An empty body (204 and friends) replays as an empty string. Anything not already text is not
+// safely capturable here — signalled with undefined so the caller can keep the key pending.
+function replayableBody(payload: unknown): string | undefined {
+  if (payload === null || payload === undefined) return '';
+  if (typeof payload === 'string') return payload;
+  return undefined;
 }

--- a/apps/api/src/common/metrics/bullmq-metrics.listener.ts
+++ b/apps/api/src/common/metrics/bullmq-metrics.listener.ts
@@ -45,33 +45,31 @@ abstract class QueueMetricsListenerBase extends QueueEventsHost {
     super();
   }
 
+  // Map upkeep is deliberately NOT leader-gated: leadership can flip between a job's `active` and
+  // its terminal event, and gating the delete would strand that entry on the ex-leader forever.
+  // Only the metric write is gated — the map is per-replica state, not a global-state metric.
   @OnQueueEvent('active')
   onActive(args: ActiveEvent): void {
-    if (!this.leader.isLeader()) return;
     this.activeAt.set(args.jobId, process.hrtime.bigint());
   }
 
   @OnQueueEvent('completed')
   onCompleted(args: CompletedEvent): void {
-    if (!this.leader.isLeader()) return;
-    this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'completed' });
-    this.observeDuration(args.jobId, 'completed');
+    this.recordTerminal(args.jobId, 'completed');
   }
 
   @OnQueueEvent('failed')
   onFailed(args: FailedEvent): void {
-    if (!this.leader.isLeader()) return;
-    this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'failed' });
-    this.observeDuration(args.jobId, 'failed');
+    this.recordTerminal(args.jobId, 'failed');
   }
 
   @OnQueueEvent('stalled')
   onStalled(args: StalledEvent): void {
-    if (!this.leader.isLeader()) return;
-    this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'stalled' });
     // Stalled jobs get re-claimed elsewhere — drop the local active entry so it can't leak.
     this.activeAt.delete(args.jobId);
     this.sweepStale();
+    if (!this.leader.isLeader()) return;
+    this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'stalled' });
   }
 
   @OnQueueEvent('delayed')
@@ -80,18 +78,25 @@ abstract class QueueMetricsListenerBase extends QueueEventsHost {
     this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status: 'delayed' });
   }
 
-  private observeDuration(jobId: string, status: 'completed' | 'failed'): void {
-    const startedAt = this.activeAt.get(jobId);
-    if (startedAt === undefined) return;
-    this.activeAt.delete(jobId);
-    const elapsedNs = process.hrtime.bigint() - startedAt;
-    const durationSeconds = Number(elapsedNs) / 1e9;
-    // Drop the sample if the active timestamp is impossibly old — keeps the histogram clean.
-    if (elapsedNs > MAX_ACTIVE_AGE_NS) return;
+  private recordTerminal(jobId: string, status: 'completed' | 'failed'): void {
+    const elapsedNs = this.takeElapsed(jobId);
+    if (!this.leader.isLeader()) return;
+
+    this.metrics.bullmqJobsTotal.inc({ queue: this.queueLabel, status });
+    // Drop the sample if the active timestamp is missing (job started before this replica saw it)
+    // or impossibly old — keeps the histogram clean.
+    if (elapsedNs === undefined || elapsedNs > MAX_ACTIVE_AGE_NS) return;
     this.metrics.bullmqJobDurationSeconds.observe(
       { queue: this.queueLabel, status },
-      durationSeconds,
+      Number(elapsedNs) / 1e9,
     );
+  }
+
+  private takeElapsed(jobId: string): bigint | undefined {
+    const startedAt = this.activeAt.get(jobId);
+    if (startedAt === undefined) return undefined;
+    this.activeAt.delete(jobId);
+    return process.hrtime.bigint() - startedAt;
   }
 
   private sweepStale(): void {

--- a/apps/api/src/common/metrics/bullmq-metrics.listener.ts
+++ b/apps/api/src/common/metrics/bullmq-metrics.listener.ts
@@ -45,9 +45,8 @@ abstract class QueueMetricsListenerBase extends QueueEventsHost {
     super();
   }
 
-  // Map upkeep is deliberately NOT leader-gated: leadership can flip between a job's `active` and
-  // its terminal event, and gating the delete would strand that entry on the ex-leader forever.
-  // Only the metric write is gated — the map is per-replica state, not a global-state metric.
+  // Map upkeep is not leader-gated: leadership can flip between `active` and the terminal event,
+  // stranding the entry on the ex-leader. It is per-replica state; only the metric write is gated.
   @OnQueueEvent('active')
   onActive(args: ActiveEvent): void {
     this.activeAt.set(args.jobId, process.hrtime.bigint());

--- a/apps/api/src/common/metrics/metrics-leader.service.ts
+++ b/apps/api/src/common/metrics/metrics-leader.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'node:crypto';
+import { redisReconnectStrategy } from '@nestjs-fastify-nx/shared';
 import Redis from 'ioredis';
 import type { EnvConfig } from '../../config/env.validation';
 
@@ -46,7 +47,7 @@ export class MetricsLeaderService implements OnModuleInit, OnModuleDestroy {
       port: config.get('REDIS_QUEUE_PORT', { infer: true }),
       lazyConnect: true,
       maxRetriesPerRequest: 1,
-      retryStrategy: () => null,
+      retryStrategy: redisReconnectStrategy,
     });
     // Surfaced as leader=false on the next failed tick — never crash the process on a Redis blip.
     this.redis.on('error', () => undefined);

--- a/apps/api/src/common/pipes/validation.pipe.ts
+++ b/apps/api/src/common/pipes/validation.pipe.ts
@@ -22,7 +22,6 @@ export class ProblemDetailsValidationPipe extends ValidationPipe {
       exceptionFactory: (validationErrors: ValidationError[] = []) => {
         const errors = flattenValidationErrors(validationErrors);
         return new UnprocessableEntityException({
-          statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
           code: ERROR_CODES.VALIDATION_FAILED,
           // GlobalExceptionFilter rewrites title/message from these keys based on the resolved locale.
           title: I18N_KEYS.validation.failed_title,

--- a/apps/api/src/common/throttler/throttler-redis.storage.ts
+++ b/apps/api/src/common/throttler/throttler-redis.storage.ts
@@ -5,6 +5,7 @@ import {
   type ThrottlerStorageRedis,
 } from '@nest-lab/throttler-storage-redis';
 import type { ThrottlerStorage } from '@nestjs/throttler';
+import { redisReconnectStrategy } from '@nestjs-fastify-nx/shared';
 import Redis from 'ioredis';
 import type { EnvConfig } from '../../config/env.validation';
 
@@ -25,7 +26,7 @@ export class ThrottlerRedisStorage implements OnModuleDestroy {
       port: config.get('REDIS_CACHE_PORT', { infer: true }),
       db: 1,
       maxRetriesPerRequest: 1,
-      retryStrategy: (times: number) => (times >= 10 ? null : Math.min(times * 200, 3000)),
+      retryStrategy: redisReconnectStrategy,
       enableOfflineQueue: false,
     });
     this.redis.on('error', (err: Error) => {

--- a/apps/api/src/graphql/graphql-error-formatter.spec.ts
+++ b/apps/api/src/graphql/graphql-error-formatter.spec.ts
@@ -18,8 +18,6 @@ function messagesOf(result: ReturnType<ReturnType<typeof createGraphqlErrorForma
 }
 
 describe('createGraphqlErrorFormatter', () => {
-  // The gap this closes: REST masks an unexpected 5xx in production, Mercurius' default formatter
-  // does not, so the same failure disclosed its raw message on one surface and not the other.
   it('masks an unexpected failure in production', () => {
     const leaky = new GraphQLError('connect ECONNREFUSED 10.0.0.5:5432 (postgres)', {
       originalError: new Error('connect ECONNREFUSED 10.0.0.5:5432 (postgres)'),

--- a/apps/api/src/graphql/graphql-error-formatter.spec.ts
+++ b/apps/api/src/graphql/graphql-error-formatter.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { BusinessRuleException } from '@nestjs-fastify-nx/core';
+import { ForbiddenException, HttpException, HttpStatus } from '@nestjs/common';
+import { GraphQLError } from 'graphql';
+import type { MercuriusContext } from 'mercurius';
+import { createGraphqlErrorFormatter } from './graphql-error-formatter';
+
+// defaultErrorFormatter logs through ctx.reply.log — a stub is enough, nothing else is touched.
+const ctx = { reply: { log: { info: () => undefined } } } as unknown as MercuriusContext;
+
+function format(isProduction: boolean, ...errors: GraphQLError[]) {
+  const formatter = createGraphqlErrorFormatter(isProduction);
+  return formatter({ data: null, errors }, ctx);
+}
+
+function messagesOf(result: ReturnType<ReturnType<typeof createGraphqlErrorFormatter>>) {
+  return (result.response.errors ?? []).map((e) => e.message);
+}
+
+describe('createGraphqlErrorFormatter', () => {
+  // The gap this closes: REST masks an unexpected 5xx in production, Mercurius' default formatter
+  // does not, so the same failure disclosed its raw message on one surface and not the other.
+  it('masks an unexpected failure in production', () => {
+    const leaky = new GraphQLError('connect ECONNREFUSED 10.0.0.5:5432 (postgres)', {
+      originalError: new Error('connect ECONNREFUSED 10.0.0.5:5432 (postgres)'),
+      path: ['users'],
+    });
+
+    const result = format(true, leaky);
+
+    expect(messagesOf(result)).toEqual(['Internal server error']);
+    expect(JSON.stringify(result)).not.toMatch(/ECONNREFUSED|postgres|10\.0\.0\.5/);
+  });
+
+  it('keeps the raw message outside production so the failure is debuggable', () => {
+    const leaky = new GraphQLError('connect ECONNREFUSED 10.0.0.5:5432 (postgres)', {
+      originalError: new Error('connect ECONNREFUSED 10.0.0.5:5432 (postgres)'),
+    });
+
+    expect(messagesOf(format(false, leaky))).toEqual([
+      'connect ECONNREFUSED 10.0.0.5:5432 (postgres)',
+    ]);
+  });
+
+  it('leaves a deliberate 4xx alone — it was raised for the client to read', () => {
+    const forbidden = new GraphQLError('Insufficient permissions', {
+      originalError: new ForbiddenException('Insufficient permissions'),
+    });
+    const domain = new GraphQLError('User not found', {
+      originalError: new BusinessRuleException({
+        status: HttpStatus.NOT_FOUND,
+        code: 'user_not_found',
+        violations: [{ path: 'userId', code: 'not_found', message: 'User not found' }],
+      }),
+    });
+
+    expect(messagesOf(format(true, forbidden, domain))).toEqual([
+      'Insufficient permissions',
+      'User not found',
+    ]);
+  });
+
+  it('masks a 5xx HttpException — the status is deliberate, the message is not', () => {
+    const internal = new GraphQLError('Storage upload failed: bucket acl denied', {
+      originalError: new HttpException('Storage upload failed: bucket acl denied', 500),
+    });
+
+    expect(messagesOf(format(true, internal))).toEqual(['Internal server error']);
+  });
+
+  it('leaves a graphql-level error alone — it describes the query the client sent', () => {
+    // No originalError: syntax/validation errors say nothing about our internals.
+    const validation = new GraphQLError('Cannot query field "nope" on type "UserType".');
+
+    expect(messagesOf(format(true, validation))).toEqual([
+      'Cannot query field "nope" on type "UserType".',
+    ]);
+  });
+
+  it('preserves path so a masked error still says which field failed', () => {
+    const leaky = new GraphQLError('internal detail', {
+      originalError: new Error('internal detail'),
+      path: ['users', 0, 'email'],
+    });
+
+    const [error] = format(true, leaky).response.errors ?? [];
+    expect(error?.message).toBe('Internal server error');
+    expect(error?.path).toEqual(['users', 0, 'email']);
+  });
+
+  it('masks only the internal error when errors are mixed', () => {
+    const leaky = new GraphQLError('internal detail', {
+      originalError: new Error('internal detail'),
+    });
+    const forbidden = new GraphQLError('Insufficient permissions', {
+      originalError: new ForbiddenException('Insufficient permissions'),
+    });
+
+    expect(messagesOf(format(true, leaky, forbidden))).toEqual([
+      'Internal server error',
+      'Insufficient permissions',
+    ]);
+  });
+});

--- a/apps/api/src/graphql/graphql-error-formatter.ts
+++ b/apps/api/src/graphql/graphql-error-formatter.ts
@@ -4,17 +4,12 @@ import { defaultErrorFormatter } from 'mercurius';
 import type { MercuriusContext } from 'mercurius';
 import type { ExecutionResult } from 'graphql';
 
-// Matches the REST detail the global filter returns for an unexpected failure.
 const MASKED_MESSAGE = 'Internal server error';
 
 type Execution = ExecutionResult & Required<Pick<ExecutionResult, 'errors'>>;
 
-/**
- * Mirrors GlobalExceptionFilter's REST rule: an error that is not an HttpException — or is a 5xx
- * one — was not deliberately raised for the client, and its message can carry driver or internal
- * detail. A GraphQL-level error (syntax, validation) has no `originalError`; it only describes the
- * query the client itself sent, so it stays verbatim.
- */
+// Same rule GlobalExceptionFilter applies to REST. A GraphQL-level error (syntax, validation) has
+// no originalError and only describes the client's own query, so it is not internal.
 function isInternalFailure(error: GraphQLError): boolean {
   const original = error.originalError;
   if (!original) return false;
@@ -24,9 +19,8 @@ function isInternalFailure(error: GraphQLError): boolean {
   return true;
 }
 
-// Rebuilt rather than mutated: GraphQLError.message is readonly. `originalError` is deliberately
-// dropped — carrying it forward would put the message straight back into the serialized error.
-// Locations and path survive so the client can still tell which field failed.
+// originalError is dropped deliberately — carrying it forward puts the message back into the
+// serialized error.
 function mask(error: GraphQLError): GraphQLError {
   return new GraphQLError(MASKED_MESSAGE, {
     nodes: error.nodes,
@@ -39,13 +33,12 @@ function mask(error: GraphQLError): GraphQLError {
 
 /**
  * Mercurius' default formatter serializes every error's `message` verbatim and has no production
- * masking, so without this an unexpected failure inside a resolver answers a GraphQL client with the
- * raw message while the same failure over REST answers "Internal Server Error".
+ * masking, so without this an unexpected resolver failure answers a GraphQL client with the raw
+ * message while REST answers "Internal Server Error".
  *
- * Masking happens before delegating: the default formatter serializes eagerly (`toJSON()`) and
- * flattens nested validation errors, so after it runs there is no `originalError` left to judge by
- * and no stable index to map back to. Nothing is lost from the logs — GlobalExceptionFilter already
- * logs the full error and reports it to Sentry before re-throwing it into this path.
+ * Masking runs before delegating because the default formatter serializes eagerly and flattens
+ * nested validation errors — afterwards there is no `originalError` left to judge by. Logs are
+ * unaffected: GlobalExceptionFilter already logged and reported the error before re-throwing here.
  */
 export function createGraphqlErrorFormatter(isProduction: boolean) {
   return (execution: Execution, context: MercuriusContext) => {

--- a/apps/api/src/graphql/graphql-error-formatter.ts
+++ b/apps/api/src/graphql/graphql-error-formatter.ts
@@ -1,0 +1,59 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { GraphQLError } from 'graphql';
+import { defaultErrorFormatter } from 'mercurius';
+import type { MercuriusContext } from 'mercurius';
+import type { ExecutionResult } from 'graphql';
+
+// Matches the REST detail the global filter returns for an unexpected failure.
+const MASKED_MESSAGE = 'Internal server error';
+
+type Execution = ExecutionResult & Required<Pick<ExecutionResult, 'errors'>>;
+
+/**
+ * Mirrors GlobalExceptionFilter's REST rule: an error that is not an HttpException — or is a 5xx
+ * one — was not deliberately raised for the client, and its message can carry driver or internal
+ * detail. A GraphQL-level error (syntax, validation) has no `originalError`; it only describes the
+ * query the client itself sent, so it stays verbatim.
+ */
+function isInternalFailure(error: GraphQLError): boolean {
+  const original = error.originalError;
+  if (!original) return false;
+  if (original instanceof HttpException) {
+    return original.getStatus() >= HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+  return true;
+}
+
+// Rebuilt rather than mutated: GraphQLError.message is readonly. `originalError` is deliberately
+// dropped — carrying it forward would put the message straight back into the serialized error.
+// Locations and path survive so the client can still tell which field failed.
+function mask(error: GraphQLError): GraphQLError {
+  return new GraphQLError(MASKED_MESSAGE, {
+    nodes: error.nodes,
+    source: error.source,
+    positions: error.positions,
+    path: error.path,
+    extensions: error.extensions,
+  });
+}
+
+/**
+ * Mercurius' default formatter serializes every error's `message` verbatim and has no production
+ * masking, so without this an unexpected failure inside a resolver answers a GraphQL client with the
+ * raw message while the same failure over REST answers "Internal Server Error".
+ *
+ * Masking happens before delegating: the default formatter serializes eagerly (`toJSON()`) and
+ * flattens nested validation errors, so after it runs there is no `originalError` left to judge by
+ * and no stable index to map back to. Nothing is lost from the logs — GlobalExceptionFilter already
+ * logs the full error and reports it to Sentry before re-throwing it into this path.
+ */
+export function createGraphqlErrorFormatter(isProduction: boolean) {
+  return (execution: Execution, context: MercuriusContext) => {
+    if (!isProduction) return defaultErrorFormatter(execution, context);
+
+    const errors = execution.errors.map((error) =>
+      isInternalFailure(error) ? mask(error) : error,
+    );
+    return defaultErrorFormatter({ ...execution, errors }, context);
+  };
+}

--- a/apps/api/src/graphql/graphql.module.ts
+++ b/apps/api/src/graphql/graphql.module.ts
@@ -6,6 +6,7 @@ import { NoSchemaIntrospectionCustomRule } from 'graphql';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { UsersModule } from '@nestjs-fastify-nx/modules-users';
 import type { EnvConfig } from '../config/env.validation';
+import { createGraphqlErrorFormatter } from './graphql-error-formatter';
 import { UserResolver } from './resolvers/user.resolver';
 
 @Module({
@@ -21,6 +22,10 @@ import { UserResolver } from './resolvers/user.resolver';
           path: '/graphql',
           context: (req: FastifyRequest, reply: FastifyReply) => ({ req, reply }),
           validationRules: isProduction ? [NoSchemaIntrospectionCustomRule] : [],
+          // Mercurius' default formatter has no production masking, so an unexpected resolver
+          // failure would answer with its raw message here while REST answers "Internal Server
+          // Error" for the same failure.
+          errorFormatter: createGraphqlErrorFormatter(isProduction),
         };
       },
     }),

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -240,9 +240,7 @@ async function bootstrap() {
       const requestId = resolveRequestId(req.headers);
       (req.raw as { requestId?: string }).requestId = requestId;
       return {
-        // Built by the shared helper so a rate-limit 429 carries the same shape — and the same
-        // `type` convention — as a 429 raised by the Nest ThrottlerGuard. Hand-rolling this body is
-        // how it came to answer an rfc6585 URL where every other error answers `/errors/<code>`.
+        // Shared helper so a rate-limit 429 matches a ThrottlerGuard 429 byte for byte.
         ...buildProblemDetails({
           status: HttpStatus.TOO_MANY_REQUESTS,
           title: 'Too Many Requests',

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -15,7 +15,7 @@ import { Redis } from 'ioredis';
 import { createHash } from 'node:crypto';
 import { toNodeHandler } from 'better-auth/node';
 import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from '@nestjs-fastify-nx/infra-auth';
-import { intEnv, positiveIntEnv } from '@nestjs-fastify-nx/shared';
+import { intEnv, positiveIntEnv, redisReconnectStrategy } from '@nestjs-fastify-nx/shared';
 import { ERROR_CODES } from '@nestjs-fastify-nx/contracts';
 import { reportFatalError, startSentry } from '@nestjs-fastify-nx/infra-observability';
 import { AppModule } from './app/app.module';
@@ -144,7 +144,7 @@ async function bootstrap() {
       port: config.get('REDIS_CACHE_PORT', { infer: true }),
       db: 5,
       maxRetriesPerRequest: 1,
-      retryStrategy: (times: number) => (times >= 10 ? null : Math.min(times * 200, 3000)),
+      retryStrategy: redisReconnectStrategy,
       enableOfflineQueue: false,
     });
     idempotencyRedis.on('error', (err: Error) => {
@@ -216,7 +216,7 @@ async function bootstrap() {
     port: config.get('REDIS_CACHE_PORT', { infer: true }),
     db: 4,
     maxRetriesPerRequest: 1,
-    retryStrategy: (times: number) => (times >= 10 ? null : Math.min(times * 200, 3000)),
+    retryStrategy: redisReconnectStrategy,
     enableOfflineQueue: false,
   });
   rateLimitRedis.on('error', (err: Error) => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -25,6 +25,7 @@ import { setupSwagger } from './common/swagger/swagger.config';
 import { createBullBoardPlugin } from './common/bull-board/create-bull-board-plugin';
 import { registerIdempotency } from './common/idempotency/register-idempotency';
 import { applyFastifyProblemDetailsHook } from './common/filters/fastify-error-handler';
+import { buildProblemDetails } from './common/filters/problem-details.helper';
 import type { EnvConfig } from './config/env.validation';
 
 const STRICT_AUTH_PATHS = new Set([
@@ -172,16 +173,16 @@ async function bootstrap() {
         .header('content-type', 'application/problem+json')
         .header('x-request-id', requestId)
         .header('retry-after', '10')
-        .send({
-          type: 'about:blank',
-          title: 'Service Unavailable',
-          status: HttpStatus.SERVICE_UNAVAILABLE,
-          code: ERROR_CODES.SERVICE_UNAVAILABLE,
-          detail: 'Server is under heavy load; please retry shortly.',
-          instance: req.url,
-          requestId,
-          timestamp: new Date().toISOString(),
-        });
+        .send(
+          buildProblemDetails({
+            status: HttpStatus.SERVICE_UNAVAILABLE,
+            title: 'Service Unavailable',
+            detail: 'Server is under heavy load; please retry shortly.',
+            code: ERROR_CODES.SERVICE_UNAVAILABLE,
+            instance: req.url,
+            requestId,
+          }),
+        );
     },
   });
 
@@ -239,16 +240,18 @@ async function bootstrap() {
       const requestId = resolveRequestId(req.headers);
       (req.raw as { requestId?: string }).requestId = requestId;
       return {
-        type: 'https://tools.ietf.org/html/rfc6585#section-4',
-        title: 'Too Many Requests',
-        status: HttpStatus.TOO_MANY_REQUESTS,
-        // Match ProblemDetailsDto so rate-limit 429s carry the same shape (and the same `code`,
-        // ERROR_CODES.RATE_LIMITED) as a 429 raised by the Nest ThrottlerGuard.
-        code: ERROR_CODES.RATE_LIMITED,
-        detail: `Rate limit exceeded. Try again in ${Math.ceil(context.ttl / 1000)} seconds.`,
+        // Built by the shared helper so a rate-limit 429 carries the same shape — and the same
+        // `type` convention — as a 429 raised by the Nest ThrottlerGuard. Hand-rolling this body is
+        // how it came to answer an rfc6585 URL where every other error answers `/errors/<code>`.
+        ...buildProblemDetails({
+          status: HttpStatus.TOO_MANY_REQUESTS,
+          title: 'Too Many Requests',
+          detail: `Rate limit exceeded. Try again in ${Math.ceil(context.ttl / 1000)} seconds.`,
+          code: ERROR_CODES.RATE_LIMITED,
+          instance: req.url,
+          requestId,
+        }),
         retryAfter: Math.ceil(context.ttl / 1000),
-        requestId,
-        timestamp: new Date().toISOString(),
       };
     },
     addHeaders: {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -295,14 +295,15 @@ async function bootstrap() {
         .header('content-type', 'application/problem+json')
         .header('retry-after', String(retryAfter))
         .send({
-          type: 'https://tools.ietf.org/html/rfc6585#section-4',
-          title: 'Too Many Requests',
-          status: HttpStatus.TOO_MANY_REQUESTS,
-          code: ERROR_CODES.RATE_LIMITED,
-          detail: `Rate limit exceeded. Try again in ${retryAfter} seconds.`,
+          ...buildProblemDetails({
+            status: HttpStatus.TOO_MANY_REQUESTS,
+            title: 'Too Many Requests',
+            detail: `Rate limit exceeded. Try again in ${retryAfter} seconds.`,
+            code: ERROR_CODES.RATE_LIMITED,
+            instance: req.url,
+            requestId,
+          }),
           retryAfter,
-          requestId,
-          timestamp: new Date().toISOString(),
         });
     } catch (err) {
       if (authRateLimitFailOpen) {
@@ -317,15 +318,16 @@ async function bootstrap() {
         .status(HttpStatus.SERVICE_UNAVAILABLE)
         .header('content-type', 'application/problem+json')
         .header('retry-after', '5')
-        .send({
-          type: 'about:blank',
-          title: 'Service Unavailable',
-          status: HttpStatus.SERVICE_UNAVAILABLE,
-          code: ERROR_CODES.SERVICE_UNAVAILABLE,
-          detail: 'Authentication is temporarily unavailable. Retry shortly.',
-          requestId,
-          timestamp: new Date().toISOString(),
-        });
+        .send(
+          buildProblemDetails({
+            status: HttpStatus.SERVICE_UNAVAILABLE,
+            title: 'Service Unavailable',
+            detail: 'Authentication is temporarily unavailable. Retry shortly.',
+            code: ERROR_CODES.SERVICE_UNAVAILABLE,
+            instance: req.url,
+            requestId,
+          }),
+        );
     }
   });
 
@@ -381,15 +383,15 @@ async function bootstrap() {
         'Better Auth handler threw unexpectedly',
       );
       if (!reply.raw.headersSent) {
-        const body = JSON.stringify({
-          type: 'https://tools.ietf.org/html/rfc7231#section-6.6.1',
-          title: 'Internal Server Error',
-          status: HttpStatus.INTERNAL_SERVER_ERROR,
-          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
-          instance: req.url,
-          requestId,
-          timestamp: new Date().toISOString(),
-        });
+        const body = JSON.stringify(
+          buildProblemDetails({
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            title: 'Internal Server Error',
+            code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+            instance: req.url,
+            requestId,
+          }),
+        );
         reply.raw.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, {
           'Content-Type': 'application/problem+json',
           'Content-Length': Buffer.byteLength(body),

--- a/apps/api/src/websocket/notification.gateway.ts
+++ b/apps/api/src/websocket/notification.gateway.ts
@@ -16,6 +16,7 @@ import Redis from 'ioredis';
 import { ConfigService } from '@nestjs/config';
 import { BETTER_AUTH_INSTANCE } from '@nestjs-fastify-nx/infra-auth';
 import type { BetterAuthInstance } from '@nestjs-fastify-nx/infra-auth';
+import { redisReconnectStrategy } from '@nestjs-fastify-nx/shared';
 import {
   createWsAuthMiddleware,
   renewWsConnectionLease,
@@ -71,25 +72,18 @@ export class NotificationGateway
   ) {}
 
   afterInit(server: Server): void {
-    // null after the cap stops ioredis reconnecting forever on a dead Redis.
-    const retryStrategy = (times: number): number | null =>
-      times >= 10 ? null : Math.min(times * 100, 3000);
     const host = this.config.get('REDIS_CACHE_HOST', { infer: true });
     const port = this.config.get('REDIS_CACHE_PORT', { infer: true });
+    const db = this.config.get('REDIS_PUBSUB_DB', { infer: true });
 
-    this.pubClient = new Redis({
-      host,
-      port,
-      db: this.config.get('REDIS_PUBSUB_DB', { infer: true }),
-      retryStrategy,
-    });
+    this.pubClient = new Redis({ host, port, db, retryStrategy: redisReconnectStrategy });
     this.subClient = this.pubClient.duplicate();
 
     this.rateLimitClient = new Redis({
       host,
       port,
-      db: this.config.get('REDIS_PUBSUB_DB', { infer: true }),
-      retryStrategy,
+      db,
+      retryStrategy: redisReconnectStrategy,
       enableOfflineQueue: false,
     });
 

--- a/apps/scheduler/src/app/app.module.ts
+++ b/apps/scheduler/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { OutboxCleanupTask } from './tasks/outbox-cleanup.task';
 import { SchedulerHealthService } from './health/scheduler-health.service';
 import { SchedulerLeadershipModule } from './leadership/scheduler-leadership.module';
 import { StoredFileCleanupTask } from './tasks/stored-file-cleanup.task';
+import { VerificationCleanupTask } from './tasks/verification-cleanup.task';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { StoredFileCleanupTask } from './tasks/stored-file-cleanup.task';
     OutboxCleanupTask,
     SchedulerHealthService,
     StoredFileCleanupTask,
+    VerificationCleanupTask,
     // Tracing only here — the scheduler has no Prometheus registry, so cqrs_* metrics are
     // skipped (CqrsMetricsRecorderHolder stays unset). See CqrsInstrumentationInitializer.
     CqrsInstrumentationInitializer,

--- a/apps/scheduler/src/app/tasks/verification-cleanup.task.spec.ts
+++ b/apps/scheduler/src/app/tasks/verification-cleanup.task.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { VerificationCleanupTask } from './verification-cleanup.task';
+import type { PrismaService } from '@nestjs-fastify-nx/infra-database';
+
+function makePrismaMock() {
+  return {
+    db: {
+      $executeRawUnsafe: vi.fn(),
+    },
+  } as unknown as PrismaService;
+}
+
+describe('VerificationCleanupTask', () => {
+  let task: VerificationCleanupTask;
+  let prisma: ReturnType<typeof makePrismaMock>;
+
+  beforeEach(() => {
+    prisma = makePrismaMock();
+    task = new VerificationCleanupTask(prisma, { isLeader: () => true } as never);
+  });
+
+  describe('purgeExpiredVerifications', () => {
+    it('issues DELETE filtered on expiresAt past the grace window', async () => {
+      vi.mocked(prisma.db.$executeRawUnsafe).mockResolvedValue(0);
+
+      await task.purgeExpiredVerifications();
+
+      const [sql] = vi.mocked(prisma.db.$executeRawUnsafe).mock.calls[0] as [string, ...unknown[]];
+      expect(sql).toMatch(/DELETE FROM "verifications"/);
+      expect(sql).toMatch(/"expiresAt" < NOW\(\) - \(\$1 \|\| ' days'\)::interval/);
+      expect(sql).toMatch(/LIMIT \$2/);
+    });
+
+    it('passes graceDays as a string parameter and batch size as a positive number', async () => {
+      vi.mocked(prisma.db.$executeRawUnsafe).mockResolvedValue(0);
+
+      await task.purgeExpiredVerifications();
+
+      const [, graceParam, batchParam] = vi.mocked(prisma.db.$executeRawUnsafe).mock.calls[0] as [
+        string,
+        string,
+        number,
+      ];
+
+      expect(typeof graceParam).toBe('string');
+      expect(Number(graceParam)).toBeGreaterThan(0);
+      expect(typeof batchParam).toBe('number');
+      expect(batchParam).toBeGreaterThan(0);
+    });
+
+    it('skips entirely when this replica is not the scheduler leader', async () => {
+      const follower = new VerificationCleanupTask(prisma, { isLeader: () => false } as never);
+
+      await follower.purgeExpiredVerifications();
+
+      expect(prisma.db.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('stops looping when a batch deletes 0 rows', async () => {
+      vi.mocked(prisma.db.$executeRawUnsafe).mockResolvedValueOnce(5).mockResolvedValueOnce(0);
+
+      await task.purgeExpiredVerifications();
+
+      expect(prisma.db.$executeRawUnsafe).toHaveBeenCalledTimes(2);
+    });
+
+    it('accumulates totalPurged across batches', async () => {
+      vi.mocked(prisma.db.$executeRawUnsafe)
+        .mockResolvedValueOnce(1000)
+        .mockResolvedValueOnce(1000)
+        .mockResolvedValueOnce(0);
+
+      const logSpy = vi.spyOn(task['logger'], 'log');
+
+      await task.purgeExpiredVerifications();
+
+      const completeLog = logSpy.mock.calls.find((c) => String(c[0]).includes('complete'));
+      expect(completeLog).toBeDefined();
+      expect(String(completeLog?.[0])).toContain('2000');
+    });
+
+    it('logs partial progress and does not throw when a batch fails mid-loop', async () => {
+      vi.mocked(prisma.db.$executeRawUnsafe)
+        .mockResolvedValueOnce(1000)
+        .mockResolvedValueOnce(500)
+        .mockRejectedValueOnce(new Error('DB connection lost'));
+
+      const errorSpy = vi.spyOn(task['logger'], 'error');
+
+      await expect(task.purgeExpiredVerifications()).resolves.toBeUndefined();
+
+      expect(errorSpy).toHaveBeenCalledOnce();
+      const [msg] = errorSpy.mock.calls[0] as [string];
+      expect(msg).toContain('1500');
+      expect(msg).toMatch(/DB connection lost/);
+    });
+
+    it('does not throw when the very first batch fails', async () => {
+      vi.mocked(prisma.db.$executeRawUnsafe).mockRejectedValue(new Error('fatal'));
+
+      await expect(task.purgeExpiredVerifications()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/scheduler/src/app/tasks/verification-cleanup.task.ts
+++ b/apps/scheduler/src/app/tasks/verification-cleanup.task.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PrismaService } from '@nestjs-fastify-nx/infra-database';
+import { positiveIntEnv } from '@nestjs-fastify-nx/shared';
+import { SchedulerLeaderService } from '../leadership/scheduler-leader.service';
+
+const BATCH_SIZE = positiveIntEnv('VERIFICATION_PURGE_BATCH_SIZE', 1000);
+const MAX_BATCHES = positiveIntEnv('VERIFICATION_PURGE_MAX_BATCHES', 200);
+// Better Auth only deletes a verification row when it is successfully consumed, so every abandoned
+// password-reset / email-verification link would otherwise live in the table forever.
+//
+// Rows are kept for a grace window past expiry rather than deleted the moment they expire: Better
+// Auth distinguishes "expired token" from "unknown token", and deleting on the expiry boundary
+// would downgrade a user who clicks a just-stale link to a generic "invalid token" error.
+const GRACE_DAYS = positiveIntEnv('VERIFICATION_PURGE_GRACE_DAYS', 1);
+
+@Injectable()
+export class VerificationCleanupTask {
+  private readonly logger = new Logger(VerificationCleanupTask.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly leadership: SchedulerLeaderService,
+  ) {}
+
+  // UTC-pinned to guard against host TZ drift; 03:45 keeps it clear of the other purge windows.
+  @Cron('45 3 * * *', { name: 'verification-purge', timeZone: 'UTC' })
+  async purgeExpiredVerifications(): Promise<void> {
+    if (!this.leadership.isLeader()) return;
+    this.logger.log(`Starting verification purge: expiresAt < NOW() - ${GRACE_DAYS} days`);
+
+    let totalPurged = 0;
+    try {
+      // Batched to keep each DELETE's lock footprint small — the same table serves live auth reads.
+      for (let batch = 0; batch < MAX_BATCHES; batch++) {
+        const deleted = await this.prisma.db.$executeRawUnsafe<number>(
+          `DELETE FROM "verifications"
+             WHERE id IN (
+               SELECT id FROM "verifications"
+                WHERE "expiresAt" < NOW() - ($1 || ' days')::interval
+                LIMIT $2
+             )`,
+          String(GRACE_DAYS),
+          BATCH_SIZE,
+        );
+        const n = Number(deleted ?? 0);
+        if (n === 0) break;
+        totalPurged += n;
+      }
+      this.logger.log(`Verification purge complete: ${totalPurged} row(s) deleted`);
+    } catch (err) {
+      this.logger.error(`Verification purge failed after ${totalPurged} deletion(s): ${String(err)}`);
+    }
+  }
+}

--- a/apps/scheduler/src/app/tasks/verification-cleanup.task.ts
+++ b/apps/scheduler/src/app/tasks/verification-cleanup.task.ts
@@ -49,7 +49,9 @@ export class VerificationCleanupTask {
       }
       this.logger.log(`Verification purge complete: ${totalPurged} row(s) deleted`);
     } catch (err) {
-      this.logger.error(`Verification purge failed after ${totalPurged} deletion(s): ${String(err)}`);
+      this.logger.error(
+        `Verification purge failed after ${totalPurged} deletion(s): ${String(err)}`,
+      );
     }
   }
 }

--- a/apps/scheduler/src/app/tasks/verification-cleanup.task.ts
+++ b/apps/scheduler/src/app/tasks/verification-cleanup.task.ts
@@ -6,12 +6,8 @@ import { SchedulerLeaderService } from '../leadership/scheduler-leader.service';
 
 const BATCH_SIZE = positiveIntEnv('VERIFICATION_PURGE_BATCH_SIZE', 1000);
 const MAX_BATCHES = positiveIntEnv('VERIFICATION_PURGE_MAX_BATCHES', 200);
-// Better Auth only deletes a verification row when it is successfully consumed, so every abandoned
-// password-reset / email-verification link would otherwise live in the table forever.
-//
-// Rows are kept for a grace window past expiry rather than deleted the moment they expire: Better
-// Auth distinguishes "expired token" from "unknown token", and deleting on the expiry boundary
-// would downgrade a user who clicks a just-stale link to a generic "invalid token" error.
+// Purged past expiry rather than at it: Better Auth distinguishes an expired token from an unknown
+// one, so deleting on the boundary would answer a just-stale link with "invalid token" instead.
 const GRACE_DAYS = positiveIntEnv('VERIFICATION_PURGE_GRACE_DAYS', 1);
 
 @Injectable()

--- a/apps/scheduler/src/config/env.validation.ts
+++ b/apps/scheduler/src/config/env.validation.ts
@@ -76,6 +76,10 @@ const schedulerEnvSchema = z
     OUTBOX_PURGE_BATCH_SIZE: z.coerce.number().int().min(100).max(10_000).default(1_000),
     OUTBOX_PURGE_MAX_BATCHES: z.coerce.number().int().min(1).max(10_000).default(200),
 
+    VERIFICATION_PURGE_GRACE_DAYS: z.coerce.number().int().min(1).max(365).default(1),
+    VERIFICATION_PURGE_BATCH_SIZE: z.coerce.number().int().min(100).max(10_000).default(1_000),
+    VERIFICATION_PURGE_MAX_BATCHES: z.coerce.number().int().min(1).max(10_000).default(200),
+
     EVENT_PUBLISHER_DRIVER: z.enum(['inprocess', 'outbox']).default('inprocess'),
 
     SENTRY_DSN: z.string().optional().default(''),

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -59,6 +59,11 @@ services:
       TZ: ${TZ:-UTC}
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
+      # Pinned to the in-network port, like REDIS_QUEUE_PORT below. Without it the container
+      # inherits REDIS_CACHE_PORT from env_file, but that value is the HOST publish port — so
+      # repointing it to dodge a clash with another stack would silently break every container's
+      # cache connection while still looking correct in .env.
+      REDIS_CACHE_PORT: '6379'
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'
       STORAGE_ENDPOINT: http://minio:9000
@@ -94,6 +99,11 @@ services:
       LOG_PRETTY: 'false'
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
+      # Pinned to the in-network port, like REDIS_QUEUE_PORT below. Without it the container
+      # inherits REDIS_CACHE_PORT from env_file, but that value is the HOST publish port — so
+      # repointing it to dodge a clash with another stack would silently break every container's
+      # cache connection while still looking correct in .env.
+      REDIS_CACHE_PORT: '6379'
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'
       STORAGE_ENDPOINT: http://minio:9000
@@ -138,6 +148,11 @@ services:
       LOG_PRETTY: 'false'
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
+      # Pinned to the in-network port, like REDIS_QUEUE_PORT below. Without it the container
+      # inherits REDIS_CACHE_PORT from env_file, but that value is the HOST publish port — so
+      # repointing it to dodge a clash with another stack would silently break every container's
+      # cache connection while still looking correct in .env.
+      REDIS_CACHE_PORT: '6379'
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'
       STORAGE_ENDPOINT: http://minio:9000

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -59,10 +59,8 @@ services:
       TZ: ${TZ:-UTC}
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
-      # Pinned to the in-network port, like REDIS_QUEUE_PORT below. Without it the container
-      # inherits REDIS_CACHE_PORT from env_file, but that value is the HOST publish port — so
-      # repointing it to dodge a clash with another stack would silently break every container's
-      # cache connection while still looking correct in .env.
+      # In-network port. Unpinned it falls through to env_file, where the value is the HOST
+      # publish port — repointing that to dodge a clash would then break the cache connection.
       REDIS_CACHE_PORT: '6379'
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'
@@ -99,10 +97,8 @@ services:
       LOG_PRETTY: 'false'
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
-      # Pinned to the in-network port, like REDIS_QUEUE_PORT below. Without it the container
-      # inherits REDIS_CACHE_PORT from env_file, but that value is the HOST publish port — so
-      # repointing it to dodge a clash with another stack would silently break every container's
-      # cache connection while still looking correct in .env.
+      # In-network port. Unpinned it falls through to env_file, where the value is the HOST
+      # publish port — repointing that to dodge a clash would then break the cache connection.
       REDIS_CACHE_PORT: '6379'
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'
@@ -148,10 +144,8 @@ services:
       LOG_PRETTY: 'false'
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
-      # Pinned to the in-network port, like REDIS_QUEUE_PORT below. Without it the container
-      # inherits REDIS_CACHE_PORT from env_file, but that value is the HOST publish port — so
-      # repointing it to dodge a clash with another stack would silently break every container's
-      # cache connection while still looking correct in .env.
+      # In-network port. Unpinned it falls through to env_file, where the value is the HOST
+      # publish port — repointing that to dodge a clash would then break the cache connection.
       REDIS_CACHE_PORT: '6379'
       REDIS_QUEUE_HOST: redis-queue
       REDIS_QUEUE_PORT: '6380'

--- a/docker/compose.observability.yml
+++ b/docker/compose.observability.yml
@@ -102,6 +102,13 @@ services:
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-nestjs-fastify-nx}
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      # SECURITY: `:ro` here is NOT a sandbox. It marks the socket inode read-only, but it does not
+      # filter the API calls made through it — Alloy still holds full read/write Docker Engine
+      # access (inspect any container's env/secrets, create a container with host mounts, i.e.
+      # root-equivalent on this host). Alloy needs the socket for container log discovery, so the
+      # mount stays; the trust boundary is the host itself. Only enable --with-obs on a host you
+      # already trust with root. For a multi-tenant or untrusted host, front this with a
+      # read-only docker-socket-proxy instead of mounting the socket directly.
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - alloy_data:/var/lib/alloy/data
     depends_on:

--- a/docker/compose.observability.yml
+++ b/docker/compose.observability.yml
@@ -102,13 +102,10 @@ services:
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-nestjs-fastify-nx}
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
-      # SECURITY: `:ro` here is NOT a sandbox. It marks the socket inode read-only, but it does not
-      # filter the API calls made through it — Alloy still holds full read/write Docker Engine
-      # access (inspect any container's env/secrets, create a container with host mounts, i.e.
-      # root-equivalent on this host). Alloy needs the socket for container log discovery, so the
-      # mount stays; the trust boundary is the host itself. Only enable --with-obs on a host you
-      # already trust with root. For a multi-tenant or untrusted host, front this with a
-      # read-only docker-socket-proxy instead of mounting the socket directly.
+      # SECURITY: `:ro` guards the socket inode, not the API calls made through it — Alloy holds
+      # full Docker Engine access either way (read any container's secrets, mount the host, i.e.
+      # root). It needs the socket for log discovery, so the mount stays and the trust boundary is
+      # the host. On a shared or untrusted host, front it with a read-only docker-socket-proxy.
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - alloy_data:/var/lib/alloy/data
     depends_on:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ nestjs-fastify-nx/
 │   │   ├── redis/        # Cache + Queue modules + DLQ helpers
 │   │   ├── messaging/    # Event bus, transactional outbox publisher + relay
 │   │   ├── storage/      # S3 / MinIO adapter (StoragePort)
+│   │   ├── i18n/         # I18N_KEYS + locale resolution used by the error filter
 │   │   └── observability/# OpenTelemetry SDK bootstrap, metrics, Sentry init
 │   ├── core/         # Cross-cutting: base classes, decorators, errors
 │   ├── shared/       # Pure utilities (uuid v7, pagination, queue names)
@@ -140,11 +141,14 @@ Enforced by `@nx/enforce-module-boundaries` (see `eslint.config.mjs`):
 | `scope:worker`      | modules, infra, core, shared, contracts                          |
 | `scope:scheduler`   | modules, infra, core, shared, contracts                          |
 | `scope:migration`   | _(empty — intentional; thin prisma deploy wrapper)_              |
-| `scope:composition` | modules, infra, core, shared, contracts                          |
+| `scope:composition` | modules, composition, infra, core, shared, contracts             |
 | `scope:modules`     | infra, core, shared, contracts _(NEVER another `scope:modules`)_ |
 | `scope:infra`       | infra, core, shared, contracts                                   |
 | `scope:core`        | shared                                                           |
 | `scope:contracts`   | shared                                                           |
+| `scope:shared`      | _(empty — leaf of the graph)_                                    |
+| `scope:client`      | shared, contracts _(generated API client)_                       |
+| `scope:tools`       | _(empty — generators depend on nothing internal)_                |
 | `scope:testing`     | modules, infra, core, shared, contracts                          |
 
 Visualised — solid arrows are allowed dependencies; the dashed crossed arrow is
@@ -394,9 +398,15 @@ The same shape applies to the other two flows:
   WebSocket upgrades go through `createWsAuthMiddleware` which validates the
   same session cookie — see `apps/api/src/websocket/ws-auth.adapter.ts`.
 
-**Auth rate-limit**: Fastify hook `fastify-rate-limit` guards `/api/auth/*`
-with configurable per-IP limits (AUTH_RATE_LIMIT_MAX, AUTH_RATE_LIMIT_WINDOW_MS).
-Exceeding the limit returns 429 with `application/problem+json` response.
+**Auth rate-limit**: `@fastify/rate-limit` guards `/api/auth/*` in two tiers.
+Credential routes (sign-in, sign-up, password reset) get a strict bucket keyed by
+IP+email — `AUTH_RATE_LIMIT_MAX` (5) per `AUTH_RATE_LIMIT_WINDOW_MS` — plus a
+looser per-IP ceiling, `AUTH_IP_RATE_LIMIT_MAX` (50), so one address cannot
+enumerate accounts by rotating the email. Every other `/api/auth/*` route uses
+`AUTH_SESSION_RATE_LIMIT_MAX` (60) per `AUTH_SESSION_RATE_LIMIT_WINDOW_MS`.
+Exceeding a limit returns 429 as `application/problem+json`. Registration must
+precede the betterAuthHandler hook: it calls `reply.hijack()`, which skips
+NestJS's ThrottlerGuard entirely.
 
 ## API Response Contract
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -21,21 +21,21 @@ Pino logs are structured JSON, correlated with `X-Request-Id`, and automatically
 
 ### Choosing a status code
 
-The status is part of the API contract — clients branch on it. Pick by what the caller can *do*
+The status is part of the API contract — clients branch on it. Pick by what the caller can _do_
 about the answer, not by what is nearest to hand. `400` and `500` are not defaults.
 
-| Situation                                                                                                          | Status | How                                                             |
-| ------------------------------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------- |
-| Request is malformed — bad JSON, an opaque cursor/token that will not decode, an unparseable header                  | `400`  | `BusinessRuleException` with `status: 400`                       |
-| Body or query failed `class-validator`                                                                               | `422`  | Nothing — `ProblemDetailsValidationPipe` owns it                 |
-| Request understood, but a domain rule says no, or the state it references violates policy                            | `422`  | `BusinessRuleException` (its default)                            |
-| No session, or the session expired — re-authenticating would fix it                                                  | `401`  | `UnauthorizedException`                                          |
-| Session is valid, but this principal may not do this — wrong role, deactivated/banned account                        | `403`  | `ForbiddenException`                                             |
-| Resource does not exist — or exists, but the caller must not learn that it does                                      | `404`  | `BusinessRuleException` with `status: 404` / `NotFoundException` |
-| State conflict a retry could resolve — duplicate key, concurrent update, work still in flight                        | `409`  | `BusinessRuleException` with `status: 409` / `ConflictException` |
-| The **request body itself** is over the size limit                                                                   | `413`  | Fastify body limit — never hand-rolled                           |
-| Rate limit hit                                                                                                       | `429`  | `@fastify/rate-limit` / `ThrottlerGuard`                         |
-| The server broke — DB down, S3 unreachable, a bug                                                                    | `500`  | `InternalServerErrorException`, with no specific `code`          |
+| Situation                                                                                           | Status | How                                                              |
+| --------------------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------- |
+| Request is malformed — bad JSON, an opaque cursor/token that will not decode, an unparseable header | `400`  | `BusinessRuleException` with `status: 400`                       |
+| Body or query failed `class-validator`                                                              | `422`  | Nothing — `ProblemDetailsValidationPipe` owns it                 |
+| Request understood, but a domain rule says no, or the state it references violates policy           | `422`  | `BusinessRuleException` (its default)                            |
+| No session, or the session expired — re-authenticating would fix it                                 | `401`  | `UnauthorizedException`                                          |
+| Session is valid, but this principal may not do this — wrong role, deactivated/banned account       | `403`  | `ForbiddenException`                                             |
+| Resource does not exist — or exists, but the caller must not learn that it does                     | `404`  | `BusinessRuleException` with `status: 404` / `NotFoundException` |
+| State conflict a retry could resolve — duplicate key, concurrent update, work still in flight       | `409`  | `BusinessRuleException` with `status: 409` / `ConflictException` |
+| The **request body itself** is over the size limit                                                  | `413`  | Fastify body limit — never hand-rolled                           |
+| Rate limit hit                                                                                      | `429`  | `@fastify/rate-limit` / `ThrottlerGuard`                         |
+| The server broke — DB down, S3 unreachable, a bug                                                   | `500`  | `InternalServerErrorException`, with no specific `code`          |
 
 The three distinctions that actually get chosen wrong:
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -19,15 +19,74 @@ Pino logs are structured JSON, correlated with `X-Request-Id`, and automatically
 
 ## Error Handling
 
-### Domain & Application Violations
+### Choosing a status code
 
-Throw `BusinessRuleException` from `@nestjs-fastify-nx/core` for domain violations (duplicate email, insufficient balance, etc.). The global exception filter converts it to a 422 or 409 Problem Details response.
+The status is part of the API contract — clients branch on it. Pick by what the caller can *do*
+about the answer, not by what is nearest to hand. `400` and `500` are not defaults.
+
+| Situation                                                                                                          | Status | How                                                             |
+| ------------------------------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------- |
+| Request is malformed — bad JSON, an opaque cursor/token that will not decode, an unparseable header                  | `400`  | `BusinessRuleException` with `status: 400`                       |
+| Body or query failed `class-validator`                                                                               | `422`  | Nothing — `ProblemDetailsValidationPipe` owns it                 |
+| Request understood, but a domain rule says no, or the state it references violates policy                            | `422`  | `BusinessRuleException` (its default)                            |
+| No session, or the session expired — re-authenticating would fix it                                                  | `401`  | `UnauthorizedException`                                          |
+| Session is valid, but this principal may not do this — wrong role, deactivated/banned account                        | `403`  | `ForbiddenException`                                             |
+| Resource does not exist — or exists, but the caller must not learn that it does                                      | `404`  | `BusinessRuleException` with `status: 404` / `NotFoundException` |
+| State conflict a retry could resolve — duplicate key, concurrent update, work still in flight                        | `409`  | `BusinessRuleException` with `status: 409` / `ConflictException` |
+| The **request body itself** is over the size limit                                                                   | `413`  | Fastify body limit — never hand-rolled                           |
+| Rate limit hit                                                                                                       | `429`  | `@fastify/rate-limit` / `ThrottlerGuard`                         |
+| The server broke — DB down, S3 unreachable, a bug                                                                    | `500`  | `InternalServerErrorException`, with no specific `code`          |
+
+The three distinctions that actually get chosen wrong:
+
+- **401 vs 403** — ask whether authenticating again would help. It cannot help a banned account, so
+  that is `403`. Answering `401` traps any client that reacts to it by redirecting to login: it gets
+  a fresh valid session and the very next request `401`s again, forever.
+- **400 vs 422** — ask whether the server understood the request. `{"key":"uploads/a.png"}` is
+  understood perfectly; refusing it because the stored object is oversized is `422`. A cursor that
+  will not base64-decode was never understood at all: `400`.
+- **413 describes the request payload**, nothing the request refers to. A 40-byte confirm call that
+  names an oversized S3 object is `422` — answering `413` tells the client to shrink the wrong thing.
+
+`5xx` responses carry the generic code for their status. Never attach a specific one: the internal
+failure taxonomy is not the client's business.
+
+### Error codes
+
+`code` is what clients branch on programmatically. Set it explicitly whenever the caller could
+reasonably act differently per cause (`invalid_cursor`, `user_not_found`, `idempotency_key_mismatch`).
+Leave it unset when the status alone says everything — the filter then fills in the generic code for
+that status (`unauthorized`, `conflict`, …). Codes are `snake_case`; see `ERROR_CODES`.
+
+### Domain & application violations
+
+Throw `BusinessRuleException` from `@nestjs-fastify-nx/core` for domain violations. It takes an
+options object, and its `errors[]` shape matches validation failures so the frontend renders both
+through one path.
 
 ```typescript
-if (user.email === email) {
-  throw new BusinessRuleException('User already registered with this email', 'duplicate_email');
+if (await this.users.exists(email)) {
+  throw new BusinessRuleException({
+    // Omit `status` for the 422 default. Pass one for any other status — and pass `title` with it,
+    // because the class titles itself "Business rule violation", which only reads right on a 422.
+    status: HttpStatus.CONFLICT,
+    title: I18N_KEYS.common.conflict,
+    code: 'user_already_exists',
+    messageKey: I18N_KEYS.errors.users.already_exists,
+    violations: [
+      {
+        path: 'email',
+        code: 'already_exists',
+        message: 'That email is already registered',
+        messageKey: I18N_KEYS.errors.users.already_exists,
+      },
+    ],
+  });
 }
 ```
+
+Pass `messageKey`/`title` as i18n keys, not literals: `GlobalExceptionFilter` only translates dotted
+strings, so a literal silently ships English to every locale.
 
 ### Input Validation
 
@@ -47,27 +106,43 @@ export class CreateUserDto {
 
 ## DTOs
 
-**One DTO per shape.** Do not create parallel application + presentation DTOs unless there is a clear reason (e.g., an integration event schema differs from the REST request shape).
+**Application and presentation DTOs are separate, deliberately.** An application DTO is the transport
+type a handler returns; a presentation DTO is the HTTP shape. Reusing one for both is what makes the
+application layer import `@nestjs/swagger`, and the layering is gone the moment it does — a handler
+must stay callable from REST, GraphQL, or a queue consumer without dragging HTTP along.
 
 ```typescript
-// libs/modules/users/src/application/dtos/user.dto.ts
-export class UserDto {
+// libs/modules/users/src/application/dtos/user-list-item.dto.ts
+// Pure TS. No @nestjs/swagger, no class-validator — nothing framework-shaped.
+export interface UserListItemDto {
   id: string;
   email: string;
-  name: string;
   role: string;
 }
 
-// DO: use UserDto everywhere
-// DON'T: create UserApplicationDto and UserPresentationDto unless justified
+// libs/modules/users/src/presentation/dto/auth-response.dto.ts
+// Swagger + class-validator decorators live here and nowhere else.
+export class UserListItemResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  role!: string;
+}
 ```
+
+The duplication is the point: it buys the boundary. Sensitive columns are kept out of responses by
+projecting into a purpose-built DTO that simply never declares them — not by `@Exclude`.
 
 **Re-export from module barrel only what is public.** Keep domain entities and repositories private. Command/query **handlers stay private** — they are registered with the global `CommandBus`/`QueryBus` by `CqrsModule.forRoot()`'s explorer and are never injected directly. Export the **command/query classes + their result types** so composition libs and cross-cutting resolvers can dispatch `commandBus.execute(new SomeCommand(...))` / `queryBus.execute(new SomeQuery(...))`. Queries/commands extend `Query<TResult>`/`Command<TResult>` so `execute()` infers the return type.
 
 ```typescript
 // libs/modules/users/src/index.ts
 export { UsersModule } from './users.module';
-export { UserDto } from './application/dtos/user.dto';
+export type { UserListItemDto } from './application/dtos/user-list-item.dto';
 // Query class + result type — consumers dispatch via QueryBus, no handler injection.
 export {
   GetUserProfileQuery,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -193,14 +193,15 @@ For a team that needs persistent access, put the host on a private network (VPN 
 
 1. Merge to `main`
 2. Tag the release: `git tag v1.2.3 && git push origin v1.2.3`
-3. The [release workflow](../.github/workflows/release.yml) automatically:
-   - Builds all 4 images (api, worker, scheduler, migration) with SBOM +
-     max-mode SLSA provenance attestations.
-   - Pushes to GHCR (`ghcr.io/<owner>/<repo>`).
-   - Signs each image with **Cosign keyless** (Sigstore Fulcio) — identity is
-     the workflow ref, recorded in the public Rekor log.
-   - Gates on **Trivy** image scan (HIGH/CRITICAL, fixable only) and
-     **Semgrep** SAST (TS/Node/OWASP rule packs).
+3. The [release workflow](../.github/workflows/release.yml) automatically, per app:
+   - Builds the image into the runner's local daemon — nothing is published yet.
+   - Gates on **Trivy** (HIGH/CRITICAL, fixable only). A failing scan stops here,
+     so a vulnerable image is never pushed and never signed.
+   - Pushes to GHCR (`ghcr.io/<owner>/<repo>`) with SBOM + max-mode SLSA
+     provenance attestations.
+   - Signs the pushed digest with **Cosign keyless** (Sigstore Fulcio) — identity
+     is the workflow ref, recorded in the public Rekor log.
+   - Runs **Semgrep** SAST (TS/Node/OWASP rule packs) as a separate job.
 4. Roll out from your target environment: pull the published tag from GHCR, run
    the migration image against the prod database, then start/restart the
    services. This step is deployment-specific and intentionally left out of CI.

--- a/docs/domain-module-anatomy.md
+++ b/docs/domain-module-anatomy.md
@@ -136,8 +136,9 @@ export class Email extends ValueObject<string> {
 `create()` validates untrusted input; `fromPersistence()` trusts a value
 already stored in the DB.
 
-**Rules**: `ValueObject<T>.equals()` compares by value (`JSON.stringify`), not
-`===`. Keep VOs immutable — no mutator methods.
+**Rules**: `ValueObject<T>.equals()` compares by value — `isDeepStrictEqual` from
+`node:util`, after checking the constructors match — not `===`. Keep VOs
+immutable: no mutator methods.
 
 ### `domain/events/` — domain events
 
@@ -274,7 +275,16 @@ export class GetUserProfileHandler implements IQueryHandler<GetUserProfileQuery,
   async execute(query: GetUserProfileQuery): Promise<UserProfileResult> {
     const user = await this.users.findById(query.userId);
     if (!user) {
-      throw new BusinessRuleException({ status: HttpStatus.NOT_FOUND, code: 'user_not_found', messageKey: I18N_KEYS.errors.users.not_found, violations: [...] });
+      // `title` is required for any non-422 status: the class titles itself with a business-rule
+      // literal that only reads right on its 422 default — and a literal is never translated,
+      // because the filter only translates dotted i18n keys.
+      throw new BusinessRuleException({
+        status: HttpStatus.NOT_FOUND,
+        title: I18N_KEYS.common.not_found,
+        code: 'user_not_found',
+        messageKey: I18N_KEYS.errors.users.not_found,
+        violations: [...],
+      });
     }
     return { id: user.id, email: user.email.toString(), name: user.name, role: user.role, status: user.status, createdAt: user.createdAt, updatedAt: user.updatedAt };
   }
@@ -348,7 +358,9 @@ process.
 export class UserRegisteredListener {
   constructor(@InjectQueue(QUEUE_NAMES.EMAIL_NOTIFICATION) private readonly emailQueue: Queue) {}
 
-  @OnEvent('users.registered', { async: true })
+  // promisify + suppressErrors:false so a throw propagates to EventBusService.publish — the outbox
+  // relay then records lastError and retries. Swallowed here, the event would look delivered.
+  @OnEvent('users.registered', { async: true, promisify: true, suppressErrors: false })
   async handle(event: UserRegistered): Promise<void> {
     const jobId = `welcome-email__${event.eventId}`; // BullMQ rejects ':' — use '__'
     await this.emailQueue.add(
@@ -426,9 +438,11 @@ per resource/route group.
 
 ```typescript
 // presentation/controllers/users.controller.ts
+// No @UseGuards here: BetterAuthGuard and RolesGuard are registered globally as APP_GUARD in
+// apps/api. Routes are authenticated by default — @Public() opts out, @Roles() narrows.
+// @ApiCookieAuth only documents that; it enforces nothing.
 @ApiTags('users')
 @Controller('users')
-@UseGuards(BetterAuthGuard)
 @ApiCookieAuth('session')
 export class UsersController {
   constructor(private readonly queryBus: QueryBus) {}

--- a/docs/domain-module-anatomy.md
+++ b/docs/domain-module-anatomy.md
@@ -435,7 +435,7 @@ export class UsersController {
 
   @Get('me')
   @ApiOkResponse({ type: UserProfileResponseDto, description: 'The current user profile.' })
-  @ApiCommonErrors({ auth: true, forbidden: false, validation: false })
+  @ApiCommonErrors({ auth: true, validation: false })
   getProfile(
     @Req() req: FastifyRequest & { user: AuthenticatedSession },
   ): Promise<UserProfileResponseDto> {

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -4,22 +4,25 @@ Copy `.env.example` to `.env` and fill in the values.
 
 ## Database
 
-| Variable                          | Default                                                   | Required    | Description                                                                  |
-| --------------------------------- | --------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
-| `DATABASE_URL`                    | `postgresql://postgres:postgres@localhost:5432/nestjs_db` | Yes         | PostgreSQL connection string                                                 |
-| `DATABASE_POOL_MAX`               | `20`                                                      | No          | Max pool connections                                                         |
-| `DATABASE_POOL_MIN`               | `0`                                                       | No          | Min pool connections                                                         |
-| `DATABASE_IDLE_TIMEOUT_MS`        | `10000`                                                   | No          | Idle connection timeout                                                      |
-| `DATABASE_CONNECTION_TIMEOUT_MS`  | `5000`                                                    | No          | Connection acquire timeout                                                   |
-| `DATABASE_STATEMENT_TIMEOUT_MS`   | `30000`                                                   | No          | Per-statement timeout                                                        |
-| `DATABASE_APPLICATION_NAME`       | `nestjs-fastify-api`                                      | No          | Surfaced in `pg_stat_activity`                                               |
-| `DB_PASSWORD_FILE`                | —                                                         | No          | Docker/Kubernetes secret file injected into password-less DB URLs            |
-| `DATABASE_SLOW_QUERY_MS`          | `200`                                                     | No          | Logs a `warn` (query template + duration, never params) above this threshold |
-| `DB_REPLICATION_LAG_THRESHOLD_MS` | `30000`                                                   | No          | Deep-health threshold for physical replica replay lag                        |
-| `POSTGRES_USER`                   | `postgres`                                                | Docker only | DB username for Compose                                                      |
-| `POSTGRES_PASSWORD`               | `postgres`                                                | Docker only | DB password for Compose                                                      |
-| `POSTGRES_DB`                     | `nestjs_db`                                               | Docker only | Database name for Compose                                                    |
-| `POSTGRES_PORT`                   | `5432`                                                    | Docker only | Host port for Compose                                                        |
+| Variable                          | Default                                                   | Required    | Description                                                                                           |
+| --------------------------------- | --------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                    | `postgresql://postgres:postgres@localhost:5432/nestjs_db` | Yes         | PostgreSQL connection string                                                                          |
+| `DATABASE_DIRECT_URL`             | —                                                         | No          | Bypasses PgBouncer for migrations; also the feature flag that enables the PgBouncer deep-health check |
+| `DATABASE_REPLICA_URL`            | —                                                         | No          | Read replica. When set, `PrismaService.dbRead` routes lag-tolerant reads here                         |
+| `DATABASE_REPLICA_POOL_MAX`       | `10`                                                      | No          | Max pool connections against the replica                                                              |
+| `DATABASE_POOL_MAX`               | `20`                                                      | No          | Max pool connections                                                                                  |
+| `DATABASE_POOL_MIN`               | `0`                                                       | No          | Min pool connections                                                                                  |
+| `DATABASE_IDLE_TIMEOUT_MS`        | `10000`                                                   | No          | Idle connection timeout                                                                               |
+| `DATABASE_CONNECTION_TIMEOUT_MS`  | `5000`                                                    | No          | Connection acquire timeout                                                                            |
+| `DATABASE_STATEMENT_TIMEOUT_MS`   | `30000`                                                   | No          | Per-statement timeout                                                                                 |
+| `DATABASE_APPLICATION_NAME`       | `nestjs-fastify-api`                                      | No          | Surfaced in `pg_stat_activity`                                                                        |
+| `DB_PASSWORD_FILE`                | —                                                         | No          | Docker/Kubernetes secret file injected into password-less DB URLs                                     |
+| `DATABASE_SLOW_QUERY_MS`          | `200`                                                     | No          | Logs a `warn` (query template + duration, never params) above this threshold                          |
+| `DB_REPLICATION_LAG_THRESHOLD_MS` | `30000`                                                   | No          | Deep-health threshold for physical replica replay lag                                                 |
+| `POSTGRES_USER`                   | `postgres`                                                | Docker only | DB username for Compose                                                                               |
+| `POSTGRES_PASSWORD`               | `postgres`                                                | Docker only | DB password for Compose                                                                               |
+| `POSTGRES_DB`                     | `nestjs_db`                                               | Docker only | Database name for Compose                                                                             |
+| `POSTGRES_PORT`                   | `5432`                                                    | Docker only | Host port for Compose                                                                                 |
 
 ## Redis
 
@@ -90,17 +93,17 @@ Optional. Each provider activates only when **both** its `*_CLIENT_ID` and `*_CL
 
 ## Application
 
-| Variable              | Default                        | Required | Description                                                        |
-| --------------------- | ------------------------------ | -------- | ------------------------------------------------------------------ |
-| `NODE_ENV`            | `development`                  | No       | `development` or `production`                                      |
-| `PORT`                | `3000`                         | No       | HTTP port                                                          |
-| `API_BASE_URL`        | `http://localhost:3000/api/v1` | No       | Generated Axios client base URL for SSR/Node execution             |
-| `TRUST_PROXY_HOPS`    | `0`                            | No       | Trusted reverse-proxy depth; keep `0` when API is exposed directly |
-| `TZ`                  | `UTC`                          | No       | IANA timezone resolved by Node (requires `tzdata` in the image)    |
-| `THROTTLER_ENABLED`   | `true`                         | No       | Toggle the global rate limiter                                     |
-| `THROTTLER_LIMIT`     | `100`                          | No       | Requests per window                                                |
-| `THROTTLER_TTL`       | `60`                           | No       | Window length in seconds                                           |
-| `THROTTLER_FAIL_OPEN` | `true`                         | No       | Permit general API traffic during throttler Redis outages          |
+| Variable              | Default                 | Required | Description                                                                                                                                           |
+| --------------------- | ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NODE_ENV`            | `development`           | No       | `development` or `production`                                                                                                                         |
+| `PORT`                | `3000`                  | No       | HTTP port                                                                                                                                             |
+| `API_BASE_URL`        | `http://localhost:3000` | No       | Origin the generated Axios client targets from SSR/Node. Origin only — the generated operations already carry `/api/v1`, so a path here is sent twice |
+| `TRUST_PROXY_HOPS`    | `0`                     | No       | Trusted reverse-proxy depth; keep `0` when API is exposed directly                                                                                    |
+| `TZ`                  | `UTC`                   | No       | IANA timezone resolved by Node (requires `tzdata` in the image)                                                                                       |
+| `THROTTLER_ENABLED`   | `true`                  | No       | Toggle the global rate limiter                                                                                                                        |
+| `THROTTLER_LIMIT`     | `100`                   | No       | Requests per window                                                                                                                                   |
+| `THROTTLER_TTL`       | `60`                    | No       | Window length in seconds                                                                                                                              |
+| `THROTTLER_FAIL_OPEN` | `true`                  | No       | Permit general API traffic during throttler Redis outages                                                                                             |
 
 ## Rate Limiting & Request Body Limits
 
@@ -179,28 +182,32 @@ safe because command handlers roll back their transaction on error.
 
 ## Eventing & Outbox
 
-| Variable                  | Default     | Required | Description                                                                 |
-| ------------------------- | ----------- | -------- | --------------------------------------------------------------------------- |
-| `EVENT_PUBLISHER_DRIVER`  | `inprocess` | No       | `inprocess` (EventEmitter2) or `outbox` (Postgres outbox + scheduler relay) |
-| `OUTBOX_TX_TIMEOUT_MS`    | `30000`     | No       | Outbox interactive tx timeout (30 sec); increase if events hang in publish  |
-| `OUTBOX_POLL_INTERVAL_MS` | `1000`      | No       | Relay polling cadence                                                       |
-| `OUTBOX_BATCH_SIZE`       | `50`        | No       | Max events relayed per poll                                                 |
-| `OUTBOX_MAX_ATTEMPTS`     | `10`        | No       | Retry budget before an event is parked                                      |
+| Variable                   | Default     | Required | Description                                                                                                     |
+| -------------------------- | ----------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `EVENT_PUBLISHER_DRIVER`   | `inprocess` | No       | `inprocess` (EventEmitter2) or `outbox` (Postgres outbox + scheduler relay)                                     |
+| `OUTBOX_TX_TIMEOUT_MS`     | `30000`     | No       | Outbox interactive tx timeout (30 sec); increase if events hang in publish                                      |
+| `OUTBOX_POLL_INTERVAL_MS`  | `1000`      | No       | Relay polling cadence                                                                                           |
+| `OUTBOX_BATCH_SIZE`        | `50`        | No       | Max events relayed per poll                                                                                     |
+| `OUTBOX_MAX_ATTEMPTS`      | `10`        | No       | Retry budget before an event is parked                                                                          |
+| `OUTBOX_RETENTION_DAYS`    | `7`         | No       | Age after which a **processed** row is hard-deleted (03:15 UTC). Unprocessed rows are never purged by this cron |
+| `OUTBOX_PURGE_BATCH_SIZE`  | `1000`      | No       | Rows deleted per purge batch                                                                                    |
+| `OUTBOX_PURGE_MAX_BATCHES` | `200`       | No       | Batches per purge run — the cap is `BATCH_SIZE × MAX_BATCHES` rows/night                                        |
 
 ## Scheduler cleanup
 
-| Variable                               | Default | Description                                    |
-| -------------------------------------- | ------- | ---------------------------------------------- |
-| `DLQ_ALERT_THRESHOLD`                  | `10`    | Alert threshold per dead-letter queue          |
-| `INACTIVE_USER_RETENTION_DAYS`         | `90`    | Age before inactive users are purged           |
-| `USER_PURGE_BATCH_SIZE`                | `500`   | Users deleted per cleanup batch                |
-| `USER_PURGE_MAX_BATCHES`               | `200`   | Maximum user cleanup batches per run           |
-| `STORED_FILE_CLEANUP_BATCH_SIZE`       | `500`   | Stored-file lifecycle records scanned per hour |
-| `STORED_FILE_FINALIZING_STALE_MINUTES` | `60`    | FINALIZING age considered abandoned            |
-| `STORED_FILE_VERIFYING_STALE_HOURS`    | `24`    | VERIFYING age considered abandoned             |
-| `VERIFICATION_PURGE_GRACE_DAYS`        | `1`     | Age past `expiresAt` before a token is deleted |
-| `VERIFICATION_PURGE_BATCH_SIZE`        | `1000`  | Verification rows deleted per batch            |
-| `VERIFICATION_PURGE_MAX_BATCHES`       | `200`   | Maximum verification purge batches per run     |
+| Variable                               | Default | Description                                      |
+| -------------------------------------- | ------- | ------------------------------------------------ |
+| `AUDIT_LOG_RETENTION_MONTHS`           | `12`    | Monthly `audit_logs` partitions kept before DROP |
+| `DLQ_ALERT_THRESHOLD`                  | `10`    | Alert threshold per dead-letter queue            |
+| `INACTIVE_USER_RETENTION_DAYS`         | `90`    | Age before inactive users are purged             |
+| `USER_PURGE_BATCH_SIZE`                | `500`   | Users deleted per cleanup batch                  |
+| `USER_PURGE_MAX_BATCHES`               | `200`   | Maximum user cleanup batches per run             |
+| `STORED_FILE_CLEANUP_BATCH_SIZE`       | `500`   | Stored-file lifecycle records scanned per hour   |
+| `STORED_FILE_FINALIZING_STALE_MINUTES` | `60`    | FINALIZING age considered abandoned              |
+| `STORED_FILE_VERIFYING_STALE_HOURS`    | `24`    | VERIFYING age considered abandoned               |
+| `VERIFICATION_PURGE_GRACE_DAYS`        | `1`     | Age past `expiresAt` before a token is deleted   |
+| `VERIFICATION_PURGE_BATCH_SIZE`        | `1000`  | Verification rows deleted per batch              |
+| `VERIFICATION_PURGE_MAX_BATCHES`       | `200`   | Maximum verification purge batches per run       |
 
 ## Bull Board
 
@@ -212,30 +219,30 @@ safe because command handlers roll back their transaction on error.
 
 ## Observability
 
-| Variable                         | Default                 | Required | Description                                                                                                                                                          |
-| -------------------------------- | ----------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LOG_LEVEL`                      | `info`                  | No       | pino log level: `trace`, `debug`, `info`, `warn`, `error`                                                                                                            |
-| `LOG_PRETTY`                     | `true`                  | No       | Pretty-print host development logs; Compose overrides this to `false` for structured container logs                                                                  |
-| `COMPOSE_PROJECT_NAME`           | `nestjs-fastify-nx`     | No       | Prefix for Compose containers, networks, volumes, and locally built image tags                                                                                       |
-| `SWARM_STACK_NAME`               | `app`                   | No       | Stack namespace used by `scripts/swarm-local-test.sh`; independent from the Compose project name                                                                     |
-| `PROD_STARTUP_TIMEOUT_SECONDS`   | `120`                   | No       | Maximum time `build-prod.sh` waits for the production stack to become healthy                                                                                        |
-| `ENABLE_METRICS`                 | `false`                 | No       | Expose `/metrics` for Prometheus (excluded from `api/v1` prefix)                                                                                                     |
-| `METRICS_ALLOW_CIDRS`            | —                       | No       | Comma-separated CIDR ranges allowed to hit `/metrics` (empty=closed)                                                                                                 |
-| `OTEL_ENABLED`                   | `false`                 | No       | Bootstrap the OpenTelemetry SDK                                                                                                                                      |
-| `OTEL_SERVICE_NAME`              | `nestjs-fastify-api`    | No       | Reported service name                                                                                                                                                |
-| `OTEL_SERVICE_NAMESPACE`         | `app`                   | No       | Reported service namespace                                                                                                                                           |
-| `OTEL_SERVICE_VERSION`           | `0.0.0`                 | No       | Release/version attached to OTel resources and Sentry events                                                                                                         |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`    | `http://localhost:4318` | No       | OTLP/HTTP collector endpoint                                                                                                                                         |
-| `OTEL_EXPORTER_OTLP_HEADERS`     | —                       | No       | Optional collector auth headers                                                                                                                                      |
-| `OTEL_TRACES_SAMPLER_RATIO`      | `1`                     | No       | Head sampling ratio for **new** traces. Keep `1` with Collector tail sampling; discarded head traces cannot be recovered                                             |
-| `OTEL_TRUST_INBOUND_TRACEPARENT` | `false`                 | No       | Trust client `traceparent`/`baggage`. Keep `false` on a public edge; `true` only behind a trusted mesh/gateway                                                       |
-| `OTEL_METRICS_EXPORT_ENABLED`    | `false`                 | No       | Push OTLP metrics from this process. Keep `false` for the API (prom-client `/metrics` is source of truth); `true` for worker/scheduler which have no scrape endpoint |
-| `OTEL_DEBUG`                     | `false`                 | No       | Verbose SDK logging                                                                                                                                                  |
-| `TRUST_INBOUND_REQUEST_ID`       | `false`                 | No       | Accept sanitized `X-Request-Id` from a trusted gateway; keep false for public callers                                                                                |
-| `GRAFANA_ADMIN_PASSWORD`         | `admin`                 | No       | Local Grafana admin password; must be replaced on shared/remote hosts                                                                                                |
-| `SENTRY_DSN`                     | —                       | No       | Sentry DSN; leave empty to disable                                                                                                                                   |
-| `SENTRY_TRACES_SAMPLE_RATE`      | `0.1`                   | No       | Sentry tracing sample rate                                                                                                                                           |
-| `SENTRY_ENVIRONMENT`             | `development`           | No       | Reported Sentry environment tag                                                                                                                                      |
+| Variable                         | Default                                  | Required | Description                                                                                                                                                          |
+| -------------------------------- | ---------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOG_LEVEL`                      | `info`                                   | No       | pino log level: `trace`, `debug`, `info`, `warn`, `error`                                                                                                            |
+| `LOG_PRETTY`                     | `true`                                   | No       | Pretty-print host development logs; Compose overrides this to `false` for structured container logs                                                                  |
+| `COMPOSE_PROJECT_NAME`           | `nestjs-fastify-nx`                      | No       | Prefix for Compose containers, networks, volumes, and locally built image tags                                                                                       |
+| `SWARM_STACK_NAME`               | `app`                                    | No       | Stack namespace used by `scripts/swarm-local-test.sh`; independent from the Compose project name                                                                     |
+| `PROD_STARTUP_TIMEOUT_SECONDS`   | `120`                                    | No       | Maximum time `build-prod.sh` waits for the production stack to become healthy                                                                                        |
+| `ENABLE_METRICS`                 | `false`                                  | No       | Expose `/metrics` for Prometheus (excluded from `api/v1` prefix)                                                                                                     |
+| `METRICS_ALLOW_CIDRS`            | —                                        | No       | Comma-separated CIDR ranges allowed to hit `/metrics` (empty=closed)                                                                                                 |
+| `OTEL_ENABLED`                   | `false`                                  | No       | Bootstrap the OpenTelemetry SDK                                                                                                                                      |
+| `OTEL_SERVICE_NAME`              | `nestjs-fastify-api`                     | No       | Reported service name                                                                                                                                                |
+| `OTEL_SERVICE_NAMESPACE`         | `app`                                    | No       | Reported service namespace                                                                                                                                           |
+| `OTEL_SERVICE_VERSION`           | `0.0.0`                                  | No       | Release/version attached to OTel resources and Sentry events                                                                                                         |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`    | `http://localhost:4318`                  | No       | OTLP/HTTP collector endpoint                                                                                                                                         |
+| `OTEL_EXPORTER_OTLP_HEADERS`     | —                                        | No       | Optional collector auth headers                                                                                                                                      |
+| `OTEL_TRACES_SAMPLER_RATIO`      | `1`                                      | No       | Head sampling ratio for **new** traces. Keep `1` with Collector tail sampling; discarded head traces cannot be recovered                                             |
+| `OTEL_TRUST_INBOUND_TRACEPARENT` | `false`                                  | No       | Trust client `traceparent`/`baggage`. Keep `false` on a public edge; `true` only behind a trusted mesh/gateway                                                       |
+| `OTEL_METRICS_EXPORT_ENABLED`    | `false`                                  | No       | Push OTLP metrics from this process. Keep `false` for the API (prom-client `/metrics` is source of truth); `true` for worker/scheduler which have no scrape endpoint |
+| `OTEL_DEBUG`                     | `false`                                  | No       | Verbose SDK logging                                                                                                                                                  |
+| `TRUST_INBOUND_REQUEST_ID`       | `false`                                  | No       | Accept sanitized `X-Request-Id` from a trusted gateway; keep false for public callers                                                                                |
+| `GRAFANA_ADMIN_PASSWORD`         | `admin`                                  | No       | Local Grafana admin password; must be replaced on shared/remote hosts                                                                                                |
+| `SENTRY_DSN`                     | —                                        | No       | Sentry DSN; leave empty to disable                                                                                                                                   |
+| `SENTRY_TRACES_SAMPLE_RATE`      | `0.01` (api, scheduler) · `0.1` (worker) | No       | Sentry tracing sample rate. The api default is deliberately 1%: at 1k RPS, 0.1 burns ~26M traces/day                                                                 |
+| `SENTRY_ENVIRONMENT`             | `development`                            | No       | Reported Sentry environment tag                                                                                                                                      |
 
 ## CI / Nx Cloud
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -198,6 +198,9 @@ safe because command handlers roll back their transaction on error.
 | `STORED_FILE_CLEANUP_BATCH_SIZE`       | `500`   | Stored-file lifecycle records scanned per hour |
 | `STORED_FILE_FINALIZING_STALE_MINUTES` | `60`    | FINALIZING age considered abandoned            |
 | `STORED_FILE_VERIFYING_STALE_HOURS`    | `24`    | VERIFYING age considered abandoned             |
+| `VERIFICATION_PURGE_GRACE_DAYS`        | `1`     | Age past `expiresAt` before a token is deleted |
+| `VERIFICATION_PURGE_BATCH_SIZE`        | `1000`  | Verification rows deleted per batch            |
+| `VERIFICATION_PURGE_MAX_BATCHES`       | `200`   | Maximum verification purge batches per run     |
 
 ## Bull Board
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Docker Desktop (required for PostgreSQL, Redis, MinIO)
-- Node.js 22+ and pnpm 10.33+ (`corepack enable && corepack prepare pnpm@10.33.0 --activate`)
+- Node.js 24+ and pnpm 10.33+ (`corepack enable && corepack prepare pnpm@10.33.0 --activate`)
 
 ## Setup
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -98,7 +98,7 @@ redis-cli -h $REDIS_QUEUE_HOST -p $REDIS_QUEUE_PORT
 5. Purge genuinely unrecoverable jobs (data from a bad deploy) after confirming replay is safe:
    Bull Board → "Clean" → select "failed" state → confirm.
 
-**Escalation:** If the queue fills faster than the worker can drain (sustained spike), scale the worker replicas via Coolify or increase `BULLMQ_CONCURRENCY`. Alert the team if a runaway job producer is suspected.
+**Escalation:** If the queue fills faster than the worker can drain (sustained spike), scale the worker replicas via your orchestrator or increase `BULLMQ_CONCURRENCY`. Alert the team if a runaway job producer is suspected.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -7,17 +7,21 @@ Operational runbook for on-call engineers. Each section follows the pattern:
 
 ## 1. Outbox stuck
 
-**Symptom:** Domain events stop flowing. Downstream listeners (audit-log, notifications) are silent. `outbox_events` rows accumulate with `processed_at IS NULL`.
+**Symptom:** Domain events stop flowing. Downstream listeners (audit-log, notifications) are silent. `outbox_events` rows accumulate with `"processedAt" IS NULL`.
 
 **Diagnostic:**
 
+Prisma maps the table to snake_case but leaves column names camelCase, so every column here must
+stay double-quoted — unquoted, Postgres folds it to lowercase and answers
+`column "event_type" does not exist`.
+
 ```sql
 -- Find events that have exhausted retry attempts
-SELECT id, event_type, aggregate_id, attempts, created_at, last_error
+SELECT id, "eventType", "aggregateId", attempts, "createdAt", "lastError"
 FROM outbox_events
-WHERE processed_at IS NULL
+WHERE "processedAt" IS NULL
   AND attempts >= 10
-ORDER BY created_at ASC
+ORDER BY "createdAt" ASC
 LIMIT 50;
 
 -- Count stuck vs in-flight events
@@ -25,7 +29,7 @@ SELECT
   CASE WHEN attempts >= 10 THEN 'exhausted' ELSE 'retrying' END AS state,
   COUNT(*)
 FROM outbox_events
-WHERE processed_at IS NULL
+WHERE "processedAt" IS NULL
 GROUP BY 1;
 ```
 
@@ -42,14 +46,14 @@ docker compose logs scheduler --tail=200 | grep -i "outbox\|error\|failed"
 ```sql
 -- Reset specific event types for replay
 UPDATE outbox_events
-SET attempts = 0, last_error = NULL
-WHERE processed_at IS NULL
-  AND event_type = 'users.registered'
+SET attempts = 0, "lastError" = NULL
+WHERE "processedAt" IS NULL
+  AND "eventType" = 'users.registered'
   AND attempts >= 10;
 ```
 
 3. The scheduler's outbox relay picks up rows with `attempts < OUTBOX_MAX_ATTEMPTS` on the next poll cycle (`OUTBOX_POLL_INTERVAL_MS`, default 1 s).
-4. Monitor `processed_at` population over the next minute.
+4. Monitor `"processedAt"` population over the next minute.
 
 **Escalation:** If events are still stuck after reset, check `OUTBOX_TX_TIMEOUT_MS` (default 30 s) — a too-short timeout causes P2028 rollback loops. Increase and redeploy.
 
@@ -105,37 +109,44 @@ redis-cli -h $REDIS_QUEUE_HOST -p $REDIS_QUEUE_PORT
 **Diagnostic:**
 
 ```bash
-# Check audit-log listener logs for subscription errors
-docker compose logs api --tail=500 | grep -i "audit"
+# Check audit-log listener logs for subscription errors.
+# With EVENT_PUBLISHER_DRIVER=outbox the listener runs in the SCHEDULER — that is where the relay
+# republishes events. Check api only when running the inprocess driver.
+docker compose logs scheduler --tail=500 | grep -i "audit"
 
 # Check if outbox relay is delivering the events
 docker compose logs scheduler --tail=200 | grep "outbox"
 ```
 
 ```sql
--- Check if outbox has the event but audit_logs does not
-SELECT o.event_type, o.aggregate_id, o.processed_at, o.last_error
+-- Check if outbox has the event but audit_logs does not.
+-- AuditLogListener writes the event's aggregateId to "userId" and its eventType to action, so those
+-- are what the two tables join on — audit_logs has no entity/aggregate column of its own.
+SELECT o."eventType", o."aggregateId", o."processedAt", o."lastError"
 FROM outbox_events o
-WHERE o.event_type LIKE 'users.%'
-  AND o.created_at > NOW() - INTERVAL '1 hour'
+WHERE o."eventType" LIKE 'users.%'
+  AND o."createdAt" > NOW() - INTERVAL '1 hour'
   AND NOT EXISTS (
     SELECT 1 FROM audit_logs a
-    WHERE a.entity_id = o.aggregate_id
-      AND a.created_at > o.created_at - INTERVAL '5 seconds'
+    -- audit_logs."userId" is uuid, outbox_events."aggregateId" is text; cast the uuid side, since
+    -- casting the text side throws outright on any aggregate id that is not a uuid.
+    WHERE a."userId"::text = o."aggregateId"
+      AND a.action = o."eventType"
+      AND a."createdAt" > o."createdAt" - INTERVAL '5 seconds'
   )
-ORDER BY o.created_at DESC
+ORDER BY o."createdAt" DESC
 LIMIT 20;
 ```
 
 **Action:**
 
-1. If outbox rows show `processed_at IS NOT NULL` but audit rows are absent: the audit listener threw an error silently. Check for schema mismatch or a bug in the listener — redeploy after fix.
-2. If outbox rows show `processed_at IS NULL`: the relay is stuck — follow the **Outbox stuck** runbook section above.
-3. To replay a specific event, reset its `attempts` and `processed_at`:
+1. If outbox rows show `"processedAt" IS NOT NULL` but audit rows are absent: the audit listener threw an error silently. Check for schema mismatch or a bug in the listener — redeploy after fix.
+2. If outbox rows show `"processedAt" IS NULL`: the relay is stuck — follow the **Outbox stuck** runbook section above.
+3. To replay a specific event, reset its `attempts` and `"processedAt"`:
 
 ```sql
 UPDATE outbox_events
-SET attempts = 0, processed_at = NULL, last_error = NULL
+SET attempts = 0, "processedAt" = NULL, "lastError" = NULL
 WHERE id = '<event-uuid>';
 ```
 
@@ -170,8 +181,11 @@ docker compose logs redis-queue --tail=100
 
 **Fallback behavior while Redis is down:**
 
-- **Session auth**: Better Auth falls back to DB verification (slower, higher DB load).
+- **Session auth**: unaffected. Better Auth is not configured with `secondaryStorage`, so sessions
+  always resolve against Postgres — there is no Redis path to lose.
 - **BullMQ**: Jobs queue in memory briefly; if the connection times out, new job enqueues fail with a 500.
+  The queue client retries reconnecting indefinitely with a 3 s cap, so it recovers on its own once
+  Redis is back — no restart needed.
 - **Cache (redis-cache)**: Cache misses — all reads go to DB. Expect elevated DB CPU.
 - **Socket.io pub/sub**: Disconnects; WebSocket clients will need to reconnect.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,6 @@ and in **CI** (gate). A clean local run mirrors the CI gate.
 | --- | -------------- | ------------- | ---------------------------------- | -------------------------------------- |
 | 1   | Secrets        | Gitleaks      | `scripts/security/scan-secrets.sh` | `ci.yml` (`secret-scan` job, lefthook) |
 | 2   | Dependencies   | OSV-Scanner   | `scripts/security/scan-deps.sh`    | `ci.yml` (`dep-scan` job)              |
-| 2   | Dependencies   | `pnpm audit`  | (built-in)                         | `ci.yml` (main job)                    |
 | 3   | SAST           | Semgrep       | `scripts/security/scan-sast.sh`    | `release.yml` (`static-analysis`)      |
 | 4   | Container CVEs | Trivy         | `scripts/security/scan-images.sh`  | `release.yml` (`build-and-push`)       |
 | 5   | Supply chain   | Cosign + SLSA | `scripts/security/sign-images.sh`  | `release.yml` (sign step)              |
@@ -21,8 +20,10 @@ Run the whole stack locally: `./scripts/security/scan-all.sh`.
 
 ### Gitleaks — secrets
 
-API keys, tokens, private keys committed to the repo. Pre-commit hook scans
-staged hunks; pre-push hook scans full history; CI scans the entire diff.
+API keys, tokens, private keys committed to the repo. The pre-push hook scans the
+full history; CI scans the entire diff. There is deliberately no Gitleaks step on
+`pre-commit` — lefthook keeps that hook to `lint-staged` + `typecheck` so commits
+stay fast, and push is the last point before anything leaves the machine.
 
 ```bash
 ./scripts/security/scan-secrets.sh           # full repo + history
@@ -117,8 +118,8 @@ back to a specific commit, workflow run, and signing identity.
 ./scripts/security/scan-images.sh
 ```
 
-Lefthook wires Gitleaks into `pre-commit` (staged hunks) and `pre-push`
-(full history). To run hooks manually:
+Lefthook wires Gitleaks into `pre-push` (full history). `pre-commit` runs
+`lint-staged` + `typecheck`; `commit-msg` runs commitlint. To run hooks manually:
 
 ```bash
 pnpm exec lefthook run pre-commit
@@ -131,7 +132,7 @@ pnpm exec lefthook run pre-push
 PR / push
   ├── secret-scan        (gitleaks-action)
   ├── dep-scan           (osv-scanner-action)
-  └── main               (lint, typecheck, test, build, pnpm audit)
+  └── main               (sync check, format, lint, typecheck, test, build)
 
 tag v*.*.*
   ├── prime-build-cache  (shared build-prod stage → gha cache)

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,7 +12,7 @@ and in **CI** (gate). A clean local run mirrors the CI gate.
 | 2   | Dependencies   | OSV-Scanner   | `scripts/security/scan-deps.sh`    | `ci.yml` (`dep-scan` job)              |
 | 2   | Dependencies   | `pnpm audit`  | (built-in)                         | `ci.yml` (main job)                    |
 | 3   | SAST           | Semgrep       | `scripts/security/scan-sast.sh`    | `release.yml` (`static-analysis`)      |
-| 4   | Container CVEs | Trivy         | `scripts/security/scan-images.sh`  | `release.yml` (`security-scan`)        |
+| 4   | Container CVEs | Trivy         | `scripts/security/scan-images.sh`  | `release.yml` (`build-and-push`)       |
 | 5   | Supply chain   | Cosign + SLSA | `scripts/security/sign-images.sh`  | `release.yml` (sign step)              |
 
 Run the whole stack locally: `./scripts/security/scan-all.sh`.
@@ -75,6 +75,12 @@ uploads SARIF to GitHub Security). The local `build-*.sh` scripts deliberately
 skip it to keep the inner loop fast — run `scripts/security/scan-images.sh`
 manually when you want a pre-push check.
 
+The scan is a **pre-push gate**: `build-and-push` builds each image into the
+runner's local daemon, scans it, and only pushes to GHCR (then cosign-signs it)
+once Trivy is clean. A failing scan therefore publishes nothing — there is no
+window in which a vulnerable, signed `latest` is pullable, and nothing needs
+retracting. The push step is a cache hit on the layers the scan build produced.
+
 ### Cosign — supply-chain signatures
 
 Production images are signed with **keyless OIDC** via Sigstore Fulcio in
@@ -128,12 +134,18 @@ PR / push
   └── main               (lint, typecheck, test, build, pnpm audit)
 
 tag v*.*.*
-  ├── build-and-push     (buildx + SBOM + provenance attestations)
-  │     └── cosign sign  (keyless via Fulcio OIDC)
-  ├── security-scan      (Trivy SARIF → GitHub Security)
-  ├── static-analysis    (Semgrep, error-only gate)
-  └── migrate-and-deploy (gated on the four above)
+  ├── prime-build-cache  (shared build-prod stage → gha cache)
+  ├── build-and-push     (per app: build local → Trivy gate → push → cosign sign)
+  │     ├── build (load, no push)   buildx into the runner's daemon
+  │     ├── trivy                   SARIF → GitHub Security; fails the job on CRITICAL/HIGH
+  │     ├── push                    only if Trivy passed; SBOM + provenance attestations
+  │     └── cosign sign             keyless via Fulcio OIDC
+  └── static-analysis    (Semgrep, error-only gate)
 ```
+
+Release stops at signed, scanned images on GHCR. Database migration and rollout
+are deployment-specific and intentionally not wired into this workflow — see
+`docs/deployment.md`.
 
 ## Tuning
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -134,38 +134,13 @@ wraps each migration in its own transaction, so the inner transaction
 conflicts. Remove the explicit transaction markers — the migration's
 statements run atomically already.
 
-### UUID migration fails on a dev database with legacy ids
-
-Symptom: `invalid input syntax for type uuid: "<some-non-uuid-string>"` while
-applying `20260428000002_uuid_pks`.
-
-Cause: rows in `users` or `audit_logs` have ids that pre-date the UUIDv7
-switch (CUID, ULID, etc.). For dev databases only, clean them out:
-
-```sql
-DELETE FROM users
-WHERE id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
-```
-
-For production rollouts, do NOT delete data — instead, run a one-off backfill
-that rewrites each row's id to a UUIDv7 before applying the migration.
-
-### Outbox migration fails with `unique violation` on `outbox_events.id`
-
-Symptom: pre-existing CUID-format ids fail the `id::uuid` cast.
-
-Resolution: drain the outbox before deploying. Wait until
-`SELECT count(*) FROM outbox_events WHERE "processedAt" IS NULL` returns 0,
-then apply the migration. The migration deletes already-processed rows whose
-ids would otherwise block the type change.
-
 ### `foreign key constraint cannot be implemented`
 
 Symptom appears mostly on dev DBs after switching between feature branches.
 
 Cause: tables created by another branch (e.g., `sessions`, `accounts`,
-`verifications` from a better-auth experiment) reference `users.id` with a
-mismatched type after the UUID migration.
+`verifications`) already exist and reference `users.id` with a mismatched type,
+so the incoming migration cannot add its constraint.
 
 Resolution: drop the orphan tables on the dev DB and re-run migrate:
 
@@ -202,7 +177,8 @@ Symptom: jobs appear in the queue UI as failed and never retry.
 Diagnostic: check `attemptsMade` against the job's `attempts` setting. If
 `attemptsMade === attempts`, the job has exhausted its retry budget and is now
 the responsibility of the dead-letter queue. Inspect the matching DLQ
-(`<queue>:dlq`) for the envelope.
+(`<queue>.dlq`, per `dlqNameFor()`) for the envelope. The separator is a dot,
+not a colon: BullMQ reserves `:` for its own Redis key scheme.
 
 ### Welcome email sent twice for the same user
 
@@ -210,8 +186,10 @@ Symptom: a user receives the welcome email twice within seconds.
 
 Cause: the listener was invoked twice (likely a duplicate domain event or a
 worker restart between enqueue and acknowledge). The producer enqueues with
-`jobId: welcome-email:<eventId>` so BullMQ deduplicates by job id — the
-second enqueue is a no-op.
+`jobId: welcome-email__<eventId>` so BullMQ deduplicates by job id — the
+second enqueue is a no-op. Note the `__` separator: a custom job id containing
+`:` makes BullMQ throw `Custom Id cannot contain :`, because `:` delimits its
+internal Redis keys.
 
 If duplicates still slip through, check that `event.eventId` is stable across
 emits (it MUST be a deterministic value — typically the same UUID for the
@@ -275,10 +253,12 @@ Cause: the migration container is connecting through pgbouncer. Prisma migrate
 uses session-scoped DDL operations (advisory locks, `SET LOCAL`) that are
 incompatible with transaction mode.
 
-Resolution: set `DATABASE_DIRECT_URL` so the migration bootstrap
-(`apps/migration/src/main.ts`) re-exports `DATABASE_URL` to the direct Postgres
-address before invoking `prisma migrate deploy`. When using the compose overlay
-this is already set — verify with:
+Resolution: set `DATABASE_DIRECT_URL`. `prisma.config.ts` resolves the datasource
+as `DATABASE_DIRECT_URL || DATABASE_URL`, so setting it points every Prisma CLI
+invocation — including `migrate deploy` — straight at Postgres while the app keeps
+using the pooled `DATABASE_URL`. (`apps/migration/src/main.ts` does not rewrite
+`DATABASE_URL`; it only splices in a `DB_PASSWORD_FILE` secret when one is set.)
+When using the compose overlay this is already set — verify with:
 
 ```bash
 docker compose config | grep -A5 'migration:'
@@ -459,7 +439,8 @@ the failing dependency from the JSON body of `/health`.
 
 ### Metrics endpoint returns 403 Forbidden or no data
 
-Endpoint: `GET /api/v1/metrics`.
+Endpoint: `GET /metrics` — the controller is `VERSION_NEUTRAL` and `main.ts`
+excludes it from the global `api` prefix, so it carries neither `/api` nor `/v1`.
 
 Cause 1: `ENABLE_METRICS=false` in the env. Set it to `true` to enable Prometheus
 collection.

--- a/libs/api-client/src/generated/api.schemas.ts
+++ b/libs/api-client/src/generated/api.schemas.ts
@@ -18,6 +18,11 @@
  * Every response carries an `X-Request-Id` header (also mirrored as `requestId` in error bodies). Quote it when filing support tickets.
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs.
+ */
+export type ProblemDetailsDtoChecks = { [key: string]: { [key: string]: unknown } };
+
 export interface ProblemDetailsDto {
   /** A URI reference identifying the problem type. SHOULD resolve to human-readable docs. */
   type: string;
@@ -39,6 +44,8 @@ export interface ProblemDetailsDto {
   requestId?: string;
   /** ISO 8601 UTC timestamp when the error was produced. */
   timestamp: string;
+  /** Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs. */
+  checks?: ProblemDetailsDtoChecks;
 }
 
 /**
@@ -68,6 +75,11 @@ export interface ValidationErrorItemDto {
   received?: ValidationErrorItemDtoReceived;
 }
 
+/**
+ * Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs.
+ */
+export type ValidationProblemDetailsDtoChecks = { [key: string]: { [key: string]: unknown } };
+
 export interface ValidationProblemDetailsDto {
   /** A URI reference identifying the problem type. SHOULD resolve to human-readable docs. */
   type: string;
@@ -89,6 +101,8 @@ export interface ValidationProblemDetailsDto {
   requestId?: string;
   /** ISO 8601 UTC timestamp when the error was produced. */
   timestamp: string;
+  /** Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs. */
+  checks?: ValidationProblemDetailsDtoChecks;
   /** Per-field violations. Frontend should highlight each `path` independently. */
   errors: ValidationErrorItemDto[];
 }
@@ -98,6 +112,80 @@ export interface ServiceInfoDto {
   name: string;
   /** Semantic version of the running build. */
   version: string;
+}
+
+/**
+ * Aggregate health status.
+ */
+export type HealthCheckResultDtoStatus =
+  (typeof HealthCheckResultDtoStatus)[keyof typeof HealthCheckResultDtoStatus];
+
+export const HealthCheckResultDtoStatus = {
+  ok: 'ok',
+  error: 'error',
+  shutting_down: 'shutting_down',
+} as const;
+
+export type HealthCheckResultDtoInfoStatus =
+  (typeof HealthCheckResultDtoInfoStatus)[keyof typeof HealthCheckResultDtoInfoStatus];
+
+export const HealthCheckResultDtoInfoStatus = {
+  up: 'up',
+  down: 'down',
+} as const;
+
+/**
+ * Per-indicator status. Keys depend on the endpoint — `/health` reports `database`, `memory_heap`, `redis_cache`, `redis_queue`; `/health/ready` reports the subset a pod needs to serve traffic (`database`, `redis_cache`, `redis_queue`); `/health/dependencies` reports the deep checks (`bullmq`, `pgbouncer`, `replication_lag`).
+ */
+export type HealthCheckResultDtoInfo = {
+  [key: string]: {
+    status: HealthCheckResultDtoInfoStatus;
+  };
+};
+
+export type HealthCheckResultDtoErrorStatus =
+  (typeof HealthCheckResultDtoErrorStatus)[keyof typeof HealthCheckResultDtoErrorStatus];
+
+export const HealthCheckResultDtoErrorStatus = {
+  up: 'up',
+  down: 'down',
+} as const;
+
+/**
+ * Indicators that reported `down`. Empty when `status === "ok"`.
+ */
+export type HealthCheckResultDtoError = {
+  [key: string]: {
+    status: HealthCheckResultDtoErrorStatus;
+  };
+};
+
+export type HealthCheckResultDtoDetailsStatus =
+  (typeof HealthCheckResultDtoDetailsStatus)[keyof typeof HealthCheckResultDtoDetailsStatus];
+
+export const HealthCheckResultDtoDetailsStatus = {
+  up: 'up',
+  down: 'down',
+} as const;
+
+/**
+ * Mirror of `info` plus failed indicators — convenient for UI rendering.
+ */
+export type HealthCheckResultDtoDetails = {
+  [key: string]: {
+    status: HealthCheckResultDtoDetailsStatus;
+  };
+};
+
+export interface HealthCheckResultDto {
+  /** Aggregate health status. */
+  status: HealthCheckResultDtoStatus;
+  /** Per-indicator status. Keys depend on the endpoint — `/health` reports `database`, `memory_heap`, `redis_cache`, `redis_queue`; `/health/ready` reports the subset a pod needs to serve traffic (`database`, `redis_cache`, `redis_queue`); `/health/dependencies` reports the deep checks (`bullmq`, `pgbouncer`, `replication_lag`). */
+  info: HealthCheckResultDtoInfo;
+  /** Indicators that reported `down`. Empty when `status === "ok"`. */
+  error: HealthCheckResultDtoError;
+  /** Mirror of `info` plus failed indicators — convenient for UI rendering. */
+  details: HealthCheckResultDtoDetails;
 }
 
 export type LivenessResponseDtoStatus =
@@ -340,222 +428,6 @@ export interface Verification {
   createdAt: string;
   updatedAt: string;
 }
-
-/**
- * @nullable
- */
-export type HealthCheck200Info = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-/**
- * @nullable
- */
-export type HealthCheck200Error = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-export type HealthCheck200Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-};
-
-export type HealthCheck200 = {
-  status?: string;
-  /** @nullable */
-  info?: HealthCheck200Info;
-  /** @nullable */
-  error?: HealthCheck200Error;
-  details?: HealthCheck200Details;
-};
-
-/**
- * @nullable
- */
-export type HealthCheck503Info = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-/**
- * @nullable
- */
-export type HealthCheck503Error = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-export type HealthCheck503Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-};
-
-export type HealthCheck503 = {
-  status?: string;
-  /** @nullable */
-  info?: HealthCheck503Info;
-  /** @nullable */
-  error?: HealthCheck503Error;
-  details?: HealthCheck503Details;
-};
-
-/**
- * @nullable
- */
-export type HealthReadiness200Info = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-/**
- * @nullable
- */
-export type HealthReadiness200Error = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-export type HealthReadiness200Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-};
-
-export type HealthReadiness200 = {
-  status?: string;
-  /** @nullable */
-  info?: HealthReadiness200Info;
-  /** @nullable */
-  error?: HealthReadiness200Error;
-  details?: HealthReadiness200Details;
-};
-
-/**
- * @nullable
- */
-export type HealthReadiness503Info = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-/**
- * @nullable
- */
-export type HealthReadiness503Error = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-export type HealthReadiness503Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-};
-
-export type HealthReadiness503 = {
-  status?: string;
-  /** @nullable */
-  info?: HealthReadiness503Info;
-  /** @nullable */
-  error?: HealthReadiness503Error;
-  details?: HealthReadiness503Details;
-};
-
-/**
- * @nullable
- */
-export type HealthDependencies200Info = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-/**
- * @nullable
- */
-export type HealthDependencies200Error = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-export type HealthDependencies200Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-};
-
-export type HealthDependencies200 = {
-  status?: string;
-  /** @nullable */
-  info?: HealthDependencies200Info;
-  /** @nullable */
-  error?: HealthDependencies200Error;
-  details?: HealthDependencies200Details;
-};
-
-/**
- * @nullable
- */
-export type HealthDependencies503Info = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-/**
- * @nullable
- */
-export type HealthDependencies503Error = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-} | null;
-
-export type HealthDependencies503Details = {
-  [key: string]: {
-    status: string;
-    [key: string]: unknown;
-  };
-};
-
-export type HealthDependencies503 = {
-  status?: string;
-  /** @nullable */
-  info?: HealthDependencies503Info;
-  /** @nullable */
-  error?: HealthDependencies503Error;
-  details?: HealthDependencies503Details;
-};
 
 export type AdminUsersListParams = {
   /**

--- a/libs/api-client/src/generated/health.ts
+++ b/libs/api-client/src/generated/health.ts
@@ -18,36 +18,34 @@
  * Every response carries an `X-Request-Id` header (also mirrored as `requestId` in error bodies). Quote it when filing support tickets.
  * OpenAPI spec version: 1.0.0
  */
-import type {
-  HealthCheck200,
-  HealthDependencies200,
-  HealthReadiness200,
-  LivenessResponseDto,
-} from './api.schemas';
+import type { HealthCheckResultDto, LivenessResponseDto } from './api.schemas';
 
 import { customAxiosInstance } from '../lib/axios-instance';
 
 export const getHealth = () => {
   /**
-   * Returns 200 with the per-indicator breakdown when everything is up; 503 with a Problem Details payload when at least one critical dependency is down.
+   * Returns 200 with the per-indicator breakdown when everything is up; 503 problem+json (with a `checks` map of the failing dependencies) when at least one critical dependency is down.
    * @summary Full health check (DB + memory + Redis cache + Redis queue).
    */
   const healthCheck = () => {
-    return customAxiosInstance<HealthCheck200>({ url: `/api/v1/health`, method: 'GET' });
+    return customAxiosInstance<HealthCheckResultDto>({ url: `/api/v1/health`, method: 'GET' });
   };
   /**
    * Use as the Kubernetes readiness probe. Checks ONLY what this pod needs to serve its core traffic. Shared-but-non-blocking dependencies (replica lag, queue depth, pgbouncer) are deliberately excluded: because every replica shares the same Postgres/Redis, wiring them here would flip all pods to NotReady at once on a single dependency blip — a correlated, cluster-wide outage even though the app is healthy. Those live on /health/dependencies for dashboards/alerting instead. Returns 503 so the orchestrator removes the pod from the load balancer when a core dependency is unreachable.
    * @summary Readiness probe (DB primary + Redis cache + Redis queue).
    */
   const healthReadiness = () => {
-    return customAxiosInstance<HealthReadiness200>({ url: `/api/v1/health/ready`, method: 'GET' });
+    return customAxiosInstance<HealthCheckResultDto>({
+      url: `/api/v1/health/ready`,
+      method: 'GET',
+    });
   };
   /**
    * Deep health of shared infrastructure — meant for dashboards and alerting, NOT for the Kubernetes readiness/liveness probes. Wiring these into a probe would remove every replica from the load balancer at once when a shared dependency degrades. Returns 503 when a deep check fails so alert rules can fire.
    * @summary Deep dependency check (BullMQ + pgbouncer + replica lag).
    */
   const healthDependencies = () => {
-    return customAxiosInstance<HealthDependencies200>({
+    return customAxiosInstance<HealthCheckResultDto>({
       url: `/api/v1/health/dependencies`,
       method: 'GET',
     });

--- a/libs/api-client/src/lib/axios-instance.ts
+++ b/libs/api-client/src/lib/axios-instance.ts
@@ -7,9 +7,13 @@ import type { AxiosRequestConfig } from 'axios';
 const _globalThis = globalThis as Record<string, unknown>;
 const _isBrowser = typeof _globalThis['window'] !== 'undefined';
 
+// Origin only — never a path. Every generated operation already carries its full server path
+// (`/api/v1/users/me`, `/api/auth/get-session`), and axios concatenates baseURL with a relative url,
+// so a baseURL ending in `/api/v1` produced `/api/v1/api/v1/users/me` and 404'd every call. The
+// browser default is empty on purpose: same-origin requests need no prefix at all.
 const BASE_URL = _isBrowser
-  ? ((_globalThis['__API_URL__'] as string | undefined) ?? '/api/v1')
-  : (process.env['API_BASE_URL'] ?? 'http://localhost:3000/api/v1');
+  ? ((_globalThis['__API_URL__'] as string | undefined) ?? '')
+  : (process.env['API_BASE_URL'] ?? 'http://localhost:3000');
 
 export const axiosInstance = axios.create({
   baseURL: BASE_URL,

--- a/libs/api-client/src/lib/axios-instance.ts
+++ b/libs/api-client/src/lib/axios-instance.ts
@@ -7,10 +7,9 @@ import type { AxiosRequestConfig } from 'axios';
 const _globalThis = globalThis as Record<string, unknown>;
 const _isBrowser = typeof _globalThis['window'] !== 'undefined';
 
-// Origin only — never a path. Every generated operation already carries its full server path
-// (`/api/v1/users/me`, `/api/auth/get-session`), and axios concatenates baseURL with a relative url,
-// so a baseURL ending in `/api/v1` produced `/api/v1/api/v1/users/me` and 404'd every call. The
-// browser default is empty on purpose: same-origin requests need no prefix at all.
+// Origin only — never a path. Generated operations already carry the full server path, and axios
+// concatenates, so `/api/v1` here would send `/api/v1/api/v1/users/me`. Empty in the browser
+// because same-origin needs no prefix.
 const BASE_URL = _isBrowser
   ? ((_globalThis['__API_URL__'] as string | undefined) ?? '')
   : (process.env['API_BASE_URL'] ?? 'http://localhost:3000');

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -9,14 +9,42 @@ backend modules and generated clients.
 ## Public API
 
 ```ts
-import { PaginationDto, PageMetaDto, PageDto } from '@nestjs-fastify-nx/contracts';
+import {
+  ListResponseDto,
+  CursorPaginationDto,
+  toListResponse,
+  toCursorListResponse,
+  PaginationDto,
+  PageMetaDto,
+  PageDto,
+  ProblemDetailsDto,
+  ValidationProblemDetailsDto,
+  ValidationErrorItemDto,
+  ERROR_CODES,
+  errorTypeUrl,
+  type ErrorCode,
+  ApiCommonErrors,
+  type CommonErrorsOptions,
+  ApiPaginatedResponse,
+} from '@nestjs-fastify-nx/contracts';
 ```
 
-| Export          | Purpose                                                       |
-| --------------- | ------------------------------------------------------------- |
-| `PaginationDto` | `class-validator`-decorated request DTO (`page`, `pageSize`)  |
-| `PageMetaDto`   | Response metadata (`total`, `page`, `pageSize`, `totalPages`) |
-| `PageDto<T>`    | Generic paginated response envelope (`items`, `meta`)         |
+Cursor pagination is the default for resource lists; the offset DTOs exist for the rare screen that
+genuinely needs jump-to-page.
+
+| Export                                              | Purpose                                                                                   |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `CursorPaginationDto`                               | Cursor request DTO (`limit`, `startingAfter`) — the default for lists                     |
+| `ListResponseDto<T>`                                | Stripe-style flat envelope (`object: 'list'`, `url`, `data`, `hasMore`, `lastCursor?`, …) |
+| `toCursorListResponse` / `toListResponse`           | Build that envelope from a cursor page / an offset page                                   |
+| `PaginationDto`                                     | Offset request DTO (`page`, `pageSize`, capped at 100)                                    |
+| `PageMetaDto` / `PageDto<T>`                        | Offset metadata + envelope (`items`, `meta`)                                              |
+| `ProblemDetailsDto` / `ValidationProblemDetailsDto` | RFC 9457 error bodies — the shape the global filter emits                                 |
+| `ValidationErrorItemDto`                            | One entry of the flat `errors[]` array                                                    |
+| `ERROR_CODES` / `ErrorCode`                         | Stable snake_case `code` values clients branch on                                         |
+| `errorTypeUrl(code)`                                | RFC 9457 `type` URI for a code (`/errors/<kebab-code>`)                                   |
+| `ApiCommonErrors` / `CommonErrorsOptions`           | Documents the error responses a route can emit                                            |
+| `ApiPaginatedResponse`                              | Documents a `ListResponseDto<T>` 200                                                      |
 
 The runtime helpers (`buildPageMeta`, `paginationSkip`, type aliases) live in
 [`@nestjs-fastify-nx/shared`](../shared/README.md). Use this lib when you need

--- a/libs/contracts/src/lib/errors/problem-details.dto.ts
+++ b/libs/contracts/src/lib/errors/problem-details.dto.ts
@@ -57,6 +57,15 @@ export class ProblemDetailsDto {
     format: 'date-time',
   })
   timestamp!: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs.',
+    type: 'object',
+    additionalProperties: { type: 'object' },
+    example: { redis_cache: { status: 'down', message: 'redis_cache check failed' } },
+  })
+  checks?: Record<string, { status: string; message?: string }>;
 }
 
 export class ValidationErrorItemDto {

--- a/libs/contracts/src/lib/swagger/api-common-errors.decorator.ts
+++ b/libs/contracts/src/lib/swagger/api-common-errors.decorator.ts
@@ -19,7 +19,11 @@ const validationProblemContent = (description: string) => ({
 export interface CommonErrorsOptions {
   /** Endpoint requires authentication — include 401. Default: true. */
   auth?: boolean;
-  /** Endpoint requires a specific role/permission — include 403. Default: true when `auth` is true. */
+  /**
+   * Include 403. Ignored when `auth` is true: 403 is not only about roles — BetterAuthGuard
+   * rejects a valid session belonging to a non-ACTIVE account with 403, so every authenticated
+   * endpoint can emit it whether or not it declares a required role. Default: false.
+   */
   forbidden?: boolean;
   /** Endpoint reads/operates on a resource by id — include 404. Default: false. */
   notFound?: boolean;
@@ -36,7 +40,9 @@ export interface CommonErrorsOptions {
 // Documents Problem Details error responses (always 400, 429, 500 plus selected optional codes).
 export const ApiCommonErrors = (options: CommonErrorsOptions = {}) => {
   const auth = options.auth ?? true;
-  const forbidden = options.forbidden ?? auth;
+  // Forced on for authenticated routes — see CommonErrorsOptions.forbidden. Opting out would
+  // document a contract the guard does not honour.
+  const forbidden = auth || (options.forbidden ?? false);
   const validation = options.validation ?? true;
   const notFound = options.notFound ?? false;
   const conflict = options.conflict ?? false;

--- a/libs/core/src/lib/errors/business-rule.exception.ts
+++ b/libs/core/src/lib/errors/business-rule.exception.ts
@@ -36,7 +36,6 @@ export class BusinessRuleException extends HttpException {
     const title = options.title ?? 'Business rule violation';
     super(
       {
-        statusCode: status,
         code,
         title,
         messageKey: options.messageKey,

--- a/libs/infra/auth/src/lib/better-auth.guard.spec.ts
+++ b/libs/infra/auth/src/lib/better-auth.guard.spec.ts
@@ -48,9 +48,6 @@ describe('BetterAuthGuard', () => {
     await expect(guard.canActivate(makeContext())).rejects.toThrow(UnauthorizedException);
   });
 
-  // Forbidden, not Unauthorized: the session is valid, so re-authenticating cannot help. 401 would
-  // send an SPA back to login, where Better Auth (which does not check this custom `status` field)
-  // hands out a fresh session — and the next request 401s again, forever.
   it('throws ForbiddenException when the session is valid but the account is not active', async () => {
     for (const status of ['INACTIVE', 'BANNED']) {
       const session = {

--- a/libs/infra/auth/src/lib/better-auth.guard.spec.ts
+++ b/libs/infra/auth/src/lib/better-auth.guard.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as Sentry from '@sentry/nestjs';
 import { BetterAuthGuard } from './better-auth.guard';
-import { UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import type { ExecutionContext } from '@nestjs/common';
 import type { Reflector } from '@nestjs/core';
 import type { ClsService } from 'nestjs-cls';
@@ -48,13 +48,20 @@ describe('BetterAuthGuard', () => {
     await expect(guard.canActivate(makeContext())).rejects.toThrow(UnauthorizedException);
   });
 
-  it('throws UnauthorizedException when user is inactive', async () => {
-    const session = {
-      user: { id: 'u1', email: 'a@b.com', name: 'A', role: 'USER', status: 'INACTIVE' },
-      session: { id: 's1', token: 'tok' },
-    };
-    const guard = new BetterAuthGuard(makeAuth(session), makeReflector(), makeCls());
-    await expect(guard.canActivate(makeContext())).rejects.toThrow(UnauthorizedException);
+  // Forbidden, not Unauthorized: the session is valid, so re-authenticating cannot help. 401 would
+  // send an SPA back to login, where Better Auth (which does not check this custom `status` field)
+  // hands out a fresh session — and the next request 401s again, forever.
+  it('throws ForbiddenException when the session is valid but the account is not active', async () => {
+    for (const status of ['INACTIVE', 'BANNED']) {
+      const session = {
+        user: { id: 'u1', email: 'a@b.com', name: 'A', role: 'USER', status },
+        session: { id: 's1', token: 'tok' },
+      };
+      const guard = new BetterAuthGuard(makeAuth(session), makeReflector(), makeCls());
+
+      await expect(guard.canActivate(makeContext())).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(makeContext())).rejects.not.toThrow(UnauthorizedException);
+    }
   });
 
   it('returns true and attaches AuthenticatedSession for valid active session', async () => {

--- a/libs/infra/auth/src/lib/better-auth.guard.ts
+++ b/libs/infra/auth/src/lib/better-auth.guard.ts
@@ -68,11 +68,8 @@ export class BetterAuthGuard implements CanActivate {
       status: string;
     };
 
-    // 403, not 401: the session is valid and unexpired, so the credentials are not the problem —
-    // the server understood the request and refuses to authorize a deactivated/banned account.
-    // 401 also traps the client in a loop: Better Auth does not check this custom `status` field on
-    // sign-in, so an SPA reacting to 401 by redirecting to login gets a fresh session and another
-    // 401, forever. 403 lets it surface "account disabled" instead.
+    // 403, not 401: the session is valid, so re-authenticating cannot help. Better Auth does not
+    // check this custom `status` on sign-in, so 401 would loop an SPA through login forever.
     if (user.status !== 'ACTIVE') {
       throw new ForbiddenException({
         messageKey: I18N_KEYS.errors.auth.account_inactive,

--- a/libs/infra/auth/src/lib/better-auth.guard.ts
+++ b/libs/infra/auth/src/lib/better-auth.guard.ts
@@ -2,7 +2,7 @@ import {
   Injectable,
   CanActivate,
   ExecutionContext,
-  HttpStatus,
+  ForbiddenException,
   UnauthorizedException,
   Inject,
 } from '@nestjs/common';
@@ -45,7 +45,6 @@ export class BetterAuthGuard implements CanActivate {
 
     if (!session || !session.user || !session.session) {
       throw new UnauthorizedException({
-        statusCode: HttpStatus.UNAUTHORIZED,
         messageKey: I18N_KEYS.errors.auth.session_missing,
         message: 'Session not found or expired',
       });
@@ -56,7 +55,6 @@ export class BetterAuthGuard implements CanActivate {
     const expiresAt = session.session.expiresAt;
     if (expiresAt && new Date(expiresAt).getTime() < Date.now()) {
       throw new UnauthorizedException({
-        statusCode: HttpStatus.UNAUTHORIZED,
         messageKey: I18N_KEYS.errors.auth.session_expired,
         message: 'Session expired',
       });
@@ -70,9 +68,13 @@ export class BetterAuthGuard implements CanActivate {
       status: string;
     };
 
+    // 403, not 401: the session is valid and unexpired, so the credentials are not the problem —
+    // the server understood the request and refuses to authorize a deactivated/banned account.
+    // 401 also traps the client in a loop: Better Auth does not check this custom `status` field on
+    // sign-in, so an SPA reacting to 401 by redirecting to login gets a fresh session and another
+    // 401, forever. 403 lets it surface "account disabled" instead.
     if (user.status !== 'ACTIVE') {
-      throw new UnauthorizedException({
-        statusCode: HttpStatus.UNAUTHORIZED,
+      throw new ForbiddenException({
         messageKey: I18N_KEYS.errors.auth.account_inactive,
         message: 'Account is not active',
       });

--- a/libs/infra/auth/src/lib/roles.guard.ts
+++ b/libs/infra/auth/src/lib/roles.guard.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  CanActivate,
-  ExecutionContext,
-  ForbiddenException,
-} from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
 import type { FastifyRequest } from 'fastify';

--- a/libs/infra/auth/src/lib/roles.guard.ts
+++ b/libs/infra/auth/src/lib/roles.guard.ts
@@ -3,7 +3,6 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
-  HttpStatus,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
@@ -33,7 +32,6 @@ export class RolesGuard implements CanActivate {
 
     if (!user || !requiredRoles.includes(user.role)) {
       throw new ForbiddenException({
-        statusCode: HttpStatus.FORBIDDEN,
         messageKey: I18N_KEYS.errors.auth.insufficient_permissions,
         message: 'Insufficient permissions',
       });

--- a/libs/infra/database/README.md
+++ b/libs/infra/database/README.md
@@ -10,13 +10,20 @@ it as a global provider.
 ## Public API
 
 ```ts
-import { DatabaseModule, PrismaService } from '@nestjs-fastify-nx/infra-database';
+import {
+  DatabaseModule,
+  PrismaService,
+  type TransactionClient,
+  PrismaReplicationLagHealthIndicator,
+} from '@nestjs-fastify-nx/infra-database';
 ```
 
-| Export           | Purpose                                                       |
-| ---------------- | ------------------------------------------------------------- |
-| `DatabaseModule` | Global NestJS module — exports `PrismaService` workspace-wide |
-| `PrismaService`  | `PrismaClient` subclass with `onModuleInit` connect logic     |
+| Export                                | Purpose                                                                                               |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `DatabaseModule`                      | Global NestJS module — exports `PrismaService` workspace-wide                                         |
+| `PrismaService`                       | `PrismaClient` subclass with `onModuleInit` connect logic, `db`/`dbRead` clients, and `transaction()` |
+| `TransactionClient`                   | The client handed to a `transaction()` callback                                                       |
+| `PrismaReplicationLagHealthIndicator` | Physical replica replay lag — wired to `/health/dependencies`, never to the readiness probe           |
 
 ## Driver adapter
 

--- a/libs/infra/i18n/src/lib/i18n-keys.ts
+++ b/libs/infra/i18n/src/lib/i18n-keys.ts
@@ -53,6 +53,9 @@ export const I18N_KEYS = {
       already_exists: 'errors.users.already_exists',
       database_error: 'errors.users.database_error',
     },
+    pagination: {
+      invalid_cursor: 'errors.pagination.invalid_cursor',
+    },
     auth: {
       session_missing: 'errors.auth.session_missing',
       session_expired: 'errors.auth.session_expired',

--- a/libs/infra/messaging/README.md
+++ b/libs/infra/messaging/README.md
@@ -14,8 +14,16 @@ import {
   OutboxPublisher,
   OutboxRelayService,
   OutboxRelayModule,
+  OUTBOX_SCHEMA_VERSION,
+  OUTBOX_RELAY_LEADERSHIP,
+  type OutboxRelayLeadership,
 } from '@nestjs-fastify-nx/infra-messaging';
 ```
+
+`OUTBOX_SCHEMA_VERSION` stamps every serialized payload, so a relay can tell which shape it is
+reading. `OUTBOX_RELAY_LEADERSHIP` is the token `OutboxRelayModule` resolves to decide whether this
+replica may drain the outbox — the scheduler binds its `SchedulerLeaderService` to it, which is why
+only one replica relays at a time.
 
 ## Two drivers, one port
 

--- a/libs/infra/messaging/src/lib/outbox-publisher.service.ts
+++ b/libs/infra/messaging/src/lib/outbox-publisher.service.ts
@@ -38,8 +38,22 @@ export class OutboxPublisher implements EventPublisherPort {
       payload: this.serializePayload(event),
     }));
 
+    const transaction = this.prisma.currentTransaction;
+    if (!transaction) {
+      // Not an error: an event-only write with no aggregate change is a legitimate use of this
+      // path. But a producer that just mutated state outside a transaction has lost the outbox's
+      // entire point — the event row and the state change can no longer commit or roll back
+      // together. From in here the two cases are indistinguishable, so warn rather than throw and
+      // let the log say which producer to look at.
+      this.logger.warn(
+        `Outbox write outside a transaction (${events.map((e) => e.eventType).join(', ')}) — ` +
+          'not atomic with aggregate state. Wrap it in prisma.transaction() if this producer ' +
+          'also changed state.',
+      );
+    }
+
     try {
-      const client = this.prisma.currentTransaction ?? this.prisma.db;
+      const client = transaction ?? this.prisma.db;
       await client.outboxEvent.createMany({ data: rows });
     } catch (err) {
       this.logger.error(`Outbox persist failed for ${events.length} event(s) — ${String(err)}`);

--- a/libs/infra/messaging/src/lib/outbox-publisher.service.ts
+++ b/libs/infra/messaging/src/lib/outbox-publisher.service.ts
@@ -40,11 +40,8 @@ export class OutboxPublisher implements EventPublisherPort {
 
     const transaction = this.prisma.currentTransaction;
     if (!transaction) {
-      // Not an error: an event-only write with no aggregate change is a legitimate use of this
-      // path. But a producer that just mutated state outside a transaction has lost the outbox's
-      // entire point — the event row and the state change can no longer commit or roll back
-      // together. From in here the two cases are indistinguishable, so warn rather than throw and
-      // let the log say which producer to look at.
+      // An event-only write is legitimate here; a producer that also mutated state has lost
+      // atomicity. Indistinguishable from in here, so warn instead of failing a valid caller.
       this.logger.warn(
         `Outbox write outside a transaction (${events.map((e) => e.eventType).join(', ')}) — ` +
           'not atomic with aggregate state. Wrap it in prisma.transaction() if this producer ' +

--- a/libs/infra/redis/README.md
+++ b/libs/infra/redis/README.md
@@ -12,6 +12,7 @@ import {
   RedisCacheModule,
   RedisCacheService,
   RedisQueueModule,
+  REDIS_QUEUE_CLIENT,
   DeadLetterModule,
   dlqNameFor,
   createDeadLetterRouterClass,
@@ -20,11 +21,16 @@ import {
 } from '@nestjs-fastify-nx/infra-redis';
 ```
 
+`REDIS_QUEUE_CLIENT` resolves to the ioredis client already connected to the queue instance. Inject
+it (`@Inject(REDIS_QUEUE_CLIENT) redis: Redis`) rather than opening a second connection for things
+like a processor's SETNX idempotency guard.
+
 ## Cache
 
 `RedisCacheModule` wires `cache-manager` over `Keyv` against the cache
 instance (`REDIS_CACHE_HOST` / `REDIS_CACHE_PORT`). `RedisCacheService` is a
-thin typed wrapper exposing `get` / `set` / `del` / `wrap`.
+thin typed wrapper exposing `get` / `set` / `del` / `reset`. `get`, `set` and
+`del` take an optional `namespace` that prefixes the key.
 
 Default TTL: `REDIS_CACHE_TTL_MS` (5 minutes).
 
@@ -41,12 +47,18 @@ and consumers can't drift.
 ## Dead-letter queues
 
 For at-least-once durability, every business queue gets a paired DLQ. The
-naming convention is enforced by `dlqNameFor(queueName)` which appends `:dlq`.
+naming convention is enforced by `dlqNameFor(queueName)`, which appends `.dlq`.
+The separator is a dot, not a colon — BullMQ reserves `:` for its internal Redis
+key scheme and rejects it in custom ids.
+
+`createDeadLetterRouterClass(queue)` returns a `QueueEventsHost` subclass already
+decorated with `@QueueEventsListener(queue)` — it listens for failures, it is not
+a `@Processor`. Register it as a provider:
 
 ```ts
-@Processor(QUEUE_NAMES.EMAIL_NOTIFICATION)
-class EmailProcessor extends createDeadLetterRouterClass(QUEUE_NAMES.EMAIL_NOTIFICATION) {
-  // failed jobs after retry exhaustion are auto-routed to email-notification:dlq
+@Injectable()
+class EmailDeadLetterRouter extends createDeadLetterRouterClass(QUEUE_NAMES.EMAIL_NOTIFICATION) {
+  // Jobs that exhaust their retries are auto-routed to email-notification.dlq
 }
 ```
 

--- a/libs/infra/redis/src/lib/redis-queue-client-provider.spec.ts
+++ b/libs/infra/redis/src/lib/redis-queue-client-provider.spec.ts
@@ -13,7 +13,7 @@ vi.mock('ioredis', () => {
 });
 
 // Import AFTER the mock is registered.
-import { RedisQueueClientProvider } from './redis-queue.module';
+import { RedisQueueClientProvider, queueRetryStrategy } from './redis-queue.module';
 
 function buildConfig(): ConfigService {
   const map: Record<string, unknown> = {
@@ -23,6 +23,27 @@ function buildConfig(): ConfigService {
   };
   return { get: (key: string) => map[key] } as unknown as ConfigService;
 }
+
+describe('queueRetryStrategy', () => {
+  // ioredis stops reconnecting for good when retryStrategy returns a non-number. A previous
+  // version returned null past 10 attempts, so any Redis outage lasting longer than ~9s stranded
+  // the queue connection permanently — no self-healing, and no healthcheck watching for it.
+  it('always returns a number, however many attempts have failed', () => {
+    for (const attempt of [1, 2, 9, 10, 11, 100, 10_000]) {
+      const delay = queueRetryStrategy(attempt);
+      expect(typeof delay, `attempt ${attempt} must yield a retry delay`).toBe('number');
+      expect(Number.isFinite(delay)).toBe(true);
+      expect(delay).toBeGreaterThan(0);
+    }
+  });
+
+  it('backs off linearly then holds at the 3s cap', () => {
+    expect(queueRetryStrategy(1)).toBe(200);
+    expect(queueRetryStrategy(5)).toBe(1000);
+    expect(queueRetryStrategy(15)).toBe(3000);
+    expect(queueRetryStrategy(1000)).toBe(3000);
+  });
+});
 
 describe('RedisQueueClientProvider', () => {
   let provider: RedisQueueClientProvider;

--- a/libs/infra/redis/src/lib/redis-queue-client-provider.spec.ts
+++ b/libs/infra/redis/src/lib/redis-queue-client-provider.spec.ts
@@ -25,9 +25,7 @@ function buildConfig(): ConfigService {
 }
 
 describe('queueRetryStrategy', () => {
-  // ioredis stops reconnecting for good when retryStrategy returns a non-number. A previous
-  // version returned null past 10 attempts, so any Redis outage lasting longer than ~9s stranded
-  // the queue connection permanently — no self-healing, and no healthcheck watching for it.
+  // ioredis stops reconnecting for good on a non-number, stranding the queue after any outage.
   it('always returns a number, however many attempts have failed', () => {
     for (const attempt of [1, 2, 9, 10, 11, 100, 10_000]) {
       const delay = queueRetryStrategy(attempt);

--- a/libs/infra/redis/src/lib/redis-queue-client-provider.spec.ts
+++ b/libs/infra/redis/src/lib/redis-queue-client-provider.spec.ts
@@ -13,7 +13,7 @@ vi.mock('ioredis', () => {
 });
 
 // Import AFTER the mock is registered.
-import { RedisQueueClientProvider, queueRetryStrategy } from './redis-queue.module';
+import { RedisQueueClientProvider } from './redis-queue.module';
 
 function buildConfig(): ConfigService {
   const map: Record<string, unknown> = {
@@ -23,25 +23,6 @@ function buildConfig(): ConfigService {
   };
   return { get: (key: string) => map[key] } as unknown as ConfigService;
 }
-
-describe('queueRetryStrategy', () => {
-  // ioredis stops reconnecting for good on a non-number, stranding the queue after any outage.
-  it('always returns a number, however many attempts have failed', () => {
-    for (const attempt of [1, 2, 9, 10, 11, 100, 10_000]) {
-      const delay = queueRetryStrategy(attempt);
-      expect(typeof delay, `attempt ${attempt} must yield a retry delay`).toBe('number');
-      expect(Number.isFinite(delay)).toBe(true);
-      expect(delay).toBeGreaterThan(0);
-    }
-  });
-
-  it('backs off linearly then holds at the 3s cap', () => {
-    expect(queueRetryStrategy(1)).toBe(200);
-    expect(queueRetryStrategy(5)).toBe(1000);
-    expect(queueRetryStrategy(15)).toBe(3000);
-    expect(queueRetryStrategy(1000)).toBe(3000);
-  });
-});
 
 describe('RedisQueueClientProvider', () => {
   let provider: RedisQueueClientProvider;

--- a/libs/infra/redis/src/lib/redis-queue.module.ts
+++ b/libs/infra/redis/src/lib/redis-queue.module.ts
@@ -1,6 +1,7 @@
 import { Injectable, Module, OnModuleDestroy } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { redisReconnectStrategy } from '@nestjs-fastify-nx/shared';
 import Redis from 'ioredis';
 
 /**
@@ -19,19 +20,6 @@ interface RedisQueueEnv {
   REDIS_QUEUE_PREFIX: string;
 }
 
-const RECONNECT_DELAY_STEP_MS = 200;
-const RECONNECT_DELAY_CAP_MS = 3000;
-
-/**
- * Always returns a delay, never a non-number. ioredis treats a non-number return as "stop
- * reconnecting for good", which would strand workers permanently after any Redis outage that
- * outlasts the attempt budget — with no self-healing and no healthcheck tied to Redis liveness.
- * Bounding in-flight commands is `maxRetriesPerRequest`'s job, not this one's.
- */
-export function queueRetryStrategy(times: number): number {
-  return Math.min(times * RECONNECT_DELAY_STEP_MS, RECONNECT_DELAY_CAP_MS);
-}
-
 /**
  * Wraps the ioredis client used by processors for idempotency guards.
  * Registered as the `REDIS_QUEUE_CLIENT` token so consumers see `Redis`
@@ -48,7 +36,7 @@ export class RedisQueueClientProvider implements OnModuleDestroy {
       host: config.get('REDIS_QUEUE_HOST', { infer: true }),
       port: config.get('REDIS_QUEUE_PORT', { infer: true }),
       maxRetriesPerRequest: null,
-      retryStrategy: queueRetryStrategy,
+      retryStrategy: redisReconnectStrategy,
       // lazyConnect prevents opening a socket until the first command —
       // importers that never call redis (e.g. health checks) pay no fd cost.
       lazyConnect: true,
@@ -72,7 +60,7 @@ export class RedisQueueClientProvider implements OnModuleDestroy {
           // BullMQ requires `maxRetriesPerRequest: null` — without it BullMQ
           // throws on every connection blip instead of letting ioredis retry.
           maxRetriesPerRequest: null,
-          retryStrategy: queueRetryStrategy,
+          retryStrategy: redisReconnectStrategy,
         },
         prefix: config.get('REDIS_QUEUE_PREFIX', { infer: true }),
         defaultJobOptions: {

--- a/libs/infra/redis/src/lib/redis-queue.module.ts
+++ b/libs/infra/redis/src/lib/redis-queue.module.ts
@@ -19,6 +19,19 @@ interface RedisQueueEnv {
   REDIS_QUEUE_PREFIX: string;
 }
 
+const RECONNECT_DELAY_STEP_MS = 200;
+const RECONNECT_DELAY_CAP_MS = 3000;
+
+/**
+ * Always returns a delay, never a non-number. ioredis treats a non-number return as "stop
+ * reconnecting for good", which would strand workers permanently after any Redis outage that
+ * outlasts the attempt budget — with no self-healing and no healthcheck tied to Redis liveness.
+ * Bounding in-flight commands is `maxRetriesPerRequest`'s job, not this one's.
+ */
+export function queueRetryStrategy(times: number): number {
+  return Math.min(times * RECONNECT_DELAY_STEP_MS, RECONNECT_DELAY_CAP_MS);
+}
+
 /**
  * Wraps the ioredis client used by processors for idempotency guards.
  * Registered as the `REDIS_QUEUE_CLIENT` token so consumers see `Redis`
@@ -35,8 +48,7 @@ export class RedisQueueClientProvider implements OnModuleDestroy {
       host: config.get('REDIS_QUEUE_HOST', { infer: true }),
       port: config.get('REDIS_QUEUE_PORT', { infer: true }),
       maxRetriesPerRequest: null,
-      retryStrategy: (times: number): number | null =>
-        times >= 10 ? null : Math.min(times * 200, 3000),
+      retryStrategy: queueRetryStrategy,
       // lazyConnect prevents opening a socket until the first command —
       // importers that never call redis (e.g. health checks) pay no fd cost.
       lazyConnect: true,
@@ -60,8 +72,7 @@ export class RedisQueueClientProvider implements OnModuleDestroy {
           // BullMQ requires `maxRetriesPerRequest: null` — without it BullMQ
           // throws on every connection blip instead of letting ioredis retry.
           maxRetriesPerRequest: null,
-          retryStrategy: (times: number): number | null =>
-            times >= 10 ? null : Math.min(times * 200, 3000),
+          retryStrategy: queueRetryStrategy,
         },
         prefix: config.get('REDIS_QUEUE_PREFIX', { infer: true }),
         defaultJobOptions: {

--- a/libs/infra/redis/tsconfig.lib.json
+++ b/libs/infra/redis/tsconfig.lib.json
@@ -20,5 +20,10 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    {
+      "path": "../../shared/tsconfig.lib.json"
+    }
   ]
 }

--- a/libs/infra/storage/README.md
+++ b/libs/infra/storage/README.md
@@ -15,16 +15,22 @@ import {
   type StoragePort,
   type StoredFile,
   type UploadOptions,
+  type ObjectMetadata,
+  type PresignedUpload,
+  type PresignUploadOptions,
 } from '@nestjs-fastify-nx/infra-storage';
 ```
 
-| Export          | Purpose                                                       |
-| --------------- | ------------------------------------------------------------- |
-| `StorageModule` | Global NestJS module — registers the S3 client + adapter      |
-| `STORAGE_PORT`  | DI token; inject as `@Inject(STORAGE_PORT) port: StoragePort` |
-| `StoragePort`   | Interface: `upload`, `delete`, `getSignedUrl`, `exists`       |
-| `StoredFile`    | Result envelope (`key`, `bucket`, `etag`, `size`)             |
-| `UploadOptions` | Per-upload knobs (content type, ACL, metadata)                |
+| Export                 | Purpose                                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `StorageModule`        | Registers the S3 client + adapter. Not `@Global` — import it where you need it                      |
+| `STORAGE_PORT`         | DI token; inject as `@Inject(STORAGE_PORT) port: StoragePort`                                       |
+| `StoragePort`          | Interface: `upload`, `presignUpload`, `head`, `getSignedUrl`, `delete`, `finalize`, `readRange`     |
+| `StoredFile`           | Result envelope (`key`, `url`, `bucket`, `size`)                                                    |
+| `UploadOptions`        | Per-upload knobs (`bucket`, `contentType`, `metadata`)                                              |
+| `ObjectMetadata`       | What `head()` returns (`contentType`, `size`, `bucket`, `etag`) — `null` when the object is missing |
+| `PresignedUpload`      | Presigned POST policy (`url`, `fields`, `key`, `bucket`, `expiresAt`, `maxBytes`)                   |
+| `PresignUploadOptions` | Policy inputs (`contentType`, `maxBytes`, optional `bucket`/`expiresInSeconds`)                     |
 
 ## Why a port?
 
@@ -33,9 +39,12 @@ depend on `StoragePort`. Swapping S3 for GCS or local disk is a single-file
 change in this lib, and tests can substitute an in-memory implementation
 without touching Nest's DI tree.
 
-The `upload` controller in `apps/api` is the only direct consumer; feature
-modules that need persistence (e.g. attaching a file to a domain entity)
-inject `STORAGE_PORT` and store the returned `key`.
+Three places inject `STORAGE_PORT` today: the upload controller
+(`libs/modules/upload`) issues policies and confirms objects, the worker's
+`upload-verification.processor` re-reads magic bytes off the final object, and
+the scheduler's `stored-file-cleanup.task` deletes abandoned ones. Feature
+modules that attach a file to a domain entity do the same and store the
+returned `key`.
 
 ## Configuration
 

--- a/libs/infra/storage/src/lib/s3-storage.adapter.ts
+++ b/libs/infra/storage/src/lib/s3-storage.adapter.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   Logger,
   BadRequestException,
-  HttpStatus,
   InternalServerErrorException,
   type OnModuleInit,
 } from '@nestjs/common';
@@ -139,7 +138,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
   async upload(key: string, body: Buffer, options?: UploadOptions): Promise<StoredFile> {
     if (body.length === 0) {
       throw new BadRequestException({
-        statusCode: HttpStatus.BAD_REQUEST,
         messageKey: I18N_KEYS.errors.storage.body_empty,
         args: { key },
         message: `Upload rejected — body is empty for key "${key}"`,
@@ -162,7 +160,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
     } catch (err) {
       this.logger.error({ err, key }, 'S3 upload failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.upload_failed,
         message: 'Storage upload failed',
       });
@@ -196,7 +193,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
     } catch (err) {
       this.logger.error({ err, key }, 'S3 presign upload failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.presign_failed,
         message: 'Storage presign failed',
       });
@@ -226,7 +222,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
       }
       this.logger.error({ err, key }, 'S3 head failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.head_failed,
         message: 'Storage head failed',
       });
@@ -248,7 +243,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
     } catch (err) {
       this.logger.error({ err, key }, 'S3 getSignedUrl failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.signed_url_failed,
         message: 'Storage signed URL generation failed',
       });
@@ -266,7 +260,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
     } catch (err) {
       this.logger.error({ err, key }, 'S3 delete failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.delete_failed,
         message: 'Storage delete failed',
       });
@@ -295,7 +288,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
     } catch (err) {
       this.logger.error({ err, sourceKey, finalKey }, 'S3 finalize copy failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.commit_failed,
         message: 'Storage finalize failed; retry confirmation',
       });
@@ -328,7 +320,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit {
     } catch (err) {
       this.logger.error({ err, key, byteCount }, 'S3 readRange failed');
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.storage.read_range_failed,
         message: 'Storage readRange failed',
       });

--- a/libs/modules/upload/src/presentation/controllers/upload.controller.ts
+++ b/libs/modules/upload/src/presentation/controllers/upload.controller.ts
@@ -11,6 +11,7 @@ import {
   NotFoundException,
   Post,
   Req,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { InjectQueue } from '@nestjs/bullmq';
@@ -36,6 +37,7 @@ import {
   ALLOWED_MIME_TYPES,
   detectFileType,
   generateId,
+  MIME_EXTENSIONS,
   positiveIntEnv,
   STORED_FILE_STATUS,
 } from '@nestjs-fastify-nx/shared';
@@ -57,14 +59,6 @@ export function verificationJobId(storageKey: string): string {
   // object key so retries deduplicate while distinct uploads can never share a BullMQ job id.
   return `verify__${createHash('sha256').update(storageKey).digest('hex')}`;
 }
-
-const MIME_EXTENSIONS: Record<string, string> = {
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/gif': 'gif',
-  'image/webp': 'webp',
-  'application/pdf': 'pdf',
-};
 
 @ApiTags('upload')
 @Controller('upload')
@@ -94,15 +88,14 @@ export class UploadController {
   })
   @ApiBody({ type: PresignUploadDto })
   @ApiCreatedResponse({ type: PresignedUploadDto, description: 'Presigned upload policy issued.' })
-  @ApiCommonErrors({ auth: true, forbidden: false })
+  @ApiCommonErrors({ auth: true })
   async presign(
     @Req() req: FastifyRequest & { user: AuthenticatedSession },
     @Body() dto: PresignUploadDto,
   ): Promise<PresignedUpload> {
-    const extension = MIME_EXTENSIONS[dto.contentType];
+    const extension = MIME_EXTENSIONS.get(dto.contentType);
     if (!extension) {
       throw new BadRequestException({
-        statusCode: HttpStatus.BAD_REQUEST,
         messageKey: I18N_KEYS.errors.upload.mime_not_allowed,
         args: { contentType: dto.contentType },
         message: `Mime type "${dto.contentType}" is not allowed`,
@@ -128,7 +121,7 @@ export class UploadController {
   })
   @ApiBody({ type: ConfirmUploadDto })
   @ApiOkResponse({ type: StoredFileDto, description: 'Object verified.' })
-  @ApiCommonErrors({ auth: true, forbidden: false, notFound: true })
+  @ApiCommonErrors({ auth: true, notFound: true })
   async confirm(
     @Req() req: FastifyRequest & { user: AuthenticatedSession },
     @Body() dto: ConfirmUploadDto,
@@ -149,10 +142,13 @@ export class UploadController {
       throw this.objectNotFound(dto.key);
     }
 
+    // 422, not 400: the request body is well-formed JSON that already passed ConfirmUploadDto. The
+    // server understood it perfectly and refuses because the *referenced S3 object* violates upload
+    // policy. (413 would be wrong for the oversize case too — the request payload is a few bytes;
+    // it is the stored object that is too large.)
     if (!ALLOWED_MIME_TYPES.has(meta.contentType)) {
       await this.safeDelete(dto.key);
-      throw new BadRequestException({
-        statusCode: HttpStatus.BAD_REQUEST,
+      throw new UnprocessableEntityException({
         messageKey: I18N_KEYS.errors.upload.mime_not_allowed,
         args: { contentType: meta.contentType },
         message: `Mime type "${meta.contentType}" is not allowed`,
@@ -161,8 +157,7 @@ export class UploadController {
 
     if (meta.size <= 0 || meta.size > this.maxFileSize) {
       await this.safeDelete(dto.key);
-      throw new BadRequestException({
-        statusCode: HttpStatus.BAD_REQUEST,
+      throw new UnprocessableEntityException({
         messageKey: I18N_KEYS.errors.upload.size_out_of_range,
         args: { size: meta.size, max: this.maxFileSize },
         message: `Object size ${meta.size} bytes is outside the allowed range (1..${this.maxFileSize})`,
@@ -174,16 +169,14 @@ export class UploadController {
     const detected = detectFileType(head);
     if (!detected || detected.mimeType !== meta.contentType) {
       await this.safeDelete(dto.key);
-      throw new BadRequestException(
+      throw new UnprocessableEntityException(
         detected
           ? {
-              statusCode: HttpStatus.BAD_REQUEST,
               messageKey: I18N_KEYS.errors.upload.magic_bytes_mismatch,
               args: { detected: detected.mimeType, declared: meta.contentType },
               message: `Magic bytes indicate "${detected.mimeType}" but Content-Type is "${meta.contentType}"`,
             }
           : {
-              statusCode: HttpStatus.BAD_REQUEST,
               messageKey: I18N_KEYS.errors.upload.magic_bytes_unknown,
               args: { key: dto.key },
               message: `Object at "${dto.key}" has no recognized binary signature`,
@@ -235,7 +228,6 @@ export class UploadController {
         'upload finalize failed — staging object remains lifecycle-managed',
       );
       throw new InternalServerErrorException({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         messageKey: I18N_KEYS.errors.upload.commit_failed,
         message: 'Failed to finalize upload; please retry',
       });
@@ -276,7 +268,6 @@ export class UploadController {
     const finalMeta = await this.storage.head(record.key, record.bucket);
     if (!finalMeta) {
       throw new ConflictException({
-        statusCode: HttpStatus.CONFLICT,
         message: 'Upload confirmation is still in progress; retry shortly',
       });
     }
@@ -325,7 +316,6 @@ export class UploadController {
 
   private objectNotFound(key: string): NotFoundException {
     return new NotFoundException({
-      statusCode: HttpStatus.NOT_FOUND,
       messageKey: I18N_KEYS.errors.upload.object_not_found,
       args: { key },
       message: `No object stored at "${key}"`,

--- a/libs/modules/upload/src/presentation/controllers/upload.controller.ts
+++ b/libs/modules/upload/src/presentation/controllers/upload.controller.ts
@@ -142,10 +142,8 @@ export class UploadController {
       throw this.objectNotFound(dto.key);
     }
 
-    // 422, not 400: the request body is well-formed JSON that already passed ConfirmUploadDto. The
-    // server understood it perfectly and refuses because the *referenced S3 object* violates upload
-    // policy. (413 would be wrong for the oversize case too — the request payload is a few bytes;
-    // it is the stored object that is too large.)
+    // 422, not 400: the body already passed ConfirmUploadDto — it is the referenced S3 object that
+    // breaks policy. 413 would be wrong for oversize too; the request payload is a few bytes.
     if (!ALLOWED_MIME_TYPES.has(meta.contentType)) {
       await this.safeDelete(dto.key);
       throw new UnprocessableEntityException({

--- a/libs/modules/users/src/application/queries/get-user-profile/get-user-profile.handler.ts
+++ b/libs/modules/users/src/application/queries/get-user-profile/get-user-profile.handler.ts
@@ -18,6 +18,9 @@ export class GetUserProfileHandler implements IQueryHandler<
     if (!user) {
       throw new BusinessRuleException({
         status: HttpStatus.NOT_FOUND,
+        // Without this the response titles a 404 "Business rule violation" — the class default only
+        // fits its default 422 — and the literal skips i18n because it isn't a dotted key.
+        title: I18N_KEYS.common.not_found,
         code: 'user_not_found',
         messageKey: I18N_KEYS.errors.users.not_found,
         violations: [

--- a/libs/modules/users/src/application/queries/list-users-cursor/list-users-cursor.handler.ts
+++ b/libs/modules/users/src/application/queries/list-users-cursor/list-users-cursor.handler.ts
@@ -1,6 +1,8 @@
-import { BadRequestException, Inject } from '@nestjs/common';
+import { HttpStatus, Inject } from '@nestjs/common';
 import { QueryHandler, type IQueryHandler } from '@nestjs/cqrs';
-import { decodeCursor, encodeCursor } from '@nestjs-fastify-nx/shared';
+import { BusinessRuleException } from '@nestjs-fastify-nx/core';
+import { I18N_KEYS } from '@nestjs-fastify-nx/infra-i18n';
+import { decodeCursor, encodeCursor, type DecodedCursor } from '@nestjs-fastify-nx/shared';
 import { USER_REPOSITORY_PORT } from '../../../domain/ports/user-repository.port';
 import type { UserRepositoryPort } from '../../../domain/ports/user-repository.port';
 import type { UserListItemDto } from '../../dtos/user-list-item.dto';
@@ -14,16 +16,8 @@ export class ListUsersCursorHandler implements IQueryHandler<
   constructor(@Inject(USER_REPOSITORY_PORT) private readonly users: UserRepositoryPort) {}
 
   async execute(query: ListUsersCursorQuery): Promise<ListUsersCursorResult> {
-    if (query.startingAfter && !decodeCursor(query.startingAfter)) {
-      throw new BadRequestException({
-        statusCode: 400,
-        code: 'invalid_cursor',
-        message: 'startingAfter is not a valid cursor',
-      });
-    }
-
     const { items, hasMore } = await this.users.findAllCursor({
-      startingAfter: query.startingAfter,
+      startingAfter: this.decodeStartingAfter(query.startingAfter),
       limit: query.limit,
       role: query.role,
       status: query.status,
@@ -44,5 +38,34 @@ export class ListUsersCursorHandler implements IQueryHandler<
     const lastCursor = lastItem ? encodeCursor(lastItem.createdAt, lastItem.id) : null;
 
     return { data, hasMore, lastCursor };
+  }
+
+  // Decoding here — rather than in the repository — keeps the cursor string at the boundary that
+  // owns input validation, so every UserRepositoryPort implementation receives a cursor that
+  // cannot be malformed.
+  private decodeStartingAfter(raw?: string): DecodedCursor | undefined {
+    if (!raw) return undefined;
+
+    const decoded = decodeCursor(raw);
+    if (!decoded) {
+      throw new BusinessRuleException({
+        status: HttpStatus.BAD_REQUEST,
+        // BusinessRuleException titles itself "Business rule violation" by default, which only reads
+        // correctly for its default 422. Non-422 callers must pass the status-appropriate key.
+        title: I18N_KEYS.common.bad_request,
+        code: 'invalid_cursor',
+        messageKey: I18N_KEYS.errors.pagination.invalid_cursor,
+        violations: [
+          {
+            path: 'startingAfter',
+            code: 'invalid_cursor',
+            message: 'startingAfter is not a valid cursor',
+            messageKey: I18N_KEYS.errors.pagination.invalid_cursor,
+          },
+        ],
+      });
+    }
+
+    return decoded;
   }
 }

--- a/libs/modules/users/src/domain/ports/user-repository.port.ts
+++ b/libs/modules/users/src/domain/ports/user-repository.port.ts
@@ -1,9 +1,11 @@
+import type { DecodedCursor } from '@nestjs-fastify-nx/shared';
 import type { User, UserRole, UserStatus } from '../entities/user.entity';
 
 export const USER_REPOSITORY_PORT = Symbol('USER_REPOSITORY_PORT');
 
 export interface FindAllCursorOptions {
-  startingAfter?: string;
+  // Already decoded by the application layer — implementations never parse a raw cursor string.
+  startingAfter?: DecodedCursor;
   limit: number;
   role?: UserRole;
   status?: UserStatus;

--- a/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.integration.spec.ts
+++ b/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.integration.spec.ts
@@ -5,7 +5,7 @@ import {
   deployTestMigrations,
 } from '@nestjs-fastify-nx/testing';
 import type { TestContainers } from '@nestjs-fastify-nx/testing';
-import { encodeCursor } from '@nestjs-fastify-nx/shared';
+import type { DecodedCursor } from '@nestjs-fastify-nx/shared';
 import { UserFactory } from '../../testing/user.factory';
 import { PrismaUserRepository } from './prisma-user.repository';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
@@ -113,7 +113,7 @@ describe('PrismaUserRepository (integration)', () => {
       }
 
       const seenIds = new Set<string>();
-      let cursor: string | undefined;
+      let cursor: DecodedCursor | undefined;
       let pagesRead = 0;
 
       for (let page = 0; page < 3; page++) {
@@ -126,7 +126,7 @@ describe('PrismaUserRepository (integration)', () => {
         }
 
         const last = result.items[result.items.length - 1];
-        cursor = encodeCursor(last.createdAt, last.id);
+        cursor = { createdAt: last.createdAt, id: last.id };
         pagesRead++;
 
         if (page < 2) {
@@ -138,14 +138,6 @@ describe('PrismaUserRepository (integration)', () => {
 
       expect(pagesRead).toBe(3);
       expect(seenIds.size).toBe(30);
-    });
-
-    it('rejects an invalid cursor before querying Postgres', async () => {
-      await repository.save(UserFactory.create({ email: 'any@test.com' }));
-
-      await expect(
-        repository.findAllCursor({ limit: 10, startingAfter: '!!!bad!!!' }),
-      ).rejects.toMatchObject({ status: 400 });
     });
 
     it('filters by search term', async () => {

--- a/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.ts
+++ b/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.ts
@@ -2,14 +2,11 @@ import {
   Injectable,
   Logger,
   ConflictException,
-  BadRequestException,
-  HttpStatus,
   InternalServerErrorException,
 } from '@nestjs/common';
 import { I18N_KEYS } from '@nestjs-fastify-nx/infra-i18n';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
 import { Prisma } from '@prisma/client';
-import { decodeCursor } from '@nestjs-fastify-nx/shared';
 import { User, UserRole, UserStatus } from '../../domain/entities/user.entity';
 import type {
   FindAllCursorOptions,
@@ -51,7 +48,6 @@ export class PrismaUserRepository implements UserRepositoryPort {
     if (err instanceof Prisma.PrismaClientKnownRequestError) {
       if (err.code === 'P2002') {
         throw new ConflictException({
-          statusCode: HttpStatus.CONFLICT,
           messageKey: I18N_KEYS.errors.users.already_exists,
           message: 'A record with this value already exists',
         });
@@ -59,7 +55,6 @@ export class PrismaUserRepository implements UserRepositoryPort {
     }
     this.logger.error({ err, context }, 'Database operation failed');
     throw new InternalServerErrorException({
-      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       messageKey: I18N_KEYS.errors.users.database_error,
       message: 'Database error',
     });
@@ -125,19 +120,11 @@ export class PrismaUserRepository implements UserRepositoryPort {
       ];
     }
     if (startingAfter) {
-      const decoded = decodeCursor(startingAfter);
-      if (!decoded) {
-        throw new BadRequestException({
-          statusCode: HttpStatus.BAD_REQUEST,
-          code: 'invalid_cursor',
-          message: 'startingAfter is not a valid cursor',
-        });
-      }
       where.AND = [
         {
           OR: [
-            { createdAt: { lt: decoded.createdAt } },
-            { AND: [{ createdAt: decoded.createdAt }, { id: { lt: decoded.id } }] },
+            { createdAt: { lt: startingAfter.createdAt } },
+            { AND: [{ createdAt: startingAfter.createdAt }, { id: { lt: startingAfter.id } }] },
           ],
         },
       ];

--- a/libs/modules/users/src/presentation/controllers/users.controller.ts
+++ b/libs/modules/users/src/presentation/controllers/users.controller.ts
@@ -20,7 +20,7 @@ export class UsersController {
       'Returns the profile of the user owning the session cookie. Use after sign-in to populate `currentUser` in the SPA.',
   })
   @ApiOkResponse({ type: UserProfileResponseDto, description: 'The current user profile.' })
-  @ApiCommonErrors({ auth: true, forbidden: false, validation: false })
+  @ApiCommonErrors({ auth: true, validation: false })
   getProfile(
     @Req() req: FastifyRequest & { user: AuthenticatedSession },
   ): Promise<UserProfileResponseDto> {

--- a/libs/modules/users/src/testing/mock-user-repository.ts
+++ b/libs/modules/users/src/testing/mock-user-repository.ts
@@ -1,4 +1,3 @@
-import { decodeCursor } from '@nestjs-fastify-nx/shared';
 import type {
   FindAllCursorOptions,
   FindAllCursorResult,
@@ -40,15 +39,12 @@ export class MockUserRepository implements UserRepositoryPort {
     });
 
     if (startingAfter) {
-      const decoded = decodeCursor(startingAfter);
-      if (decoded) {
-        rows = rows.filter((u) => {
-          const tDiff = u.createdAt.getTime() - decoded.createdAt.getTime();
-          if (tDiff < 0) return true;
-          if (tDiff === 0) return u.id < decoded.id;
-          return false;
-        });
-      }
+      rows = rows.filter((u) => {
+        const tDiff = u.createdAt.getTime() - startingAfter.createdAt.getTime();
+        if (tDiff < 0) return true;
+        if (tDiff === 0) return u.id < startingAfter.id;
+        return false;
+      });
     }
 
     const hasMore = rows.length > limit;

--- a/libs/shared/README.md
+++ b/libs/shared/README.md
@@ -12,26 +12,49 @@ nothing internal.
 ```ts
 import {
   generateId,
+  generateCorrelationId,
   buildPageMeta,
   paginationSkip,
   type Page,
   type PageMeta,
   type PaginationOptions,
+  encodeCursor,
+  decodeCursor,
+  type DecodedCursor,
   QUEUE_NAMES,
   type QueueName,
   SENSITIVE_REDACT_PATHS,
   SENSITIVE_REDACT_CENSOR,
+  ALLOWED_MIME_TYPES,
+  MIME_EXTENSIONS,
+  detectFileType,
+  type DetectedFileType,
+  intEnv,
+  positiveIntEnv,
+  boolEnv,
+  injectDatabasePassword,
+  STORED_FILE_STATUS,
+  type StoredFileStatus,
 } from '@nestjs-fastify-nx/shared';
 ```
 
-| Export                                               | Purpose                                                          |
-| ---------------------------------------------------- | ---------------------------------------------------------------- |
-| `generateId()`                                       | UUID v7 generator (`uuid@14`) — sortable, time-ordered           |
-| `buildPageMeta(page, pageSize, total)`               | Builds a `PageMeta` from page/pageSize + total count             |
-| `paginationSkip({ page, pageSize })`                 | `(page - 1) * pageSize`, clamped to safe values                  |
-| `Page<T>`, `PageMeta`, `PaginationOptions`           | Pure type aliases for the paginated query contract               |
-| `QUEUE_NAMES` / `QueueName`                          | Single source of truth for BullMQ queue identifiers              |
-| `SENSITIVE_REDACT_PATHS` / `SENSITIVE_REDACT_CENSOR` | Pino redaction config — drops `cookie` / `authorization` headers |
+| Export                                               | Purpose                                                                                    |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `generateId()`                                       | UUID v7 generator (`uuid@14`) — sortable, time-ordered                                     |
+| `generateCorrelationId()`                            | Correlation id for a request/trace chain                                                   |
+| `buildPageMeta(page, pageSize, total)`               | Builds a `PageMeta` from page/pageSize + total count                                       |
+| `paginationSkip({ page, pageSize })`                 | `(page - 1) * pageSize`, clamped so a bad page can't reach the driver as a negative skip   |
+| `Page<T>`, `PageMeta`, `PaginationOptions`           | Pure type aliases for the offset-paginated query contract                                  |
+| `encodeCursor(sortField, id)` / `decodeCursor(s)`    | Composite `base64url(iso:id)` cursor — cursor pagination is the default for resource lists |
+| `DecodedCursor`                                      | A cursor that has passed validation; repository ports take this, never a raw string        |
+| `QUEUE_NAMES` / `QueueName`                          | Single source of truth for BullMQ queue identifiers                                        |
+| `SENSITIVE_REDACT_PATHS` / `SENSITIVE_REDACT_CENSOR` | Pino redaction config — drops `cookie` / `authorization` headers                           |
+| `ALLOWED_MIME_TYPES`                                 | Upload allow-list, derived from the magic-byte signature table                             |
+| `MIME_EXTENSIONS`                                    | mime → canonical extension, derived from the same table so the two cannot drift            |
+| `detectFileType(buffer)` / `DetectedFileType`        | Magic-byte sniffing; `null` when no signature matches                                      |
+| `intEnv` / `positiveIntEnv` / `boolEnv`              | Typed `process.env` readers with defaults, for code outside Nest's config validation       |
+| `injectDatabasePassword(url)`                        | Splices a Docker/K8s secret file into a password-less DB URL                               |
+| `STORED_FILE_STATUS` / `StoredFileStatus`            | Upload lifecycle states (`FINALIZING`, `VERIFYING`, `READY`, `REJECTED`)                   |
 
 ## Why a separate lib?
 

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -15,6 +15,7 @@ export {
   type DetectedFileType,
 } from './lib/file-signature';
 export { intEnv, positiveIntEnv, boolEnv } from './lib/env-readers';
+export { redisReconnectStrategy } from './lib/redis-reconnect';
 export { encodeCursor, decodeCursor, type DecodedCursor } from './lib/cursor-pagination';
 export { injectDatabasePassword } from './lib/db-password-file';
 export { STORED_FILE_STATUS, type StoredFileStatus } from './lib/stored-file-status';

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -8,8 +8,13 @@ export {
 } from './lib/pagination.types';
 export { QUEUE_NAMES, type QueueName } from './lib/queue-names';
 export { SENSITIVE_REDACT_PATHS, SENSITIVE_REDACT_CENSOR } from './lib/logger-redact';
-export { ALLOWED_MIME_TYPES, detectFileType, type DetectedFileType } from './lib/file-signature';
+export {
+  ALLOWED_MIME_TYPES,
+  MIME_EXTENSIONS,
+  detectFileType,
+  type DetectedFileType,
+} from './lib/file-signature';
 export { intEnv, positiveIntEnv, boolEnv } from './lib/env-readers';
-export { encodeCursor, decodeCursor } from './lib/cursor-pagination';
+export { encodeCursor, decodeCursor, type DecodedCursor } from './lib/cursor-pagination';
 export { injectDatabasePassword } from './lib/db-password-file';
 export { STORED_FILE_STATUS, type StoredFileStatus } from './lib/stored-file-status';

--- a/libs/shared/src/lib/cursor-pagination.ts
+++ b/libs/shared/src/lib/cursor-pagination.ts
@@ -2,11 +2,18 @@
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+// A cursor that has already passed validation. Repository ports take this rather than the raw
+// string so a malformed cursor is unrepresentable below the boundary that decodes it.
+export interface DecodedCursor {
+  createdAt: Date;
+  id: string;
+}
+
 export function encodeCursor(sortField: Date, id: string): string {
   return Buffer.from(`${sortField.toISOString()}:${id}`).toString('base64url');
 }
 
-export function decodeCursor(cursor: string): { createdAt: Date; id: string } | null {
+export function decodeCursor(cursor: string): DecodedCursor | null {
   try {
     if (!cursor || !BASE64URL.test(cursor)) return null;
     const bytes = Buffer.from(cursor, 'base64url');

--- a/libs/shared/src/lib/file-signature.ts
+++ b/libs/shared/src/lib/file-signature.ts
@@ -23,6 +23,13 @@ const SIGNATURES: readonly Signature[] = [
 
 export const ALLOWED_MIME_TYPES = new Set(SIGNATURES.map((s) => s.mimeType));
 
+// Canonical extension per mime, derived from the same table that drives magic-byte detection.
+// Hand-maintaining this mapping next to SIGNATURES lets the two drift: a format could become
+// presignable with no signature to verify it against on confirm, or vice versa.
+export const MIME_EXTENSIONS: ReadonlyMap<string, string> = new Map(
+  SIGNATURES.map((s) => [s.mimeType, s.extensions[0]]),
+);
+
 export interface DetectedFileType {
   readonly mimeType: string;
   readonly extension: string;

--- a/libs/shared/src/lib/file-signature.ts
+++ b/libs/shared/src/lib/file-signature.ts
@@ -23,9 +23,8 @@ const SIGNATURES: readonly Signature[] = [
 
 export const ALLOWED_MIME_TYPES = new Set(SIGNATURES.map((s) => s.mimeType));
 
-// Canonical extension per mime, derived from the same table that drives magic-byte detection.
-// Hand-maintaining this mapping next to SIGNATURES lets the two drift: a format could become
-// presignable with no signature to verify it against on confirm, or vice versa.
+// Derived from SIGNATURES, not hand-kept beside it: a second list drifts, and a format could then
+// become presignable with no signature to verify it against on confirm.
 export const MIME_EXTENSIONS: ReadonlyMap<string, string> = new Map(
   SIGNATURES.map((s) => [s.mimeType, s.extensions[0]]),
 );

--- a/libs/shared/src/lib/pagination.types.spec.ts
+++ b/libs/shared/src/lib/pagination.types.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildPageMeta, paginationSkip } from './pagination.types';
+
+describe('paginationSkip', () => {
+  it('computes (page - 1) * pageSize for valid input', () => {
+    expect(paginationSkip({ page: 1, pageSize: 20 })).toBe(0);
+    expect(paginationSkip({ page: 2, pageSize: 20 })).toBe(20);
+    expect(paginationSkip({ page: 5, pageSize: 100 })).toBe(400);
+  });
+
+  // A negative skip reaches Prisma as `Argument skip cannot be negative` — an error naming the
+  // driver, not the caller that passed page 0.
+  it('clamps page below 1 up to the first page rather than emitting a negative skip', () => {
+    expect(paginationSkip({ page: 0, pageSize: 20 })).toBe(0);
+    expect(paginationSkip({ page: -5, pageSize: 20 })).toBe(0);
+  });
+
+  it('clamps a negative pageSize to zero', () => {
+    expect(paginationSkip({ page: 3, pageSize: -10 })).toBe(0);
+  });
+
+  it('truncates fractional input to whole rows', () => {
+    expect(paginationSkip({ page: 2.9, pageSize: 20 })).toBe(20);
+    expect(paginationSkip({ page: 3, pageSize: 10.7 })).toBe(20);
+  });
+
+  it('falls back to a safe skip for non-finite input', () => {
+    expect(paginationSkip({ page: Number.NaN, pageSize: 20 })).toBe(0);
+    expect(paginationSkip({ page: Number.POSITIVE_INFINITY, pageSize: 20 })).toBe(0);
+    expect(paginationSkip({ page: 2, pageSize: Number.NaN })).toBe(0);
+  });
+});
+
+describe('buildPageMeta', () => {
+  it('reports totalPages and neighbour flags for a middle page', () => {
+    expect(buildPageMeta(2, 10, 35)).toEqual({
+      page: 2,
+      pageSize: 10,
+      total: 35,
+      totalPages: 4,
+      hasPrevPage: true,
+      hasNextPage: true,
+    });
+  });
+
+  it('reports a single page when there are no rows', () => {
+    const meta = buildPageMeta(1, 10, 0);
+    expect(meta.totalPages).toBe(1);
+    expect(meta.hasPrevPage).toBe(false);
+    expect(meta.hasNextPage).toBe(false);
+  });
+
+  it('marks the last page as having no next page', () => {
+    const meta = buildPageMeta(4, 10, 35);
+    expect(meta.hasNextPage).toBe(false);
+    expect(meta.hasPrevPage).toBe(true);
+  });
+});

--- a/libs/shared/src/lib/pagination.types.ts
+++ b/libs/shared/src/lib/pagination.types.ts
@@ -29,6 +29,11 @@ export function buildPageMeta(page: number, pageSize: number, total: number): Pa
   };
 }
 
+// Clamped, as libs/shared/README.md promises. PaginationDto's @Min(1) only guards the HTTP path —
+// a service, queue consumer, or test calling this directly could otherwise produce a negative skip,
+// which Prisma rejects at the driver with an error that says nothing about which page caused it.
 export function paginationSkip(options: PaginationOptions): number {
-  return (options.page - 1) * options.pageSize;
+  const page = Number.isFinite(options.page) ? Math.max(1, Math.trunc(options.page)) : 1;
+  const pageSize = Number.isFinite(options.pageSize) ? Math.max(0, Math.trunc(options.pageSize)) : 0;
+  return (page - 1) * pageSize;
 }

--- a/libs/shared/src/lib/pagination.types.ts
+++ b/libs/shared/src/lib/pagination.types.ts
@@ -34,6 +34,8 @@ export function buildPageMeta(page: number, pageSize: number, total: number): Pa
 // which Prisma rejects at the driver with an error that says nothing about which page caused it.
 export function paginationSkip(options: PaginationOptions): number {
   const page = Number.isFinite(options.page) ? Math.max(1, Math.trunc(options.page)) : 1;
-  const pageSize = Number.isFinite(options.pageSize) ? Math.max(0, Math.trunc(options.pageSize)) : 0;
+  const pageSize = Number.isFinite(options.pageSize)
+    ? Math.max(0, Math.trunc(options.pageSize))
+    : 0;
   return (page - 1) * pageSize;
 }

--- a/libs/shared/src/lib/pagination.types.ts
+++ b/libs/shared/src/lib/pagination.types.ts
@@ -29,9 +29,8 @@ export function buildPageMeta(page: number, pageSize: number, total: number): Pa
   };
 }
 
-// Clamped, as libs/shared/README.md promises. PaginationDto's @Min(1) only guards the HTTP path —
-// a service, queue consumer, or test calling this directly could otherwise produce a negative skip,
-// which Prisma rejects at the driver with an error that says nothing about which page caused it.
+// PaginationDto's @Min(1) only guards the HTTP path; a direct caller could otherwise hand Prisma a
+// negative skip, which it rejects with an error naming the driver rather than the bad page.
 export function paginationSkip(options: PaginationOptions): number {
   const page = Number.isFinite(options.page) ? Math.max(1, Math.trunc(options.page)) : 1;
   const pageSize = Number.isFinite(options.pageSize)

--- a/libs/shared/src/lib/redis-reconnect.spec.ts
+++ b/libs/shared/src/lib/redis-reconnect.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { redisReconnectStrategy } from './redis-reconnect';
+
+describe('redisReconnectStrategy', () => {
+  // ioredis stops reconnecting for good on a non-number, stranding every feature behind the client
+  // after any outage. This must never return anything but a positive, finite delay.
+  it('always returns a positive finite number, however many attempts have failed', () => {
+    for (const attempt of [1, 2, 9, 10, 11, 100, 10_000]) {
+      const delay = redisReconnectStrategy(attempt);
+      expect(typeof delay, `attempt ${attempt} must yield a retry delay`).toBe('number');
+      expect(Number.isFinite(delay)).toBe(true);
+      expect(delay).toBeGreaterThan(0);
+    }
+  });
+
+  it('backs off linearly then holds at the 3s cap', () => {
+    expect(redisReconnectStrategy(1)).toBe(200);
+    expect(redisReconnectStrategy(5)).toBe(1000);
+    expect(redisReconnectStrategy(15)).toBe(3000);
+    expect(redisReconnectStrategy(1000)).toBe(3000);
+  });
+});

--- a/libs/shared/src/lib/redis-reconnect.ts
+++ b/libs/shared/src/lib/redis-reconnect.ts
@@ -1,0 +1,12 @@
+const RECONNECT_STEP_MS = 200;
+const RECONNECT_CAP_MS = 3000;
+
+// ioredis treats any non-number returned from `retryStrategy` as "stop reconnecting for good".
+// That turns a transient Redis blip into a permanent failure — the client never heals and the
+// feature behind it (queue, rate limit, idempotency, health probe, metrics leadership, WS pub/sub)
+// stays broken until the process restarts. Always return a capped backoff delay instead; per-command
+// timeouts (`maxRetriesPerRequest`, `enableOfflineQueue: false`) are what bound how long a call waits
+// during the outage, not this.
+export function redisReconnectStrategy(times: number): number {
+  return Math.min(times * RECONNECT_STEP_MS, RECONNECT_CAP_MS);
+}

--- a/libs/testing/README.md
+++ b/libs/testing/README.md
@@ -14,19 +14,31 @@ import {
   createTestContainers,
   type TestContainers,
   DatabaseCleaner,
+  deployTestMigrations,
 } from '@nestjs-fastify-nx/testing';
 ```
 
 ### `createTestContainers()`
 
-Boots ephemeral Postgres 18 and Redis 8 containers, runs `prisma migrate
-deploy` against the fresh DB, and returns connection details + a `teardown()`
-hook. Use it in `beforeAll`; tear down in `afterAll`.
+Boots ephemeral Postgres 18 and Redis 8 containers and returns the two started
+containers plus a `teardown()` hook. It does **not** migrate — call
+`deployTestMigrations(databaseUrl)` yourself once the URL is known, or every
+query fails with `relation does not exist`. Use it in `beforeAll`; tear down in
+`afterAll`.
+
+The containers start sequentially, and the first is stopped if the second fails
+to start — a `Promise.all` would leave the survivor running with no handle left
+to stop it.
 
 ```ts
 const containers = await createTestContainers();
-process.env.DATABASE_URL = containers.databaseUrl;
-process.env.REDIS_CACHE_HOST = containers.redisHost;
+const databaseUrl = containers.postgres.getConnectionUri();
+
+process.env.DATABASE_URL = databaseUrl;
+process.env.REDIS_CACHE_HOST = containers.redis.getHost();
+process.env.REDIS_CACHE_PORT = String(containers.redis.getFirstMappedPort());
+
+deployTestMigrations(databaseUrl);
 // ... boot the Nest test module ...
 await containers.teardown();
 ```

--- a/libs/testing/src/lib/containers/test-containers.ts
+++ b/libs/testing/src/lib/containers/test-containers.ts
@@ -7,11 +7,14 @@ export interface TestContainers {
   teardown: () => Promise<void>;
 }
 
+// Pinned to the same major as docker/compose.yml so tests exercise the Redis the apps actually run
+// against. Started sequentially, not via Promise.all: a rejected Promise.all discards the other
+// container's handle mid-flight, leaving it running with nothing left holding a reference to stop it.
 export async function createTestContainers(): Promise<TestContainers> {
   const postgres = await new PostgreSqlContainer('postgres:18-alpine').start();
   let redis: StartedRedisContainer;
   try {
-    redis = await new RedisContainer('redis:7-alpine').start();
+    redis = await new RedisContainer('redis:8-alpine').start();
   } catch (error) {
     await postgres.stop().catch(() => undefined);
     throw error;

--- a/libs/testing/src/lib/containers/test-containers.ts
+++ b/libs/testing/src/lib/containers/test-containers.ts
@@ -7,9 +7,8 @@ export interface TestContainers {
   teardown: () => Promise<void>;
 }
 
-// Pinned to the same major as docker/compose.yml so tests exercise the Redis the apps actually run
-// against. Started sequentially, not via Promise.all: a rejected Promise.all discards the other
-// container's handle mid-flight, leaving it running with nothing left holding a reference to stop it.
+// Images match docker/compose.yml so tests exercise what the apps run against. Sequential, not
+// Promise.all: a rejection there discards the other handle, leaking a running container.
 export async function createTestContainers(): Promise<TestContainers> {
   const postgres = await new PostgreSqlContainer('postgres:18-alpine').start();
   let redis: StartedRedisContainer;

--- a/prisma/migrations/20260717000000_verification_lookup_indexes/migration.sql
+++ b/prisma/migrations/20260717000000_verification_lookup_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- Better Auth reads "verifications" only by "identifier" (ORDER BY "createdAt" DESC LIMIT 1) —
+-- every password-reset, email-verification, and delete-account confirmation hits that path. The
+-- table shipped with only its primary key, so each of those lookups was a sequential scan.
+-- "expiresAt" backs the scheduler's expired-token purge, which is what keeps the table bounded.
+--
+-- Plain CREATE INDEX (not CONCURRENTLY): prisma migrate deploy runs each migration inside a
+-- transaction, and CONCURRENTLY cannot run in one. This takes a brief write lock on "verifications".
+-- The table holds only short-lived auth tokens, so it is small; on an existing deployment that let
+-- it grow unbounded before the purge job existed, delete expired rows first.
+CREATE INDEX "verifications_identifier_createdAt_idx" ON "verifications"("identifier", "createdAt" DESC);
+CREATE INDEX "verifications_expiresAt_idx" ON "verifications"("expiresAt");

--- a/prisma/migrations/20260717000000_verification_lookup_indexes/migration.sql
+++ b/prisma/migrations/20260717000000_verification_lookup_indexes/migration.sql
@@ -1,11 +1,8 @@
--- Better Auth reads "verifications" only by "identifier" (ORDER BY "createdAt" DESC LIMIT 1) —
--- every password-reset, email-verification, and delete-account confirmation hits that path. The
--- table shipped with only its primary key, so each of those lookups was a sequential scan.
--- "expiresAt" backs the scheduler's expired-token purge, which is what keeps the table bounded.
+-- Better Auth reads "verifications" only by "identifier", ordered by "createdAt" — every
+-- password-reset, email-verification and delete-account confirmation takes that path.
+-- "expiresAt" backs the scheduler's expired-token purge.
 --
--- Plain CREATE INDEX (not CONCURRENTLY): prisma migrate deploy runs each migration inside a
--- transaction, and CONCURRENTLY cannot run in one. This takes a brief write lock on "verifications".
--- The table holds only short-lived auth tokens, so it is small; on an existing deployment that let
--- it grow unbounded before the purge job existed, delete expired rows first.
+-- Not CONCURRENTLY: migrate deploy wraps each migration in a transaction, which CONCURRENTLY
+-- cannot run inside. This briefly locks writes; purge expired rows first if the table is large.
 CREATE INDEX "verifications_identifier_createdAt_idx" ON "verifications"("identifier", "createdAt" DESC);
 CREATE INDEX "verifications_expiresAt_idx" ON "verifications"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,9 +26,8 @@ model User {
   @@index([status])
   @@index([createdAt])
   @@index([status, updatedAt])
-  // Composite backing cursor pagination, which reads ORDER BY createdAt DESC, id DESC.
-  // Declared with the real sort order and the real index name: without them `migrate diff` sees
-  // drift against the DDL and the next `migrate dev` writes a migration that drops this index.
+  // Backs cursor pagination (ORDER BY createdAt DESC, id DESC). Sort order and name must match the
+  // DDL exactly — otherwise `migrate diff` sees drift and the next `migrate dev` drops the index.
   @@index([createdAt(sort: Desc), id(sort: Desc)], map: "users_createdAt_id_desc_idx")
   @@index([email(ops: raw("gin_trgm_ops"))], type: Gin, map: "users_email_trgm_idx")
   @@index([name(ops: raw("gin_trgm_ops"))], type: Gin, map: "users_name_trgm_idx")
@@ -79,9 +78,8 @@ model Verification {
   createdAt  DateTime? @default(now())
   updatedAt  DateTime? @updatedAt
 
-  // Better Auth reads this table only by `identifier` (ordered by createdAt desc, limit 1) on every
-  // password-reset, email-verification, and delete-account confirmation. Without this index each of
-  // those is a sequential scan. `expiresAt` backs the scheduler's expired-token purge.
+  // Better Auth reads this table only by `identifier`, ordered by createdAt — every password-reset,
+  // email-verification and delete-account confirmation. `expiresAt` backs the scheduler's purge.
   @@index([identifier, createdAt(sort: Desc)])
   @@index([expiresAt])
   @@map("verifications")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,11 @@ model Verification {
   createdAt  DateTime? @default(now())
   updatedAt  DateTime? @updatedAt
 
+  // Better Auth reads this table only by `identifier` (ordered by createdAt desc, limit 1) on every
+  // password-reset, email-verification, and delete-account confirmation. Without this index each of
+  // those is a sequential scan. `expiresAt` backs the scheduler's expired-token purge.
+  @@index([identifier, createdAt(sort: Desc)])
+  @@index([expiresAt])
   @@map("verifications")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,11 +26,12 @@ model User {
   @@index([status])
   @@index([createdAt])
   @@index([status, updatedAt])
-  // Composite for cursor pagination — see migration
-  // 20260601200000_users_cursor_composite_index. Prisma's schema DSL has no
-  // sort-order qualifier so the DESC ordering is enforced by the raw SQL
-  // migration only; the @@index here keeps `prisma db pull` round-trippable.
-  @@index([createdAt, id])
+  // Composite backing cursor pagination, which reads ORDER BY createdAt DESC, id DESC.
+  // Declared with the real sort order and the real index name: without them `migrate diff` sees
+  // drift against the DDL and the next `migrate dev` writes a migration that drops this index.
+  @@index([createdAt(sort: Desc), id(sort: Desc)], map: "users_createdAt_id_desc_idx")
+  @@index([email(ops: raw("gin_trgm_ops"))], type: Gin, map: "users_email_trgm_idx")
+  @@index([name(ops: raw("gin_trgm_ops"))], type: Gin, map: "users_name_trgm_idx")
   @@map("users")
 }
 

--- a/tools/generators/src/generators/module/files/src/application/commands/create-__fileName__/create-__fileName__.command.ts__template__
+++ b/tools/generators/src/generators/module/files/src/application/commands/create-__fileName__/create-__fileName__.command.ts__template__
@@ -1,3 +1,9 @@
-export class Create<%= className %>Command {
-  constructor(readonly requestedBy: string) {}
+import { Command } from '@nestjs/cqrs';
+import type { <%= className %> } from '../../../domain';
+
+// Command<TResult> carries the result type so CommandBus.execute() infers it end-to-end.
+export class Create<%= className %>Command extends Command<<%= className %>> {
+  constructor(readonly requestedBy: string) {
+    super();
+  }
 }

--- a/tools/generators/src/generators/module/files/src/application/commands/create-__fileName__/create-__fileName__.handler.ts__template__
+++ b/tools/generators/src/generators/module/files/src/application/commands/create-__fileName__/create-__fileName__.handler.ts__template__
@@ -1,11 +1,16 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject } from '@nestjs/common';
+import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
 import { Create<%= className %>Command } from './create-<%= fileName %>.command';
 import { <%= constantName %>_REPOSITORY } from '../../../domain';
 import type { <%= className %>RepositoryPort } from '../../../domain';
 import { <%= className %> } from '../../../domain';
 
-@Injectable()
-export class Create<%= className %>Handler {
+// @CommandHandler (not @Injectable) is what CqrsModule's explorer looks for. Consumers dispatch
+// `commandBus.execute(new Create<%= className %>Command(...))` — never inject this class directly.
+@CommandHandler(Create<%= className %>Command)
+export class Create<%= className %>Handler
+  implements ICommandHandler<Create<%= className %>Command, <%= className %>>
+{
   constructor(
     @Inject(<%= constantName %>_REPOSITORY)
     private readonly repository: <%= className %>RepositoryPort,

--- a/tools/generators/src/generators/module/files/src/application/index.ts__template__
+++ b/tools/generators/src/generators/module/files/src/application/index.ts__template__
@@ -1,3 +1,4 @@
-<% if (withCqrs) { %>export { Create<%= className %>Command } from './commands/create-<%= fileName %>/create-<%= fileName %>.command';
-export { Create<%= className %>Handler } from './commands/create-<%= fileName %>/create-<%= fileName %>.handler';
+<% if (withCqrs) { %>// Command classes only. Handlers stay internal — CqrsModule's explorer registers them from the
+// module's providers, and injecting one directly bypasses the bus.
+export { Create<%= className %>Command } from './commands/create-<%= fileName %>/create-<%= fileName %>.command';
 <% } %>

--- a/tools/generators/src/generators/module/files/src/index.ts__template__
+++ b/tools/generators/src/generators/module/files/src/index.ts__template__
@@ -1,1 +1,7 @@
 export { <%= className %>Module } from './<%= fileName %>.module';
+<% if (withCqrs) { %>
+// Re-exported so cross-cutting consumers (composition libs, other apps) can dispatch through the
+// CommandBus. Without this the command is unreachable outside this module — the tsconfig path
+// alias resolves to this barrel and nothing else.
+export { Create<%= className %>Command } from './application';
+<% } %>

--- a/tools/generators/src/generators/module/files/vitest.config.mts__template__
+++ b/tools/generators/src/generators/module/files/vitest.config.mts__template__
@@ -7,7 +7,7 @@ export default defineConfig(() => ({
   cacheDir: '<%= offsetFromRoot %>node_modules/.vite/<%= projectRoot %>',
   resolve: { tsconfigPaths: true },
   test: {
-    name: 'modules-<%= fileName %>',
+    name: '<%= projectName %>',
     watch: false,
     globals: true,
     environment: 'node',

--- a/tools/generators/src/generators/module/generator.spec.ts
+++ b/tools/generators/src/generators/module/generator.spec.ts
@@ -141,6 +141,60 @@ describe('module generator', () => {
     ).toBe(true);
   });
 
+  // The generated command/handler must be dispatchable through the CommandBus. Asserting on content
+  // rather than file existence: a handler missing @CommandHandler still produces both files, but
+  // CqrsModule's explorer never registers it, so `commandBus.execute` fails at runtime.
+  it('generates a command that extends Command<TResult> so execute() infers the return type', async () => {
+    await moduleGenerator(tree, { name: 'tasks', directory: 'modules', withCqrs: true });
+
+    const command = tree.read(
+      'libs/modules/tasks/src/application/commands/create-tasks/create-tasks.command.ts',
+      'utf-8',
+    );
+    expect(command).toContain("import { Command } from '@nestjs/cqrs'");
+    expect(command).toContain('export class CreateTasksCommand extends Command<Tasks>');
+  });
+
+  it('generates a handler decorated with @CommandHandler and implementing ICommandHandler', async () => {
+    await moduleGenerator(tree, { name: 'tasks', directory: 'modules', withCqrs: true });
+
+    const handler = tree.read(
+      'libs/modules/tasks/src/application/commands/create-tasks/create-tasks.handler.ts',
+      'utf-8',
+    );
+    expect(handler).toContain('@CommandHandler(CreateTasksCommand)');
+    // Whitespace-tolerant: prettier reflows the generic argument list across lines.
+    expect(handler).toMatch(/implements ICommandHandler<\s*CreateTasksCommand,\s*Tasks\s*>/);
+    // @Injectable would register the class as a plain provider and hide the missing bus wiring.
+    expect(handler).not.toContain('@Injectable()');
+  });
+
+  it('exports the command from the public barrel so other scopes can dispatch it', async () => {
+    await moduleGenerator(tree, { name: 'tasks', directory: 'modules', withCqrs: true });
+
+    const barrel = tree.read('libs/modules/tasks/src/index.ts', 'utf-8');
+    expect(barrel).toContain('CreateTasksCommand');
+  });
+
+  it('keeps handlers out of every barrel', async () => {
+    await moduleGenerator(tree, { name: 'tasks', directory: 'modules', withCqrs: true });
+
+    expect(tree.read('libs/modules/tasks/src/index.ts', 'utf-8')).not.toContain(
+      'CreateTasksHandler',
+    );
+    expect(tree.read('libs/modules/tasks/src/application/index.ts', 'utf-8')).not.toContain(
+      'CreateTasksHandler',
+    );
+  });
+
+  it('names the vitest project after the resolved project name, not a hardcoded modules- prefix', async () => {
+    await moduleGenerator(tree, { name: 'billing', directory: 'composition', withCqrs: false });
+
+    const vitestConfig = tree.read('libs/composition/billing/vitest.config.mts', 'utf-8');
+    expect(vitestConfig).toContain("name: 'composition-billing'");
+    expect(vitestConfig).not.toContain('modules-billing');
+  });
+
   it('emits controller with correct route segment (no pluralisation)', async () => {
     await moduleGenerator(tree, { name: 'users', directory: 'modules', withCqrs: false });
 

--- a/tools/generators/src/generators/module/generator.spec.ts
+++ b/tools/generators/src/generators/module/generator.spec.ts
@@ -141,9 +141,8 @@ describe('module generator', () => {
     ).toBe(true);
   });
 
-  // The generated command/handler must be dispatchable through the CommandBus. Asserting on content
-  // rather than file existence: a handler missing @CommandHandler still produces both files, but
-  // CqrsModule's explorer never registers it, so `commandBus.execute` fails at runtime.
+  // Asserting on content, not file existence: a handler missing @CommandHandler still emits both
+  // files, but the explorer never registers it and commandBus.execute fails at runtime.
   it('generates a command that extends Command<TResult> so execute() infers the return type', async () => {
     await moduleGenerator(tree, { name: 'tasks', directory: 'modules', withCqrs: true });
 

--- a/tools/generators/src/generators/module/generator.ts
+++ b/tools/generators/src/generators/module/generator.ts
@@ -73,6 +73,7 @@ export async function moduleGenerator(tree: Tree, options: ModuleGeneratorSchema
   generateFiles(tree, path.join(__dirname, 'files'), projectRoot, {
     ...moduleNames,
     withCqrs,
+    projectName,
     projectRoot,
     offsetFromRoot: offset,
     template: '',


### PR DESCRIPTION
## Summary

A full audit of the codebase and all 51 markdown docs, verified against running services rather than by reading alone. 18 focused commits: correctness and resilience fixes, status-code and contract corrections, a repo-wide reconnection-strategy fix, and ~50 documentation corrections. Every claim below was checked against the live stack (Postgres/Redis/API in Docker), the exported OpenAPI spec, or `prisma migrate diff` — not just static review.

## Highest-severity fixes

- **Redis clients gave up reconnecting after a blip (8 places).** `retryStrategy` returned a non-number, which ioredis reads as "stop reconnecting for good" — a transient outage permanently disabled the queue, health probes, metrics leadership, throttler, auth rate-limit, idempotency, and WebSocket pub/sub until a process restart. Consolidated into one shared `redisReconnectStrategy`. Reproduced live: stop redis-cache → readiness stays 503 forever before, recovers in ~2s after.
- **`libs/api-client` never worked.** `baseURL` carried `/api/v1` while every generated op already embeds the full path, so axios sent `/api/v1/api/v1/users/me` → 404 on every call. baseURL is now origin-only.
- **GraphQL leaked internal error messages in production** while REST masked them. Added an error formatter mirroring the REST rule.
- **Health-probe 503 lost the failing dependency.** The global filter flattened terminus's HealthCheckResult to a bare "Service Unavailable"; it now carries a `checks` map naming what is down, as RFC 9457 problem+json, and the OpenAPI spec now matches runtime.
- **CQRS generator emitted non-CQRS code.** Scaffolded commands/handlers lacked `extends Command<T>` / `@CommandHandler`, so `commandBus.execute` failed at runtime for every new module.
- **`verifications` had no index and no purge** — every password-reset/verify-email lookup was a sequential scan on an unbounded table. Added the composite index + a scheduler purge task.

## Contract & status-code corrections

- Deactivated/banned account: `401` → `403` (a valid session can't be fixed by re-authenticating; 401 looped SPAs through login forever).
- Upload-confirm policy violations: `400` → `422` (the request was understood; the stored object breaks policy).
- Removed a dead `statusCode` field from ~26 exception payloads (the filter never read it).
- Consolidated every hand-rolled `problem+json` body through `buildProblemDetails` so `type`/shape are uniform.
- Cursor pagination decoded once at the boundary; repository ports now take a validated `DecodedCursor`.
- Documented the status-code decision table in `docs/code-standards.md`.

## Schema

- Declared the `users` cursor/search indexes to match the DDL (sort order + names + GIN ops) so `migrate diff` is empty — previously the next `migrate dev` would have dropped them.

## CI / infra

- `release.yml` now runs Trivy **before** pushing to GHCR, so a vulnerable image is never published or signed. ⚠️ This workflow only runs on `v*.*.*` tags and has not been executed — recommend a dry-run tag on a fork before relying on it.
- Fixed `full-check.yml` running Node 22 while the project targets Node 24.
- Documented the `docker.sock :ro` caveat in the observability overlay.

## Documentation

~50 corrections across README, CONTRIBUTING, CLAUDE.md, CHANGELOG, `docs/*`, and lib READMEs — including SQL in the runbook that referenced non-existent columns (every SQL block now runs clean against the live DB), stale Node/Nx versions, a documented "Coolify deploy" and "multi-platform build" that don't exist, wrong endpoints (`/docs`, `/metrics`), and lib READMEs promising APIs that aren't exported.

## Verification

- `typecheck` 21/21, `lint` 21/21, `format` clean
- 412 unit tests + 50 e2e (Testcontainers) green
- OpenAPI spec asserted against code; `prisma migrate diff` empty; runbook SQL executed against live Postgres
- Independent adversarial review of the earlier commits found no defects

## Not covered / residual risk

- `release.yml` has never actually executed (tag-triggered only).
- Pure barrel/module-wiring/thin-declaration files were confirmed via typecheck + e2e boot rather than line-by-line reading.
