### PR TITLE
feat: add DATABASE_LOG_QUERIES for full query debugging in dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ DB_PASSWORD_FILE=
 # Prisma query events slower than this are logged as `warn` (query template + duration only —
 # params are never logged, they can carry PII/secrets).
 DATABASE_SLOW_QUERY_MS=200
+# Dev debugging: log EVERY query at `debug` level, INCLUDING params. Set LOG_LEVEL=debug to see them.
+# Ignored in production — params must never reach a production log. Leave false unless debugging.
+DATABASE_LOG_QUERIES=false
 # Deep dependency health turns unhealthy when physical replica replay lag exceeds this.
 DB_REPLICATION_LAG_THRESHOLD_MS=30000
 

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -22,6 +22,11 @@ const envSchema = z
     // Prisma query events above this duration are logged as `warn` (query template + duration
     // only — never params, which can carry PII/secrets). See PrismaService.
     DATABASE_SLOW_QUERY_MS: z.coerce.number().int().min(1).default(200),
+    // Dev-only full query logging (incl. params) at debug level. PrismaService ignores it in production.
+    DATABASE_LOG_QUERIES: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
 
     // Redis cache
     REDIS_CACHE_HOST: z.string().default('localhost'),

--- a/apps/scheduler/src/config/env.validation.ts
+++ b/apps/scheduler/src/config/env.validation.ts
@@ -15,6 +15,11 @@ const schedulerEnvSchema = z
     DB_PASSWORD_FILE: z.string().trim().min(1).optional(),
     // Prisma query events above this duration are logged as `warn`. See PrismaService.
     DATABASE_SLOW_QUERY_MS: z.coerce.number().int().min(1).default(200),
+    // Dev-only full query logging (incl. params) at debug level. PrismaService ignores it in production.
+    DATABASE_LOG_QUERIES: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
 
     REDIS_QUEUE_HOST: z.string().default('localhost'),
     REDIS_QUEUE_PORT: z.coerce.number().int().min(1).max(65535).default(6380),

--- a/apps/worker/src/config/env.validation.ts
+++ b/apps/worker/src/config/env.validation.ts
@@ -15,6 +15,11 @@ const workerEnvSchema = z
     DATABASE_APPLICATION_NAME: z.string().default('nestjs-fastify-worker'),
     DB_PASSWORD_FILE: z.string().trim().min(1).optional(),
     DATABASE_SLOW_QUERY_MS: z.coerce.number().int().min(1).default(200),
+    // Dev-only full query logging (incl. params) at debug level. PrismaService ignores it in production.
+    DATABASE_LOG_QUERIES: z
+      .string()
+      .default('false')
+      .transform((v) => v === 'true'),
 
     // Redis queue
     REDIS_QUEUE_HOST: z.string().default('localhost'),

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -4,25 +4,26 @@ Copy `.env.example` to `.env` and fill in the values.
 
 ## Database
 
