### PR TITLE
fix: correct audit-followup doc/config accuracy gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,11 +58,8 @@ updates:
         update-types: [major]
 
   - package-ecosystem: docker
-    directories:
-      - /apps/api
-      - /apps/worker
-      - /apps/scheduler
-      - /apps/migration
+    # Single multi-stage Dockerfile at the repo root builds all four app images.
+    directory: /
     schedule:
       interval: weekly
       day: monday

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,10 @@ apps/
     src/common/ filters, interceptors, swagger, throttler, health
   worker/       BullMQ consumer
   scheduler/    cron jobs (@nestjs/schedule)
-  migration/    one-shot `prisma migrate deploy` + optional seed (Docker CMD bypasses
-                main.ts; the file exists only so Nx sees an entry point. Gated by orchestrator
-                via `depends_on: service_completed_successfully` before api/worker/scheduler boot)
+  migration/    one-shot `prisma migrate deploy` + optional seed. main.ts holds the real logic
+                (retry/backoff around migrate deploy, DB_PASSWORD_FILE injection, RUN_SEED gate) and
+                the Docker CMD runs it. Gated by orchestrator via
+                `depends_on: service_completed_successfully` before api/worker/scheduler boot)
 
 libs/
   modules/      bounded contexts (DDD per module — see below)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Optional — local observability (Prometheus · Grafana · Jaeger · Loki · All
 ```
 
 > Enable in `.env`: `OTEL_ENABLED=true`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`,
-> `ENABLE_METRICS=true`, `METRICS_ALLOW_CIDRS=172.0.0.0/8`
+> `ENABLE_METRICS=true`, `METRICS_ALLOW_CIDRS=172.16.0.0/12`
 
 Once the stack is up:
 

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -109,8 +109,6 @@ services:
         condition: service_healthy
       migration:
         condition: service_completed_successfully
-      redis-cache:
-        condition: service_healthy
       redis-queue:
         condition: service_healthy
       minio:
@@ -156,8 +154,6 @@ services:
         condition: service_healthy
       migration:
         condition: service_completed_successfully
-      redis-cache:
-        condition: service_healthy
       redis-queue:
         condition: service_healthy
       minio:

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -254,8 +254,6 @@ services:
         condition: service_healthy
       migration:
         condition: service_completed_successfully
-      redis-cache:
-        condition: service_healthy
       redis-queue:
         condition: service_healthy
     restart: unless-stopped

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -312,4 +312,4 @@ or alias to `db` when `DATABASE_REPLICA_URL` is unset).
 - No `TODO` comments without a task ID and plan to fix
 - No temporary solutions or hacks
 - All code paths tested (including error paths)
-- All breaking changes documented in `docs/project-changelog.md`
+- All breaking changes documented in `CHANGELOG.md`

--- a/docs/creating-a-module.md
+++ b/docs/creating-a-module.md
@@ -108,12 +108,12 @@ storage…), not DDD bounded contexts, so the DDD module generator doesn't apply
 `--directory=modules|composition`). To add one:
 
 - **Preferred:** copy the closest existing infra lib (e.g. `libs/infra/redis`) and rename — it already
-  matches the workspace conventions (inferred targets, `vite-tsconfig-paths` in the vitest config,
-  `scope:infra` tag).
+  matches the workspace conventions (inferred targets, `resolve: { tsconfigPaths: true }` in the
+  vitest config, `scope:infra` tag).
 - `pnpm gen:lib` / `pnpm gen:app` are raw `@nx/js:library` / `@nx/nest:application` passthroughs.
   Their Nx-default output drifts from this repo (it emits an explicit `build` target and the
   deprecated `nxViteTsPaths`/`nxCopyAssetsPlugin` vite plugins), so align it afterwards: delete the
-  explicit targets and swap the vitest plugins to `vite-tsconfig-paths`. Also add the correct
+  explicit targets and switch the vitest config to `resolve: { tsconfigPaths: true }`. Also add the correct
   `scope:*` / `type:*` tags so `@nx/enforce-module-boundaries` applies.
 
 ## After Generating

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -143,7 +143,7 @@ OTEL_ENABLED=true
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 ENABLE_METRICS=true
 # Allow the Prometheus container (Docker bridge) to scrape /metrics
