### PR TITLE
refactor: migrate prisma to the prisma-client generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ vitest.config.*.timestamp*
 .claude/worktrees
 .claude/agent-memory/
 .claude/settings.local.json
-/generated/prisma
+libs/infra/database/src/generated/
 .test-tmp/
 .code-review-graph/
 .claude/settings.json.bak

--- a/docs/domain-module-anatomy.md
+++ b/docs/domain-module-anatomy.md
@@ -387,8 +387,10 @@ here). BullMQ custom `jobId`s must never contain `:`.
 ### `infrastructure/repositories/` — Prisma adapters
 
 An `@Injectable()` implementing a domain port, talking to Prisma — the only
-place in the module importing `@nestjs-fastify-nx/infra-database` or
-`@prisma/client`. Create one per repository port.
+place in the module importing `@nestjs-fastify-nx/infra-database`. Prisma types
+(`Prisma`, model rows) come from that same barrel, not from `@prisma/client`
+directly (the Prisma 7 `prisma-client` generator emits into the database lib and
+re-exports through its barrel). Create one per repository port.
 
 ```typescript
 // infrastructure/repositories/prisma-user.repository.ts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,9 +27,12 @@ and matches every module library.
 
 ### `cannot find module '@nestjs-fastify-nx/...'` after a fresh checkout
 
-Run `pnpm prisma generate && pnpm nx sync`. The Prisma client is generated
-into `node_modules/.prisma`, and Nx path mappings flow through `tsconfig`
-references that `nx sync` regenerates from `project.json`.
+Run `pnpm prisma generate && pnpm nx sync`. The Prisma 7 `prisma-client`
+generator emits the client into `libs/infra/database/src/generated/prisma`
+(gitignored — regenerated on `postinstall`), and Nx path mappings flow through
+`tsconfig` references that `nx sync` regenerates from `project.json`. Consumers
+import Prisma types from the `@nestjs-fastify-nx/infra-database` barrel, not from
+`@prisma/client` directly.
 
 ### Import `@nestjs-fastify-nx/admin` not found (moved library)
 

--- a/libs/infra/auth/src/lib/better-auth.config.ts
+++ b/libs/infra/auth/src/lib/better-auth.config.ts
@@ -3,7 +3,7 @@ import { betterAuth } from 'better-auth';
 import type { BetterAuthOptions } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { openAPI } from 'better-auth/plugins';
-import type { PrismaClient } from '@prisma/client';
+import type { PrismaClient } from '@nestjs-fastify-nx/infra-database';
 import { I18nService } from 'nestjs-i18n';
 import {
   I18N_KEYS,

--- a/libs/infra/database/src/index.ts
+++ b/libs/infra/database/src/index.ts
@@ -1,3 +1,19 @@
 export { DatabaseModule } from './lib/database.module';
 export { PrismaService, type TransactionClient } from './lib/prisma.service';
 export { PrismaReplicationLagHealthIndicator } from './lib/prisma-replication-lag.health';
+
+// Prisma 7 `prisma-client` generator emits the client into this lib's source tree
+// (see prisma/schema.prisma `output`). Re-export it here so consumers depend on the
+// database lib's public API instead of reaching into the generated path — keeps the
+// generated client behind one project boundary and lets `tsc --build` resolve it
+// through project-reference declarations.
+export { PrismaClient, Prisma } from './generated/prisma/client';
+export type {
+  User,
+  Session,
+  Account,
+  Verification,
+  StoredFile,
+  OutboxEvent,
+  AuditLog,
+} from './generated/prisma/client';

--- a/libs/infra/database/src/lib/prisma.service.spec.ts
+++ b/libs/infra/database/src/lib/prisma.service.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Logger } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '../generated/prisma/client';
 import { PrismaService, isSlowQuery } from './prisma.service';
 
 type QueryListener = (event: { query: string; params: string; duration: number }) => void;

--- a/libs/infra/database/src/lib/prisma.service.ts
+++ b/libs/infra/database/src/lib/prisma.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
-import type { Prisma } from '@prisma/client';
+import { PrismaClient } from '../generated/prisma/client';
+import type { Prisma } from '../generated/prisma/client';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { injectDatabasePassword, intEnv } from '@nestjs-fastify-nx/shared';

--- a/libs/infra/messaging/src/lib/outbox-publisher.service.ts
+++ b/libs/infra/messaging/src/lib/outbox-publisher.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
-import type { Prisma } from '@prisma/client';
+import type { Prisma } from '@nestjs-fastify-nx/infra-database';
 import type { DomainEvent, EventPublisherPort } from '@nestjs-fastify-nx/core';
 import { generateId } from '@nestjs-fastify-nx/shared';
 import { OUTBOX_SCHEMA_VERSION } from './outbox-schema-version';

--- a/libs/modules/audit-log/src/infrastructure/repositories/prisma-audit-log.repository.spec.ts
+++ b/libs/modules/audit-log/src/infrastructure/repositories/prisma-audit-log.repository.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@nestjs-fastify-nx/infra-database';
 import { PrismaAuditLogRepository } from './prisma-audit-log.repository';
 import { AuditLog } from '../../domain/entities/audit-log.entity';
 import type { PrismaService } from '@nestjs-fastify-nx/infra-database';

--- a/libs/modules/audit-log/src/infrastructure/repositories/prisma-audit-log.repository.ts
+++ b/libs/modules/audit-log/src/infrastructure/repositories/prisma-audit-log.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@nestjs-fastify-nx/infra-database';
 import type { AuditLogRepositoryPort } from '../../domain/ports/audit-log-repository.port';
 import type { AuditLog } from '../../domain/entities/audit-log.entity';
 

--- a/libs/modules/upload/src/presentation/controllers/upload.controller.ts
+++ b/libs/modules/upload/src/presentation/controllers/upload.controller.ts
@@ -42,7 +42,7 @@ import {
   STORED_FILE_STATUS,
 } from '@nestjs-fastify-nx/shared';
 
-import type { StoredFile as StoredFileRecord } from '@prisma/client';
+import type { StoredFile as StoredFileRecord } from '@nestjs-fastify-nx/infra-database';
 import { PresignUploadDto } from '../dto/presign-upload.dto';
 import { ConfirmUploadDto } from '../dto/confirm-upload.dto';
 import { PresignedUploadDto } from '../dto/presigned-upload.dto';

--- a/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.ts
+++ b/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { I18N_KEYS } from '@nestjs-fastify-nx/infra-i18n';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@nestjs-fastify-nx/infra-database';
 import { User, UserRole, UserStatus } from '../../domain/entities/user.entity';
 import type {
   FindAllCursorOptions,

--- a/libs/testing/src/lib/helpers/database-cleaner.ts
+++ b/libs/testing/src/lib/helpers/database-cleaner.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from '@prisma/client';
+import type { PrismaClient } from '@nestjs-fastify-nx/infra-database';
 
 export class DatabaseCleaner {
   constructor(private readonly prisma: PrismaClient) {}

--- a/libs/testing/tsconfig.lib.json
+++ b/libs/testing/tsconfig.lib.json
@@ -20,5 +20,10 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    {
+      "path": "../infra/database/tsconfig.lib.json"
+    }
   ]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,9 @@
 generator client {
-  provider = "prisma-client-js"
+  provider            = "prisma-client"
+  output              = "../libs/infra/database/src/generated/prisma"
+  runtime             = "nodejs"
+  moduleFormat        = "esm"
+  importFileExtension = ""
 }
 
 datasource db {

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -5,10 +5,19 @@
  * accountId=user.id) using its own scrypt-based hash. The on-disk format must
  * be produced by `hashPassword` from `better-auth/crypto` — any other hasher
  * (e.g. argon2) yields output that Better Auth's signin path cannot verify.
+ *
+ * This seed talks to Postgres through the `pg` driver directly rather than the
+ * Prisma Client. The Prisma 7 `prisma-client` generator emits the client as
+ * TypeScript into `libs/infra/database/src/generated`, but the migration image
+ * that runs this script (`node prisma/seed.mjs`) is a pruned, bundle-only image
+ * — it carries `dist/apps/migration` + `prisma/` but not `libs/`, so the
+ * generated client is simply not present at runtime. `pg` and `better-auth` are
+ * declared as seed runtime deps (see apps/migration/webpack.config.js) and are
+ * installed in the image, so raw SQL is the dependency-safe path here. `id`
+ * defaults to a database-generated UUIDv7, so nothing here needs the ORM.
  */
 
-import { PrismaClient } from '@prisma/client';
-import { PrismaPg } from '@prisma/adapter-pg';
+import { Client } from 'pg';
 import { hashPassword } from 'better-auth/crypto';
 
 const url = process.env['DATABASE_URL'];
@@ -17,8 +26,7 @@ if (!url) {
   process.exit(1);
 }
 
-const adapter = new PrismaPg({ connectionString: url });
-const prisma = new PrismaClient({ adapter });
+const client = new Client({ connectionString: url });
 
 async function main() {
   const email = process.env['SEED_ADMIN_EMAIL'];
@@ -29,8 +37,8 @@ async function main() {
     return;
   }
 
-  const existing = await prisma.user.findUnique({ where: { email } });
-  if (existing) {
+  const existing = await client.query('SELECT id FROM users WHERE email = $1', [email]);
+  if (existing.rowCount && existing.rowCount > 0) {
     console.log(`[seed] Admin ${email} already exists — skipping.`);
     return;
   }
@@ -39,33 +47,38 @@ async function main() {
 
   // Create the user row + linked credential account in a single transaction
   // so a partial seed never leaves an orphaned user with no signin path.
-  await prisma.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email,
-        emailVerified: true,
-        name: 'Admin',
-        role: 'ADMIN',
-        status: 'ACTIVE',
-      },
-    });
+  // `id` defaults to uuidv7() in the database; `updatedAt` is Prisma's
+  // application-managed `@updatedAt`, so it has no DB default and is set here.
+  await client.query('BEGIN');
+  try {
+    const userResult = await client.query(
+      `INSERT INTO users (email, "emailVerified", name, role, status, "updatedAt")
+       VALUES ($1, true, 'Admin', 'ADMIN', 'ACTIVE', now())
+       RETURNING id`,
+      [email],
+    );
+    const userId = userResult.rows[0].id;
 
-    await tx.account.create({
-      data: {
-        userId: user.id,
-        accountId: user.id,
-        providerId: 'credential',
-        password: passwordHash,
-      },
-    });
-  });
+    await client.query(
+      `INSERT INTO accounts ("userId", "accountId", "providerId", password, "updatedAt")
+       VALUES ($1, $2, 'credential', $3, now())`,
+      [userId, userId, passwordHash],
+    );
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
 
   console.log(`[seed] Admin user ${email} created successfully.`);
 }
 
-main()
+client
+  .connect()
+  .then(main)
   .catch((e) => {
     console.error('[seed] Error:', e);
     process.exit(1);
   })
-  .finally(() => prisma.$disconnect());
+  .finally(() => client.end());


### PR DESCRIPTION
## What

Migrate the Prisma generator from `prisma-client-js` (maintenance mode, removed in Prisma 8) to the Prisma 7 default `prisma-client`.

## How — following Prisma's official monorepo guidance

- **Generated into the db lib**: `output = libs/infra/database/src/generated/prisma` (gitignored, regenerated on `postinstall`). `runtime = nodejs`, `moduleFormat = esm`.
- **Barrel re-export**: `libs/infra/database/src/index.ts` re-exports `PrismaClient` / `Prisma` / model types. All consumers import from `@nestjs-fastify-nx/infra-database`, never `@prisma/client` directly. Keeping the client behind one project boundary lets `tsc --build` resolve it through project-reference declarations (avoids `TS6307` on cross-project imports).
- **`importFileExtension = ""`** (extensionless): the workspace resolves via webpack/vite/tsgo in `bundler` mode, which sidesteps the [Prisma 7 Webpack ESM `.js` import bug (#28627)](https://github.com/prisma/prisma/issues/28627).

## Seed → raw `pg` (prod-Docker correctness)

`node prisma/seed.mjs` runs in the migration image, which is pruned/bundle-only and ships `prisma/` but **not** `libs/` — so the generated TS client is absent at runtime. `pg` + `better-auth` are already declared as seed runtime deps (`apps/migration/webpack.config.js`) and installed there, and `id` defaults to a DB-generated UUIDv7, so the seed uses raw SQL. Same behaviour as before (admin user + credential account, single transaction, idempotent).

## Verification

- `nx affected` **lint** (12), **typecheck** (12 + 24 deps), **test** (23 files / 190), **build** (4 apps, webpack compiled), **api:e2e** (5 files / 50) — all green.
- **Live seed smoke test** against a real Postgres 18: migrate deploy → seed creates admin + credential account → re-run is idempotent (count stays 1).

## Notes

- Docs updated (`troubleshooting.md`, `domain-module-anatomy.md`) for the new client location + barrel import.
- Overlaps `prisma.service.ts` with the open DATABASE_LOG_QUERIES PR, but in a different region (import lines vs logger methods) — trivial rebase if that merges first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma setup and troubleshooting guidance for the new generated client location.
  * Clarified that Prisma types should be imported through the database library’s public exports.

* **Improvements**
  * Centralized generated Prisma client and model type exports through the database library.
  * Updated database-related components to use the centralized Prisma types.
  * Improved admin seeding reliability by using direct database transactions.
  * Updated TypeScript project references for database integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->