-| Variable                          | Default                                                   | Required    | Description                                                                                           |
-| --------------------------------- | --------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                    | `postgresql://postgres:postgres@localhost:5432/nestjs_db` | Yes         | PostgreSQL connection string                                                                          |
-| `DATABASE_DIRECT_URL`             | —                                                         | No          | Bypasses PgBouncer for migrations; also the feature flag that enables the PgBouncer deep-health check |
-| `DATABASE_REPLICA_URL`            | —                                                         | No          | Read replica. When set, `PrismaService.dbRead` routes lag-tolerant reads here                         |
-| `DATABASE_REPLICA_POOL_MAX`       | `10`                                                      | No          | Max pool connections against the replica                                                              |
-| `DATABASE_POOL_MAX`               | `20`                                                      | No          | Max pool connections                                                                                  |
-| `DATABASE_POOL_MIN`               | `0`                                                       | No          | Min pool connections                                                                                  |
-| `DATABASE_IDLE_TIMEOUT_MS`        | `10000`                                                   | No          | Idle connection timeout                                                                               |
-| `DATABASE_CONNECTION_TIMEOUT_MS`  | `5000`                                                    | No          | Connection acquire timeout                                                                            |
-| `DATABASE_STATEMENT_TIMEOUT_MS`   | `30000`                                                   | No          | Per-statement timeout                                                                                 |
-| `DATABASE_APPLICATION_NAME`       | `nestjs-fastify-api`                                      | No          | Surfaced in `pg_stat_activity`                                                                        |
-| `DB_PASSWORD_FILE`                | —                                                         | No          | Docker/Kubernetes secret file injected into password-less DB URLs                                     |
-| `DATABASE_SLOW_QUERY_MS`          | `200`                                                     | No          | Logs a `warn` (query template + duration, never params) above this threshold                          |
-| `DB_REPLICATION_LAG_THRESHOLD_MS` | `30000`                                                   | No          | Deep-health threshold for physical replica replay lag                                                 |
-| `POSTGRES_USER`                   | `postgres`                                                | Docker only | DB username for Compose                                                                               |
-| `POSTGRES_PASSWORD`               | `postgres`                                                | Docker only | DB password for Compose                                                                               |
-| `POSTGRES_DB`                     | `nestjs_db`                                               | Docker only | Database name for Compose                                                                             |
-| `POSTGRES_PORT`                   | `5432`                                                    | Docker only | Host port for Compose                                                                                 |
+| Variable                          | Default                                                   | Required    | Description                                                                                              |
+| --------------------------------- | --------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                    | `postgresql://postgres:postgres@localhost:5432/nestjs_db` | Yes         | PostgreSQL connection string                                                                             |
+| `DATABASE_DIRECT_URL`             | —                                                         | No          | Bypasses PgBouncer for migrations; also the feature flag that enables the PgBouncer deep-health check    |
+| `DATABASE_REPLICA_URL`            | —                                                         | No          | Read replica. When set, `PrismaService.dbRead` routes lag-tolerant reads here                            |
+| `DATABASE_REPLICA_POOL_MAX`       | `10`                                                      | No          | Max pool connections against the replica                                                                 |
+| `DATABASE_POOL_MAX`               | `20`                                                      | No          | Max pool connections                                                                                     |
+| `DATABASE_POOL_MIN`               | `0`                                                       | No          | Min pool connections                                                                                     |
+| `DATABASE_IDLE_TIMEOUT_MS`        | `10000`                                                   | No          | Idle connection timeout                                                                                  |
+| `DATABASE_CONNECTION_TIMEOUT_MS`  | `5000`                                                    | No          | Connection acquire timeout                                                                               |
+| `DATABASE_STATEMENT_TIMEOUT_MS`   | `30000`                                                   | No          | Per-statement timeout                                                                                    |
+| `DATABASE_APPLICATION_NAME`       | `nestjs-fastify-api`                                      | No          | Surfaced in `pg_stat_activity`                                                                           |
+| `DB_PASSWORD_FILE`                | —                                                         | No          | Docker/Kubernetes secret file injected into password-less DB URLs                                        |
+| `DATABASE_SLOW_QUERY_MS`          | `200`                                                     | No          | Logs a `warn` (query template + duration, never params) above this threshold                             |
+| `DATABASE_LOG_QUERIES`            | `false`                                                   | No          | Dev only: logs every query at `debug` **with params** (set `LOG_LEVEL=debug` too). Ignored in production |
+| `DB_REPLICATION_LAG_THRESHOLD_MS` | `30000`                                                   | No          | Deep-health threshold for physical replica replay lag                                                    |
+| `POSTGRES_USER`                   | `postgres`                                                | Docker only | DB username for Compose                                                                                  |
+| `POSTGRES_PASSWORD`               | `postgres`                                                | Docker only | DB password for Compose                                                                                  |
+| `POSTGRES_DB`                     | `nestjs_db`                                               | Docker only | Database name for Compose                                                                                |
+| `POSTGRES_PORT`                   | `5432`                                                    | Docker only | Host port for Compose                                                                                    |
 
 ## Redis
 

