### PR TITLE
refactor: replace CQRS bus any-types with unknown; document Windows build flake

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,6 +70,25 @@ Prevention: exclude the workspace folder from Windows Defender real-time scannin
 (Settings → Virus & threat protection → Exclusions), which removes the main source of the
 lock contention. CI on Linux runners does not hit this.
 
+A second, distinct flavour is a hard native crash — `Assertion failed: (insertion_info.second)
+== (true)` with exit code 134/130 — from the TypeScript 7 native compiler (`@typescript/native`,
+the `typecheck`/`build` engine) or esbuild under Vitest. It is a bug in those pre-release native
+binaries that only surfaces on **Windows** under Nx's concurrent task execution; there is no newer
+`typescript@7` patch to bump to yet, and it does **not** reproduce on Linux — the `full-check` and
+`CI` workflows run the same `nx run-many -t typecheck --all` green on every push to `main`, which
+is the authoritative signal. It is not a code or type error. Treat a run that ends in this crash as
+a flake:
+
+```bash
+# Re-run; it passes. To see every project's real result instead of aborting on the first flake:
+pnpm nx run-many -t typecheck --nx-bail=false
+# Or lower concurrency so fewer native processes race:
+pnpm nx run-many -t typecheck --parallel=1
+```
+
+Never conclude "typecheck is failing" from this crash alone — confirm with `grep "error TS"`
+(zero matches means no type error) or a single-project `pnpm nx run <project>:typecheck`.
+
 ### `pnpm codegen` crashes with `js-yaml does not provide an export named 'default'`
 
 Symptom: `pnpm codegen` (orval) aborts before generating the client:

--- a/libs/core/src/lib/cqrs/traced-command-bus.ts
+++ b/libs/core/src/lib/cqrs/traced-command-bus.ts
@@ -7,10 +7,13 @@ import { instrumentBusExecution } from './instrument-execution';
 // app's existing CommandBus singleton (see cqrs-instrumentation.initializer.ts for why), so
 // every constructor-injected `CommandBus` gains this override with zero callsite changes.
 export class TracedCommandBus extends CommandBus {
-  // `R = any` mirrors CommandBus's own overload set exactly — narrowing the default here
-  // would make this override incompatible with the base class's public signature.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override execute<T extends ICommand, R = any>(command: T, context?: AsyncContext): Promise<R> {
+  // Callers inject the base `CommandBus`, so they keep the typed `Command<R>` inference — this
+  // override only has to stay assignable to the base's untyped legacy overload. `unknown` (not the
+  // base's `any`) as the fallback keeps that assignable without reintroducing `any` here.
+  override execute<T extends ICommand, R = unknown>(
+    command: T,
+    context?: AsyncContext,
+  ): Promise<R> {
     return instrumentBusExecution<R>(
       'command',
       command,

--- a/libs/core/src/lib/cqrs/traced-query-bus.ts
+++ b/libs/core/src/lib/cqrs/traced-query-bus.ts
@@ -7,10 +7,10 @@ import { instrumentBusExecution } from './instrument-execution';
 // app's existing QueryBus singleton (see cqrs-instrumentation.initializer.ts for why), so
 // every constructor-injected `QueryBus` gains this override with zero callsite changes.
 export class TracedQueryBus extends QueryBus {
-  // `TResult = any` mirrors QueryBus's own overload set exactly — narrowing the default
-  // here would make this override incompatible with the base class's public signature.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override execute<T extends IQuery, TResult = any>(
+  // Callers inject the base `QueryBus`, so they keep the typed `Query<TResult>` inference — this
+  // override only has to stay assignable to the base's untyped legacy overload. `unknown` (not the
+  // base's `any`) as the fallback keeps that assignable without reintroducing `any` here.
+  override execute<T extends IQuery, TResult = unknown>(
     query: T,
     asyncContext?: AsyncContext,
   ): Promise<TResult> {


### PR DESCRIPTION
## Summary

Two small, independent quality fixes.

**1. Removes both `eslint-disable no-explicit-any` in the CQRS bus wrappers.** `TracedCommandBus`/`TracedQueryBus` overrode `execute` with a `= any` default to match the framework's untyped legacy overload. Callers inject the **base** `CommandBus`/`QueryBus`, so they keep the typed `Command<R>`/`Query<TResult>` inference regardless — the override only has to stay *assignable* to the base, which `unknown` does as well as `any`. Both disables are gone; repo now has **zero** `eslint-disable` in non-test source.

**2. Documents the Windows-only native build flake.** The intermittent `Assertion failed: (insertion_info.second) == (true)` crash (exit 134/130) comes from the pre-release `typescript@7` native compiler / esbuild under Nx concurrency. Researched: no newer `typescript@7` patch exists to bump to, and it does **not** reproduce on Linux — `full-check`/`CI` run the same `nx typecheck --all` green on every push to `main`. Added a troubleshooting entry so it is not mistaken for a real failure, with the `--nx-bail=false` / `--parallel=1` / `grep 'error TS'` verification steps.

## Verification
- `core`, `modules-users`, `composition-admin`, `api` all typecheck (proves caller inference is preserved by the `unknown` change).
- `core` lint + 12 unit tests green.
- No code change for the flake — doc only.

Files: the two traced bus classes, `docs/troubleshooting.md`.