### PR TITLE
chore: drop machine-specific code-review-graph hooks from shared claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,31 +9,5 @@
   },
   "enabledPlugins": {
     "nx@nx-claude-plugins": true
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write|Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "git rev-parse --git-dir >/dev/null 2>&1 && code-review-graph update --skip-flows --repo \"D:/nestjs-fastify-nx\" || true",
-            "timeout": 30
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "git rev-parse --git-dir >/dev/null 2>&1 && code-review-graph status --repo \"D:/nestjs-fastify-nx\" || echo 'Not a git repo, skipping'",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
## What

Remove the `hooks` block from the committed `.claude/settings.json` (shared/team config).

## Why

The removed hooks ran `code-review-graph update/status` on every `Edit|Write|Bash` and at `SessionStart`, hardcoding an absolute machine path `D:/nestjs-fastify-nx` and depending on a personal `code-review-graph` CLI that is not part of the repo's dependencies.

Since `.claude/settings.json` is the shared config committed for everyone who clones this public boilerplate, that path/tool is meaningless (and mildly noisy) on any other machine or in CI. The `extraKnownMarketplaces` + `enabledPlugins` (nx plugin) entries are kept since they benefit contributors.

Personal graph-update workflow belongs in the gitignored `.claude/settings.local.json`, not the shared file.

## Change

- `.claude/settings.json`: 26 deletions (the `hooks` block only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated code review hook configurations from project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->