--- a/libs/infra/database/src/lib/prisma.service.spec.ts
+++ b/libs/infra/database/src/lib/prisma.service.spec.ts
@@ -207,3 +207,91 @@ describe('PrismaService — slow query logging', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('PrismaService — DATABASE_LOG_QUERIES full query debug logging', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/test';
+    delete process.env['DATABASE_REPLICA_URL'];
+    delete process.env['NODE_ENV'];
+    delete process.env['DATABASE_LOG_QUERIES'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  function captureQueryListener(): { listener: QueryListener | undefined } {
+    const captured: { listener: QueryListener | undefined } = { listener: undefined };
+    vi.spyOn(PrismaClient.prototype, '$on').mockImplementation(((
+      event: string,
+      cb: QueryListener,
+    ) => {
+      if (event === 'query') captured.listener = cb;
+    }) as typeof PrismaClient.prototype.$on);
+    return captured;
+  }
+
+  it('logs every query at debug WITH params when enabled outside production', () => {
+    process.env['DATABASE_LOG_QUERIES'] = 'true';
+    const captured = captureQueryListener();
+    const debugSpy = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+    new PrismaService();
+
+    captured.listener?.({
+      query: 'SELECT * FROM "User" WHERE "id" = $1',
+      params: '["a-real-value"]',
+      duration: 3,
+    });
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      { durationMs: 3, query: 'SELECT * FROM "User" WHERE "id" = $1', params: '["a-real-value"]' },
+      'Database query',
+    );
+  });
+
+  it('does not debug-log any query when DATABASE_LOG_QUERIES is unset', () => {
+    const captured = captureQueryListener();
+    const debugSpy = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+    new PrismaService();
+    captured.listener?.({ query: 'SELECT 1', params: '["x"]', duration: 3 });
+
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores the flag in production so params never reach a log', () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['DATABASE_LOG_QUERIES'] = 'true';
+    process.env['DATABASE_URL'] = 'postgresql://user:pass@db:5432/prod';
+    process.env['BETTER_AUTH_SECRET'] = 'x'.repeat(32);
+    const captured = captureQueryListener();
+    const debugSpy = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    new PrismaService();
+    captured.listener?.({ query: 'SELECT 1', params: '["secret"]', duration: 3 });
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    // The boot warning must announce that the flag was ignored.
+    const warnedIgnore = warnSpy.mock.calls.some((c) =>
+      String(c[0]).includes('ignored in production'),
+    );
+    expect(warnedIgnore).toBe(true);
+  });
+
+  it('DATABASE_LOG_QUERIES=false does not enable debug logging (string, not coerced)', () => {
+    process.env['DATABASE_LOG_QUERIES'] = 'false';
+    const captured = captureQueryListener();
+    const debugSpy = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+    new PrismaService();
+    captured.listener?.({ query: 'SELECT 1', params: '["x"]', duration: 3 });
+
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/infra/database/src/lib/prisma.service.ts
+++ b/libs/infra/database/src/lib/prisma.service.ts
@@ -3,7 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import type { Prisma } from '@prisma/client';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { injectDatabasePassword, intEnv } from '@nestjs-fastify-nx/shared';
+import { boolEnv, injectDatabasePassword, intEnv } from '@nestjs-fastify-nx/shared';
 
 // Derived from the $transaction overload to avoid importing @prisma/client/runtime internals.
 export type TransactionClient = Parameters<PrismaClient['$transaction']>[0] extends (
@@ -61,6 +61,7 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
 
     const appName = process.env['DATABASE_APPLICATION_NAME'] ?? 'nestjs-fastify-api';
     const slowQueryThresholdMs = intEnv('DATABASE_SLOW_QUERY_MS', 200);
+    const logAllQueries = this.resolveQueryLogging();
 
     this._writeClient = new PrismaClient({
       adapter: buildPgAdapter(writeUrl, {
@@ -70,7 +71,7 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
       }),
       log: [{ emit: 'event', level: 'query' }],
     });
-    this.registerSlowQueryLogger(this._writeClient, slowQueryThresholdMs);
+    this.registerQueryLogger(this._writeClient, slowQueryThresholdMs, logAllQueries);
 
     const replicaUrl = injectDatabasePassword(
       process.env['DATABASE_REPLICA_URL']?.trim(),
@@ -87,22 +88,54 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
         }),
         log: [{ emit: 'event', level: 'query' }],
       });
-      this.registerSlowQueryLogger(this._readClient, slowQueryThresholdMs);
+      this.registerQueryLogger(this._readClient, slowQueryThresholdMs, logAllQueries);
       this.logger.log('Read replica enabled via DATABASE_REPLICA_URL');
     } else {
       this._readClient = this._writeClient;
     }
   }
 
