### PR TITLE
chore: automate versioning and changelog with nx release

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,82 @@
+name: Version and Tag
+
+# Cuts a release with Nx Release: derives the next version from conventional
+# commits, updates package.json + CHANGELOG.md, commits, and pushes a
+# `v{version}` git tag. That tag triggers `release.yml`, which builds, scans,
+# signs, and publishes the container images.
+#
+# Manual trigger only — releasing is a deliberate act, not every push to main.
+#
+# RELEASE_TOKEN: a PAT (or GitHub App token) allowed to push to the protected
+# `main` branch and to create tags/releases. The default GITHUB_TOKEN cannot
+# bypass the branch-protection pull-request requirement, so the version-bump
+# commit would be rejected. Scope: contents:write. Set it in repo secrets.
+
+on:
+  workflow_dispatch:
+    inputs:
+      specifier:
+        description: 'Version bump — leave as "auto" to derive from conventional commits'
+        required: true
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
+      dry-run:
+        description: 'Preview only — no commit, tag, or push'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-version
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Full history + tags so Nx Release resolves the current version from
+          # the last `v*` tag and computes the diff since it.
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 11.14.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Nx Release
+        env:
+          # Nx Release creates the GitHub Release through this token.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          SPECIFIER=""
+          if [ "${{ inputs.specifier }}" != "auto" ]; then
+            SPECIFIER="${{ inputs.specifier }}"
+          fi
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            pnpm nx release $SPECIFIER --dry-run --verbose
+          else
+            pnpm nx release $SPECIFIER --yes
+          fi

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Consolidate the maintainer's multiple git identities into one canonical
+# name + email. Used by `git shortlog`, `git log`, GitHub, and Nx Release's
+# changelog "Thank You" section.
+Lê Vạn Bảo Trọng <32262183+chuanghiduoc@users.noreply.github.com> <levanbaotrong03@gmail.com>
+Lê Vạn Bảo Trọng <32262183+chuanghiduoc@users.noreply.github.com> <tronglvb@phanmemmkt.vn>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,127 +1,73 @@
-# Changelog
+## 1.1.0 (2026-07-18)
 
