### PR TITLE
fix: tighten production csp and redact pii in sentry events

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -94,7 +94,9 @@ async function bootstrap() {
     maxAge: 600,
   });
 
-  // CSP disabled in dev so Scalar/Bull Board can load CDN assets.
+  // CSP is disabled in dev so Scalar/Bull Board load freely. In prod the policy
+  // is same-origin only: Bull Board serves its own bundled assets and Scalar
+  // docs never mount in production, so no third-party CDN needs allowlisting.
   await fastify.register(fastifyHelmet, {
     contentSecurityPolicy: isProduction
       ? {
@@ -106,20 +108,10 @@ async function bootstrap() {
             frameAncestors: ["'self'"],
             imgSrc: ["'self'", 'data:', 'https:'],
             objectSrc: ["'none'"],
-            scriptSrc: [
-              "'self'",
-              "'unsafe-inline'",
-              'https://cdn.jsdelivr.net',
-              'https://*.scalar.com',
-            ],
+            scriptSrc: ["'self'", "'unsafe-inline'"],
             scriptSrcAttr: ["'none'"],
             styleSrc: ["'self'", 'https:', "'unsafe-inline'"],
-            connectSrc: [
-              "'self'",
-              'https://cdn.jsdelivr.net',
-              'https://*.scalar.com',
-              'https://api.scalar.com',
-            ],
+            connectSrc: ["'self'"],
             upgradeInsecureRequests: [],
             workerSrc: ["'self'", 'blob:'],
           },

--- a/libs/infra/observability/src/lib/start-sentry.ts
+++ b/libs/infra/observability/src/lib/start-sentry.ts
@@ -6,7 +6,11 @@ export interface StartSentryOptions {
   readonly profiling?: boolean;
 }
 
-const SENSITIVE_KEY = /authorization|password|token|secret|cookie|api[-_]?key/i;
+// Defense-in-depth key-name redaction on every Sentry event (sendDefaultPii is
+// already false). Covers auth secrets and direct PII so a stray breadcrumb or
+// `extra` field never ships credentials or personal data off-box.
+const SENSITIVE_KEY =
+  /authorization|password|token|secret|cookie|api[-_]?key|email|phone|ssn|credit[-_]?card|card[-_]?number|tax[-_]?id/i;
 const MAX_SCRUB_DEPTH = 8;
 
 function scrub(value: unknown, depth = 0, seen = new WeakSet<object>()): void {


### PR DESCRIPTION
## What

Two evidence-based hardening fixes surfaced during a code audit (the rest of the audit was mostly opinions, big refactors, or false positives — only these two are genuine defects worth fixing now).

### 1. Redact PII in Sentry events
`start-sentry.ts` scrub matched only auth-secret key names (`authorization|password|token|secret|cookie|api-key`). Added direct PII — `email|phone|ssn|credit-card|card-number|tax-id`. `sendDefaultPii` is already `false`; this is defense-in-depth so a stray breadcrumb / `extra` field can never ship personal data off-box.

### 2. Tighten the production CSP
The production CSP allowed `cdn.jsdelivr.net` + `*.scalar.com` in `scriptSrc`/`connectSrc`. Those are only needed by the **Scalar docs UI**, which mounts in **dev only** (`setupSwagger` runs behind `if (!isProduction)`). The single prod HTML surface, **Bull Board** (`/api/admin/queues`), serves its own **same-origin** bundled assets. So the CDN allowances were dead in prod — removing them makes the prod CSP same-origin with zero functional change. `'unsafe-inline'` is kept (Bull Board may rely on it).

## Not changed (audit items rejected after verification)
- **Read-replica routing "missing"** — false; `dbRead` is used in `prisma-user.repository.ts` with deliberate primary-vs-replica per-query routing.
- **Outbox "no max attempts → poison loop"** — false; `OUTBOX_MAX_ATTEMPTS=10` + stuck-row warning exist.
- **Idempotency "not cross-replica"** — false; uses a Redis Lua atomic lock.
- **Trust-proxy "silent clamp"** — non-issue; Zod bounds `TRUST_PROXY_HOPS` 0–10 and fails fast at boot.
- Password length, throttler fail-open, argon2 — deliberate documented trade-offs, not defects.
- Upload DDD refactor / rich domain / multi-tenancy / coverage gate — architectural, out of scope for a fix pass.

## Verification
`pnpm nx affected -t lint test typecheck build --base=origin/main` — all green (5 projects). Sentry scrub unit tests pass with the extended regex.

**Reviewer note:** CSP change affects the served Bull Board UI. Recommend a quick smoke-test of `/api/admin/queues` in the prod image (check browser console for CSP violations) before merge.