-  // Only `query` (the parameterized SQL template) and `duration` are logged — `params` is
-  // the serialized argument values and can carry PII/secrets, so it is never logged here.
-  private registerSlowQueryLogger(client: PrismaClient, thresholdMs: number): void {
-    (client as unknown as PrismaQueryEventEmitter).$on('query', (event) => {
-      if (!isSlowQuery(event.duration, thresholdMs)) return;
+  // DATABASE_LOG_QUERIES turns on a full per-query debug log — including `params` — for local
+  // debugging. Forced off in production regardless of the flag: `params` is the serialized argument
+  // values and can carry PII/secrets, so it must never reach a production log.
+  private resolveQueryLogging(): boolean {
+    const requested = boolEnv('DATABASE_LOG_QUERIES', false);
+    if (!requested) return false;
+    if (process.env['NODE_ENV'] === 'production') {
       this.logger.warn(
-        { durationMs: event.duration, query: event.query },
-        'Slow database query detected',
+        'DATABASE_LOG_QUERIES is ignored in production — query params must never be logged there',
       );
+      return false;
+    }
+    this.logger.warn(
+      'DATABASE_LOG_QUERIES enabled — every query, including params, is logged at debug level. ' +
+        'Development only; never enable in production.',
+    );
+    return true;
+  }
+
+  // Two independent concerns on one `query` subscription:
+  //  - slow-query WARN always runs (template + duration only; never params — safe for production).
+  //  - full-query DEBUG runs only when DATABASE_LOG_QUERIES made `logAllQueries` true, and carries
+  //    params. resolveQueryLogging() already guaranteed that is dev-only.
+  private registerQueryLogger(
+    client: PrismaClient,
+    thresholdMs: number,
+    logAllQueries: boolean,
+  ): void {
+    (client as unknown as PrismaQueryEventEmitter).$on('query', (event) => {
+      if (logAllQueries) {
+        this.logger.debug(
+          { durationMs: event.duration, query: event.query, params: event.params },
+          'Database query',
+        );
+      }
+      if (isSlowQuery(event.duration, thresholdMs)) {
+        this.logger.warn(
+          { durationMs: event.duration, query: event.query },
+          'Slow database query detected',
+        );
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Adds `DATABASE_LOG_QUERIES` — a dev-only toggle to log **every** Prisma query at `debug` level **including params**, so you can see the exact SQL and the values it ran with while debugging locally.

## Why

`PrismaService` already logs *slow* queries (`DATABASE_SLOW_QUERY_MS`, default 200ms) at `warn`, but deliberately **never logs `params`** — the right call for production, since params carry PII/secrets. The gap: when debugging locally you usually need exactly those values, and normal (fast) queries aren't logged at all.

## Behaviour

- `DATABASE_LOG_QUERIES=true` + `LOG_LEVEL=debug` → every query logged at `debug` with `query` + `params` + `durationMs`, request-id correlated.
- **Forced off in production** regardless of the flag: PrismaService logs a warning and ignores it, so params can never reach a production log.
- The existing slow-query `warn` (template only, no params) still runs independently — the two share one `query` subscription.
- Default `false`. Declared as `z.string().transform(v => v === 'true')` (not `z.coerce.boolean()`, which would coerce the string `"false"` to `true`).

## Usage

```dotenv
LOG_LEVEL=debug
DATABASE_LOG_QUERIES=true
```

## Verification

- **Live**: with the flag on, a sign-up emitted `debug` logs for the users/accounts/sessions INSERTs including their param arrays, each tagged with the request's `requestId`; with the flag off, zero query debug lines.
- 22/22 `infra-database` unit tests (4 new: logs-with-params, unset-is-silent, production-ignores-flag, `"false"`-string-stays-off) + slow-query tests unchanged and green.
- typecheck 21/21 (0 `error TS`), lint 21/21, app tests green (api 190, worker 19, scheduler 40).
- Documented in `.env.example` and `docs/environment.md`.

Files: `PrismaService` + its spec, the three app env schemas, `.env.example`, `docs/environment.md`.