-All notable changes to this project will be documented in this file.
+### Features
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- integrate code-review-graph mcp server with hooks and skills ([3bceaf6](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/3bceaf6))
+- scalar docs, nestjs-i18n, build-prod auto-up ([7d898a1](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/7d898a1))
+- harden boilerplate with cqrs bus, structured logging, and resilience ([#82](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/82))
+- harden dev workflow, add social login, and dx tooling ([#88](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/88))
+- ts7 toolchain, observability (cls + cqrs tracing), committed api-client, docker + docs ([#89](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/89))
+- add DATABASE_LOG_QUERIES for full query debugging in dev ([#104](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/104))
+- **api:** adopt stripe-style + rfc 9457 response contract ([400e36e](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/400e36e))
+- **api:** production hardening pass ([890f503](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/890f503))
+- **api:** add idempotency-key replay and request-timeout guards ([#90](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/90))
+- **config:** add trust-proxy/ws-cap/throttler-fail-open vars and lower sentry default ([c88e665](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/c88e665))
+- **db:** index and constraint hardening ([3a9d6bb](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/3a9d6bb))
+- **docker:** add swarm overlay for multi-host deployment ([d5467a8](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/d5467a8))
+- **graphql:** block schema introspection in production ([2ef1eb8](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/2ef1eb8))
+- **observability:** harden tracing, metrics ownership, health probes + local stack ([#96](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/96))
+- **scaling:** horizontal scaling primitives ([#43](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/43))
+- **scheduler:** warn when any dlq exceeds threshold ([a79dbb0](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/a79dbb0))
+- **scripts:** build-dev service filter, build report, and lf line endings ([a7f8d8b](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/a7f8d8b))
+- **shared:** add typed env reader helpers ([e5a6f8f](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/e5a6f8f))
+- **ws:** per-ip connection cap and explicit session expiry check ([9c75f72](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/9c75f72))
 
-## [Unreleased] — Best-Practice Overhaul (2026-05-16)
+### Bug Fixes
 
-### Removed
+- swc es2022 target, faster local builds, docker-smoke CI, deploy-agnostic ports ([#58](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/58))
+- remediate deep code-audit findings (6 high + 9 medium) ([#59](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/59))
+- harden system reliability and delivery ([9af562e](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/9af562e))
+- codebase audit — resilience, contracts, and doc accuracy ([#103](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/103))
+- drop the obsolete prisma runtime artifact from the docker build ([#107](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/107))
+- **api:** emit problem details on fastify errors and standardize pagination naming ([9e3aef9](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/9e3aef9))
+- **api:** document liveness probe error responses in swagger ([f158a3c](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/f158a3c))
+- **api:** use /health/live for container healthcheck and size memory to container limit ([670c47b](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/670c47b))
+- **api:** drive trustproxy from env and tighten dev cors allowlist ([6091220](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/6091220))
+- **api:** pin /metrics to VERSION_NEUTRAL and swap bullmq probe to getJobCounts ([#48](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/48))
+- **auth:** timing-safe bull-board credentials and explicit session expiry check ([2b5e7ca](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/2b5e7ca))
+- **deps:** pin kysely>=0.28.17 via pnpm override to patch GHSA-pv5w-4p9q-p3v2 ([8c1db35](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/8c1db35))
+- **deps:** floor undici to 8.5.0 ([#65](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/65))
+- **deps:** cap js-yaml at v4, drop unused @fastify/static, block typescript 7 major ([#95](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/95))
+- **docker:** stop exposing data-tier ports and bind api to loopback in prod overlay ([34a6d4d](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/34a6d4d))
+- **scripts:** build-dev smoke test no longer hangs on dual-stack hosts ([72fabf4](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/72fabf4))
+- **security:** clear semgrep findings + harden release workflow ([1d52eda](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/1d52eda))
+- **test:** set database url default in vitest.setup for app-module specs ([585c1a4](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/585c1a4))
+- **throttler:** fail open when redis storage is unreachable ([f208432](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/f208432))
+- **upload:** verify magic bytes inline on confirm ([cca31e2](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/cca31e2))
 
-- `AggregateRoot` dead inheritance — domain entities no longer extend it
-- `RequestContext` zombie class — removed from codebase; use NestJS `@Req()` + guard injection
-- Parallel `UserProfileDto` in application layer — unified to single DTO per shape
-- `BetterAuthModule.forRootAsync()` and `BETTER_AUTH_HOOKS` scaffolding — simplified to direct factory
-- `libs/modules/admin` (moved to `libs/composition/admin` with `scope:composition` tag)
-- `apps/api/src/common/upload` (moved to `libs/modules/upload`)
-- Logger duplicates — three `LoggerModule.forRoot()` calls unified to single shared factory
-- `BetterAuthHooks` interface and `databaseHooks.user.create.after` block — dead code removed (user registration events flow through Postgres trigger → outbox, not this hook)
+### Performance
 
-### Added
+- build apps with swc compiler instead of tsc ([#57](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/57))
+- **docker:** unify api/worker/scheduler into one image build with shared workspace stage ([e0bbd27](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/e0bbd27))
+- **scripts:** make build-dev incremental by default ([86a75ad](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/86a75ad))
 
-- Auth rate-limit enforcement — `fastify-rate-limit` hook guards `/api/auth/*` (AUTH_RATE_LIMIT_MAX, AUTH_RATE_LIMIT_WINDOW_MS)
-- HTTP body + multipart caps — HTTP_BODY_LIMIT_BYTES, UPLOAD_MAX_FILE_BYTES env vars with validation
-- Outbox interactive transaction — lock-through-publish semantics with OUTBOX_TX_TIMEOUT_MS timeout
-- Health readiness probe for BullMQ — `BullMqHealthIndicator` pings email-notification queue (2s timeout)
-- Sentry PII scrubbing — beforeSend filter masks password, token, secret, cookie patterns in event.extra and breadcrumbs
-- Metrics IP allowlist — `METRICS_ALLOW_CIDRS` (comma-separated CIDR ranges) with socket.remoteAddress validation
-- Metrics IP allowlist health check — `MetricsIpAllowGuard` reads `METRICS_ALLOW_CIDRS` at guard evaluation time
-- NX_CLOUD_AUTH_TOKEN for Nx Cloud remote caching in CI
-- Shared Testcontainers setup — global-setup/teardown with SIGINT handler for clean container teardown on CI cancel
-- docs/code-standards.md — enforcement of logging (pino-only), error handling (BusinessRuleException), DTOs (1 per shape), module boundaries, testing ratios
-- docs/runbook.md — 6 sections for ops troubleshooting (health, metrics, outbox, BullMQ, performance, security)
-- **Phase 6** — Module generator overhaul: `pnpm nx g @nestjs-fastify-nx/tools-generators:module --name=foo --directory=modules` scaffolds full DDD layout (domain/application/infrastructure/presentation) with zero TODOs, kebab-case validation, correct `scope:*` tag scheme
-- **Phase 7** — Ops tooling: `scripts/doctor.sh` (preflight check: Docker, Node, pnpm, ports, env vars), `scripts/teardown.sh` (clean compose stack wrapper), `scripts/build-dev.sh --with-obs` flag, `docker/compose.observability.yml` (opt-in Prometheus + Grafana + Jaeger + OTel collector), MinIO bucket auto-provision + healthcheck
-- **Phase 8** — Documentation polish: CLAUDE.md updated (honest HMR comment, .env.example guidance, post-clone sanity check, Better Auth body parser gotcha, generator invocation hints, runbook/code-standards links), new CONTRIBUTING.md (human dev onboarding, 5-minute quick start, daily commands table, PR checklist, troubleshooting table)
+### Refactors
 
-### Fixed
+- monorepo best-practice overhaul (phases 1-10) ([#36](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/36))
+- dedupe env parsing via shared env-readers ([8b87a3c](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/8b87a3c))
+- migrate off deprecated zod and terminus apis ([#102](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/102))
+- type the CQRS bus overrides with unknown instead of any ([#105](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/105))
+- migrate prisma to the prisma-client generator ([#106](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/106))
+- **api:** redeclare schema type locally to drop @nestjs/swagger deep import ([c0b70a4](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/c0b70a4))
+- **db:** fold fk indexes and user constraints into the init migration ([3e4c986](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/3e4c986))
+- **messaging:** release outbox claim transaction before publish ([8ffe748](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/8ffe748))
 
-- Audit listener no longer silently swallows persistence errors — re-throws to trigger transaction rollback
-- GraphQL `me` query delegates to `GetUserProfileHandler` for REST/GraphQL parity
-- Hijack handler try/catch + socket.destroy for slowloris mitigation (socket reset on timeout)
-- Health indicator timer leaks — clear setTimeout via .finally() in prisma and redis health checks
-- E2E test isolation — shared Testcontainers containers + global truncateAll cleanup between test suites
-- Sentry sample rate cap at 0.1 in production (avoid over-sampling high-volume services)
+### Documentation
 
-## [1.0.0] - 2026-05-01
+- clarify outbox dual-write paths and metrics swagger exclusion ([66e1092](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/66e1092))
+- add mermaid architecture diagrams ([105eb32](https://github.com/chuanghiduoc/nestjs-fastify-nx/commit/105eb32))
 
-Initial public release of the boilerplate.
+### Build System
 
-### Added
-
-#### Core platform
-
-- **Four runnable apps** — `api`, `worker`, `scheduler`, `migration` — sharing one Nx workspace and one pnpm lockfile
-- **Nx 23** monorepo with `@nx/enforce-module-boundaries` enforcing DDD layering via `scope:*` tags (api, worker, scheduler, migration, modules, composition, infra, core, shared, contracts, testing)
-- **Webpack 5** bundler wired with `tsc` compiler so NestJS decorator metadata resolves correctly in production builds
-- **TypeScript project references** kept in sync via `nx sync`
-
-#### API surfaces (single Fastify instance)
-
-- **REST** with `@nestjs/swagger` — auto-mounted at `/docs` (Scalar) outside production, deterministic `operationId` factory consumed by Orval codegen
-- **GraphQL** via `@nestjs/mercurius` — schema-first, GraphiQL exposed at `/graphiql` in dev
-- **Socket.io 4** with `@socket.io/redis-adapter` for cross-pod broadcast; WebSocket upgrades reuse the Better Auth cookie via a custom adapter
-- **OpenAPI codegen** — Orval emits a typed REST client into `libs/api-client` from the live spec exported by `CodegenAppModule`
-
-#### Authentication & authorization
-
-- **Better Auth 1.6** for sign-up / sign-in / sign-out / password reset / social providers — cookie sessions backed by Postgres, scrypt password hashing
-- **`BetterAuthGuard`** + **`RolesGuard`** wired as global `APP_GUARD` providers; `@Roles('ADMIN')` decorator
-- **Cross-context admin module** at `libs/modules/admin` (tag `scope:composition`) exposing `GET /api/v1/admin/users` for ADMIN role
-- **Argon2** available alongside scrypt for legacy hashes
-
-#### Domain & infrastructure
-
-- **DDD/CQRS layout** for bounded contexts under `libs/modules/*` (domain / application / infrastructure / presentation)
-- **`users` module** — profile lookup with cookie-session guard
-- **`audit-log` module** — domain-event listener writes immutable audit rows
-- **Prisma 7** with `@prisma/adapter-pg` driver adapter; PostgreSQL 18 with native `uuidv7()`
-- **Redis 8** — cache (`cache-manager` + Keyv) and queue (BullMQ) on separate instances
-- **Transactional outbox** — `inprocess` (EventEmitter2) and `outbox` (Postgres relay) drivers, switchable via `EVENT_PUBLISHER_DRIVER`
-- **Object storage port** — S3 SDK v3 with presigned URLs, MinIO-compatible in dev
-- **SMTP** via Nodemailer; Mailpit in dev
-
-#### Background work
-
-- **BullMQ** queues with **Bull Board** UI behind admin auth at `/api/admin/queues`
-- **Welcome email** flow — `UserRegistered` domain event → `UserRegisteredListener` → BullMQ job → worker sends mail
-- **Dead-letter queues** with helper router (`createDeadLetterRouterClass`)
-- **`@nestjs/schedule`** in the dedicated scheduler app — `CleanupTask` purges INACTIVE users 90d+, weekly `VACUUM ANALYZE`; `HeartbeatTask` for liveness
-- **File-based liveness probes** for worker (`/tmp/worker-alive`) and scheduler (`/tmp/scheduler-alive`), refreshed every 30s
-
-#### Quality & operations
-
-- **Rate limiting** — `@nest-lab/throttler-storage-redis` for global throttling; per-route overrides
-- **File upload** — `POST /api/v1/upload` via `@fastify/multipart`, streams to `StoragePort` (10 MB cap)
-- **Pagination utilities** — `Page<T>`, `PageMeta`, `paginationSkip`, `buildPageMeta` in `@nestjs-fastify-nx/shared`
-- **UUID v7** (`uuid@14`) for sortable, time-ordered identifiers
-- **Zod env validation** — fail-fast on startup for missing/invalid env vars
-- **nestjs-pino** structured JSON logging with correlation-id middleware and automatic redaction of `cookie` / `authorization` headers
-
-#### Observability
-
-- **OpenTelemetry SDK** with auto-instrumentations (HTTP, Fastify, NestJS, Prisma, BullMQ, Redis, Pino), OTLP/HTTP exporters
-- **Sentry NestJS** integration + `@sentry/profiling-node` continuous profiler
-- **Prometheus** exposition at `/metrics` via `prom-client`; default Node + HTTP request histograms
-- **Terminus health checks** — DB, Redis cache, Redis queue, memory; liveness and readiness probes
-
-#### Security
-
-- **Five-layer scan pipeline** — Gitleaks, OSV-Scanner, Semgrep, Trivy, Cosign — with parity between local (`scripts/security/scan-all.sh`) and CI
-- **Container hardening** — base images pinned by SHA256 digest, non-root UID 1001, `STOPSIGNAL SIGTERM`, tini PID 1, healthcheck via Node `http`, npm CLI vendored stripped from runtime layer
-- **SBOM + max-mode SLSA provenance** attestations on every release image
-- **Cosign keyless OIDC** signing via Sigstore Fulcio recorded in the public Rekor log
-- **pnpm overrides** pinning known-vulnerable transitive deps (fastify, picomatch, brace-expansion, yaml, follow-redirects, @hono/node-server)
-
-#### Tooling
-
-- **Nx generator** at `tools/generators` — scaffold a DDD module with `pnpm nx g @nestjs-fastify-nx/tools-generators:module --name=<context>`
-- **Lefthook** pre-commit/pre-push hooks — lint-staged, commitlint, Gitleaks (staged + history)
-- **GitHub Actions**:
-  - `ci.yml` — lint, typecheck, unit tests, build, secret scan, dep scan
-  - `integration.yml` — Vitest integration suite with Testcontainers services
-  - `release.yml` — buildx + SBOM + provenance, Trivy gate BEFORE push, Cosign sign, Semgrep gate. Stops at a signed image — deploy is deployment-specific and not wired here
-- **Vitest 4** + **Testcontainers** (real Postgres + Redis) + **Supertest** for unit, integration, and HTTP e2e suites
-
-[1.0.0]: https://github.com/chuanghiduoc/nestjs-fastify-nx/releases/tag/v1.0.0
+- optimize deployment artifacts and images ([#100](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/100))
+- upgrade to pnpm 11 ([#110](https://github.com/chuanghiduoc/nestjs-fastify-nx/pull/110))

--- a/apps/api/src/common/swagger/swagger.config.ts
+++ b/apps/api/src/common/swagger/swagger.config.ts
@@ -12,8 +12,6 @@ import {
 } from '@nestjs-fastify-nx/contracts';
 import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from '@nestjs-fastify-nx/infra-auth';
 import type { NestFastifyApplication } from '@nestjs/platform-fastify';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import ScalarApiReference from '@scalar/fastify-api-reference';
 
 const API_TITLE = 'NestJS Fastify Nx Boilerplate';
@@ -43,29 +41,12 @@ const DESCRIPTION = [
   `Every response carries an \`${REQUEST_ID_HEADER}\` header (also mirrored as \`requestId\` in error bodies). Quote it when filing support tickets.`,
 ].join('\n');
 
-// Walks up from cwd looking for package.json — handles `nx serve` (root cwd) and the generated dist/apps/api/package.json from generatePackageJson alike.
-function readWorkspaceVersion(): string {
-  const candidates = [
-    path.join(process.cwd(), 'package.json'),
-    path.join(__dirname, '..', '..', '..', '..', '..', 'package.json'),
-    path.join(__dirname, '..', '..', '..', 'package.json'),
-  ];
-  for (const candidate of candidates) {
-    try {
-      const raw = fs.readFileSync(candidate, 'utf-8');
-      const parsed = JSON.parse(raw) as { version?: string };
-      if (parsed.version) return parsed.version;
-    } catch {
-      // try next candidate
-    }
-  }
-  return '0.0.0';
-}
-
-const API_VERSION = readWorkspaceVersion();
-
-const REPOSITORY_URL = 'https://github.com/baotrong/nestjs-fastify-nx';
-const SUPPORT_EMAIL = 'hoangproo2624@gmail.com';
+// OpenAPI contract version — deliberately decoupled from the package release
+// version. `nx release` bumps package.json on every release; tying the spec to
+// it would regenerate the entire api-client (orval) on each bump for a no-op
+// comment change. This only moves on a breaking REST contract change, which
+// also introduces a new URI version (/api/v2). Matches the URI default "1".
+const API_VERSION = '1.0.0';
 
 function camelCase(input: string): string {
   return input.length === 0 ? input : input[0].toLowerCase() + input.slice(1);
@@ -77,9 +58,6 @@ export async function buildSwaggerDocument(app: INestApplication): Promise<OpenA
     .setDescription(DESCRIPTION)
     .setVersion(API_VERSION)
     .setLicense('MIT', 'https://opensource.org/licenses/MIT')
-    .setContact('API support', REPOSITORY_URL, SUPPORT_EMAIL)
-    .setTermsOfService(`${REPOSITORY_URL}/blob/main/LICENSE`)
-    .setExternalDoc('Architecture & runbook', `${REPOSITORY_URL}/blob/main/docs/architecture.md`)
     .addServer('/', 'Current host')
     .addTag('app', 'Service metadata')
     .addTag('health', 'Liveness, readiness, dependency checks')

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -191,9 +191,26 @@ For a team that needs persistent access, put the host on a private network (VPN 
 
 ## Release Process
 
-1. Merge to `main`
-2. Tag the release: `git tag v1.2.3 && git push origin v1.2.3`
-3. The [release workflow](../.github/workflows/release.yml) automatically, per app:
+Versioning and the changelog are driven by [Nx Release](https://nx.dev/features/manage-releases)
+from your [Conventional Commits](https://www.conventionalcommits.org/) — you never
+hand-edit `CHANGELOG.md` or bump `package.json` manually.
+
+1. Merge your work to `main`.
+2. Cut the version + tag. Either trigger the **Version and Tag** workflow
+   (`.github/workflows/version.yml`, `workflow_dispatch`) or run it locally:
+
+   ```bash
+   pnpm release:dry     # preview the next version + changelog, no writes
+   pnpm release         # bump package.json, write CHANGELOG.md, commit, tag v{version}, push
+   ```
+
+   Nx derives the bump from commit types (`feat` → minor, `fix`/`perf`/`refactor`
+   → patch, `feat!`/`BREAKING CHANGE` → major; `chore`/`ci`/`test` are hidden).
+   The current version is resolved from the last `v*` git tag, and the new version
+   is written to the root `package.json`.
+
+3. Pushing the `v*.*.*` tag triggers the [release workflow](../.github/workflows/release.yml),
+   which automatically, per app:
    - Builds the image into the runner's local daemon — nothing is published yet.
    - Gates on **Trivy** (HIGH/CRITICAL, fixable only). A failing scan stops here,
      so a vulnerable image is never pushed and never signed.
@@ -208,6 +225,18 @@ For a team that needs persistent access, put the host on a private network (VPN 
 
 See [docs/security.md](./security.md) for the full scanner inventory and how
 to verify a signed tag locally with `cosign verify`.
+
+**Prerequisites:**
+
+- **First release** — Nx resolves the current version from the last `v*` tag, so
+  the very first release must be seeded once. Tag the current baseline and push it:
+  `git tag v1.1.0 && git push origin v1.1.0`. That tag also triggers `release.yml`,
+  publishing the `1.1.0` images. Every later release is fully derived from commits.
+- **`RELEASE_TOKEN` secret** (CI only) — the Version and Tag workflow pushes the
+  version-bump commit to the protected `main` branch. `GITHUB_TOKEN` cannot bypass
+  the branch-protection pull-request requirement, so a PAT (or GitHub App token)
+  with `contents:write` and permission to push to `main` is required. Running
+  `pnpm release` locally uses your own credentials and needs no secret.
 
 ## Health Checks
 

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,9 @@
     "lint": {
       "cache": true,
       "inputs": ["default", "{workspaceRoot}/eslint.config.mjs", "{workspaceRoot}/.prettierrc"],
-      "options": { "args": "--max-warnings=0" }
+      "options": {
+        "args": "--max-warnings=0"
+      }
     },
     "test": {
       "cache": true,
@@ -41,6 +43,100 @@
   },
   "sync": {
     "applyChanges": true
+  },
+  "release": {
+    "projects": ["api"],
+    "projectsRelationship": "fixed",
+    "releaseTag": {
+      "pattern": "v{version}"
+    },
+    "version": {
+      "specifierSource": "conventional-commits",
+      "currentVersionResolver": "git-tag",
+      "manifestRootsToUpdate": ["."]
+    },
+    "changelog": {
+      "projectChangelogs": false,
+      "workspaceChangelog": {
+        "file": "{workspaceRoot}/CHANGELOG.md",
+        "createRelease": "github",
+        "renderOptions": {
+          "authors": false
+        }
+      }
+    },
+    "conventionalCommits": {
+      "types": {
+        "feat": {
+          "semverBump": "minor",
+          "changelog": {
+            "title": "Features"
+          }
+        },
+        "fix": {
+          "semverBump": "patch",
+          "changelog": {
+            "title": "Bug Fixes"
+          }
+        },
+        "perf": {
+          "semverBump": "patch",
+          "changelog": {
+            "title": "Performance"
+          }
+        },
+        "refactor": {
+          "semverBump": "patch",
+          "changelog": {
+            "title": "Refactors"
+          }
+        },
+        "revert": {
+          "semverBump": "patch",
+          "changelog": {
+            "title": "Reverts"
+          }
+        },
+        "docs": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false,
+            "title": "Documentation"
+          }
+        },
+        "build": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false,
+            "title": "Build System"
+          }
+        },
+        "chore": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": true
+          }
+        },
+        "ci": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": true
+          }
+        },
+        "test": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": true
+          }
+        },
+        "style": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": true
+          }
+        }
+      }
+    }
   },
   "generators": {
     "@nx/js:library": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-fastify-nx",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "postinstall": "node -e \"require('fs').existsSync('prisma/schema.prisma')&&require('child_process').execSync('pnpm exec prisma generate',{stdio:'inherit'})\"",
@@ -19,6 +19,8 @@
     "gen:app": "nx g @nx/nest:application",
     "rm:project": "bash scripts/remove-project.sh",
     "graph": "nx graph",
+    "release": "nx release",
+    "release:dry": "nx release --dry-run",
     "sync": "nx sync",
     "reset": "nx reset",
     "clean": "nx reset && node -e \"const fs=require('fs');['dist','tmp','.nx/cache'].forEach(d=>fs.rmSync(d,{recursive:true,force:true}))\"",


### PR DESCRIPTION
## What

Adopt **Nx Release** to drive versioning and `CHANGELOG.md` from Conventional Commits, replacing the manual changelog workflow.

## Changes

- **`nx.json`** — `release` config: version derived from conventional commits, current version resolved from the last `v*` git tag, written to the root `package.json` (`manifestRootsToUpdate: ["."]`), tag pattern `v{version}`, per-type changelog sections (feat → Features, fix → Bug Fixes, …). The `Thank You` author list is disabled (`renderOptions.authors: false`) — this is a single-maintainer repo and authorship is already credited via the per-entry commit/PR links.
- **`package.json`** — version `1.0.0` → `1.1.0`; add `release` + `release:dry` scripts.
- **`CHANGELOG.md`** — fully regenerated from git history into a single consistent nx-format `1.1.0` entry (Keep a Changelog preamble removed; Nx prepends new versions at the top).
- **`.github/workflows/version.yml`** — new `workflow_dispatch` job that cuts a release with Nx and pushes the `v*.*.*` tag, which triggers the existing `release.yml` image build.
- **`.mailmap`** — consolidate the maintainer's multiple git identities into one canonical author for `git shortlog` / `git blame` / the GitHub contributor graph.
- **`docs/deployment.md`** — update the Release Process section + prerequisites.

## How to use

```bash
pnpm release:dry   # preview next version + changelog
pnpm release       # bump, changelog, commit, tag v{version}, push
```

Or trigger the **Version and Tag** workflow from the Actions tab.

## Follow-ups (not in this PR)

- **First release bootstrap** — Nx resolves the current version from the last `v*` tag, so the first release must be seeded once: `git tag v1.1.0 && git push origin v1.1.0` (this also triggers `release.yml` to publish the `1.1.0` images).
- **`RELEASE_TOKEN` secret** — required only for the CI workflow to push the version-bump commit to protected `main` (`GITHUB_TOKEN` cannot bypass the branch-protection PR requirement). Running `pnpm release` locally needs no secret.

## Verification

Validated end-to-end with `nx release --dry-run` (seeded temp tag): current version resolved from tag → conventional-commit bump → written to root `package.json` → new entry inserted above the previous version in `CHANGELOG.md` → `v{version}` tag. No stray tags left behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamlined release versioning with automatic patch, minor, or major release selection.
  * Added dry-run support to preview release changes before publishing.
* **Documentation**
  * Updated deployment guidance for the new release workflow, versioning conventions, and deployment safeguards.
* **Bug Fixes**
  * Standardized the public API specification version for more consistent documentation.
* **Chores**
  * Published release 1.1.0 with updated feature, fix, performance, refactoring, and build-system notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->