-METRICS_ALLOW_CIDRS=172.0.0.0/8
+METRICS_ALLOW_CIDRS=172.16.0.0/12
 ```
 
 | Service    | URL                    | Notes                 |

--- a/libs/api-client/src/generated/api.schemas.ts
+++ b/libs/api-client/src/generated/api.schemas.ts
@@ -59,7 +59,7 @@ export type ValidationErrorItemDtoConstraint = { [key: string]: unknown };
 export type ValidationErrorItemDtoReceived = { [key: string]: unknown };
 
 export interface ValidationErrorItemDto {
-  /** Path to the offending field. Dotted notation for objects, bracket for arrays. Prefixed with `query.`/`header.`/`path.` when the violation is not in the request body. */
+  /** Path to the offending field. Dotted notation for objects, bracket for arrays. */
   path: string;
   /** Stable error code for this specific violation (snake_case). */
   code: string;
@@ -270,7 +270,7 @@ export interface ListResponseDto {
    * @nullable
    */
   lastCursor?: ListResponseDtoLastCursor;
-  /** Total matching rows. Only present when `?withTotalCount=true` is requested (COUNT is expensive on large tables). */
+  /** Total matching rows. Omitted (undefined) on large/growth tables where COUNT would be a hot path — clients navigate via `hasMore`, not this. */
   totalCount?: number;
   /** Current page (1-based). Present only on offset-paginated endpoints. */
   page?: number;

--- a/libs/contracts/src/lib/dto/list-response.dto.ts
+++ b/libs/contracts/src/lib/dto/list-response.dto.ts
@@ -41,7 +41,7 @@ export class ListResponseDto<T = unknown> {
 
   @ApiPropertyOptional({
     description:
-      'Total matching rows. Only present when `?withTotalCount=true` is requested (COUNT is expensive on large tables).',
+      'Total matching rows. Omitted (undefined) on large/growth tables where COUNT would be a hot path — clients navigate via `hasMore`, not this.',
     example: 1284,
   })
   totalCount?: number;

--- a/libs/contracts/src/lib/errors/problem-details.dto.ts
+++ b/libs/contracts/src/lib/errors/problem-details.dto.ts
@@ -70,8 +70,7 @@ export class ProblemDetailsDto {
 
 export class ValidationErrorItemDto {
   @ApiProperty({
-    description:
-      'Path to the offending field. Dotted notation for objects, bracket for arrays. Prefixed with `query.`/`header.`/`path.` when the violation is not in the request body.',
+    description: 'Path to the offending field. Dotted notation for objects, bracket for arrays.',
     example: 'items[0].quantity',
   })
   path!: string;


### PR DESCRIPTION
Follow-up to #115. The integration audit + literal 100% file sweep found doc/config that diverged from actual behavior (no logic bugs). All small, no runtime code changes.

- **dependabot** — docker ecosystem pointed at `apps/*` (no Dockerfile there) → base-image CVEs never scanned. Now `directory: /` (the real Dockerfile).
- **compose** — worker/scheduler had a `redis-cache` `depends_on` health gate but neither uses redis-cache; a redis-cache blip would needlessly block their startup. Dropped (both still gate on postgres + redis-queue + minio). **Still two Redis instances** — nothing removed.
- **contracts (OpenAPI)** — `totalCount` described a non-existent `?withTotalCount=true` flag; `ValidationErrorItemDto.path` described non-existent `query./header.` prefixes. Aligned descriptions to real behavior + regenerated api-client.
- **docs** — vite-tsconfig-paths → `resolve.tsconfigPaths`, broken changelog link, `METRICS_ALLOW_CIDRS` example `172.0.0.0/8` → `172.16.0.0/12`.
- **CLAUDE.md** — corrected the apps/migration note (main.ts is not bypassed).

Local: contracts/api-client/api typecheck+lint+build green; api-client matches fresh codegen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified migration execution and service startup ordering.
  * Updated Prometheus metrics configuration with a narrower, more specific network range.
  * Documented that large datasets may omit total counts; use `hasMore` for navigation.
  * Updated validation error and development setup guidance.
  * Breaking changes are now documented in `CHANGELOG.md`.

* **Bug Fixes**
  * Improved service startup dependencies by removing unnecessary cache readiness requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->