### PR TITLE
feat: bearer-token ws auth, env-driven service identity, and nx release setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# Service identity (exposed at GET /). Optional — APP_VERSION defaults to the built package version,
+# APP_NAME defaults to nestjs-fastify-nx. Override to surface a deploy-specific name/version.
+# APP_NAME=nestjs-fastify-nx
+# APP_VERSION=1.2.0
+
 # Database
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "api",
+  "version": "1.1.0",
+  "private": true
+}

--- a/apps/api/src/app/app.controller.ts
+++ b/apps/api/src/app/app.controller.ts
@@ -1,13 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiOkResponse, ApiOperation, ApiProperty, ApiTags } from '@nestjs/swagger';
 import { ApiCommonErrors } from '@nestjs-fastify-nx/contracts';
 import { Public } from '@nestjs-fastify-nx/infra-auth';
+import type { EnvConfig } from '../config/env.validation';
 
 class ServiceInfoDto {
   @ApiProperty({ description: 'Service identifier.', example: 'nestjs-fastify-nx' })
   name!: string;
 
-  @ApiProperty({ description: 'Semantic version of the running build.', example: '1.0.0' })
+  @ApiProperty({ description: 'Semantic version of the running build.', example: '1.2.0' })
   version!: string;
 }
 
@@ -15,11 +17,16 @@ class ServiceInfoDto {
 @Public()
 @Controller()
 export class AppController {
+  constructor(private readonly config: ConfigService<EnvConfig, true>) {}
+
   @Get()
   @ApiOperation({ summary: 'Service metadata (name + version).' })
   @ApiOkResponse({ type: ServiceInfoDto, description: 'Service identification.' })
   @ApiCommonErrors({ auth: false, forbidden: false, validation: false })
   root(): ServiceInfoDto {
-    return { name: 'nestjs-fastify-nx', version: '1.0.0' };
+    return {
+      name: this.config.get('APP_NAME', { infer: true }),
+      version: this.config.get('APP_VERSION', { infer: true }),
+    };
   }
 }

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
+// The package version is the single source of truth for APP_VERSION's default; nx release bumps it
+// (and root) in lockstep. Operators can still override APP_VERSION/APP_NAME via env.
+import pkg from '../../package.json';
 
 const envSchema = z
   .object({
+    // Service identity — exposed at `GET /`. Defaults derive from the build; override via env.
+    APP_NAME: z.string().default('nestjs-fastify-nx'),
+    APP_VERSION: z.string().default(pkg.version),
     // Database
     DATABASE_URL: z.string().trim().min(1),
     // Prisma CLI uses this to bypass transaction-mode poolers (pgbouncer, RDS Proxy) for migrations.

--- a/apps/api/src/websocket/ws-auth.adapter.ts
+++ b/apps/api/src/websocket/ws-auth.adapter.ts
@@ -34,8 +34,8 @@ export function wsData(socket: Socket): WsSocketData {
   return socket.data as WsSocketData;
 }
 
-// Browser SPAs forward the Cookie header directly; non-browser clients pass auth.token, which is
-// wrapped into a synthetic cookie so both code paths are identical.
+// Browser SPAs forward the Cookie header directly; non-browser clients pass auth.token, forwarded
+// as an Authorization: Bearer header for the Better Auth bearer plugin to validate.
 // Redis sorted-set leases cap sockets per IP without leaking counts after process crashes.
 export interface WsAuthOptions {
   redis?: Redis;
@@ -45,15 +45,16 @@ export interface WsAuthOptions {
 
 export async function revalidateWsSession(auth: BetterAuthInstance, socket: Socket): Promise<void> {
   const cookieHeader = socket.handshake.headers['cookie'];
-  const fallbackToken =
+  const bearerToken =
     (socket.handshake.auth['token'] as string | undefined) ||
     extractBearer(socket.handshake.headers['authorization']);
 
-  const headers: Record<string, string> = cookieHeader
-    ? { cookie: cookieHeader }
-    : fallbackToken
-      ? { cookie: `better-auth.session_token=${fallbackToken}` }
-      : {};
+  const headers: Record<string, string> = {};
+  if (cookieHeader) headers['cookie'] = cookieHeader;
+  // Non-browser clients pass the session token via auth.token / Authorization. Hand it to the
+  // bearer plugin as-is — it verifies the signature and maps it to the correctly-named session
+  // cookie (incl. __Secure- under useSecureCookies), which a synthetic cookie can't do reliably.
+  if (bearerToken) headers['authorization'] = `Bearer ${bearerToken}`;
 
   if (Object.keys(headers).length === 0) {
     throw new Error('UNAUTHORIZED: No session credentials provided');

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -97,6 +97,9 @@ services:
       # Self-identify in logs/metrics/traces. Without this the worker inherits the
       # Override the shared .env default so logs/traces have the worker identity.
       OTEL_SERVICE_NAME: nestjs-fastify-worker
+      # PrismaService reads this from the env directly (not ConfigService), so the per-app zod
+      # default never reaches it — set it here so pg_stat_activity distinguishes worker connections.
+      DATABASE_APPLICATION_NAME: nestjs-fastify-worker
     healthcheck:
       test:
         [
@@ -116,6 +119,8 @@ services:
       TZ: ${TZ:-UTC}
       # Self-identify in logs/metrics/traces (see worker note above).
       OTEL_SERVICE_NAME: nestjs-fastify-scheduler
+      # See worker note — makes pg_stat_activity distinguish scheduler connections.
+      DATABASE_APPLICATION_NAME: nestjs-fastify-scheduler
     healthcheck:
       test:
         [

--- a/libs/infra/auth/src/lib/better-auth.config.ts
+++ b/libs/infra/auth/src/lib/better-auth.config.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 import { betterAuth } from 'better-auth';
 import type { BetterAuthOptions } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
-import { openAPI } from 'better-auth/plugins';
+import { bearer, openAPI } from 'better-auth/plugins';
 import type { PrismaClient } from '@nestjs-fastify-nx/infra-database';
 import type { I18nService } from 'nestjs-i18n';
 import {
@@ -191,7 +191,11 @@ export function createBetterAuth(
       useSecureCookies:
         process.env['NODE_ENV'] === 'production' || (baseURL?.startsWith('https://') ?? false),
     },
-    plugins: [openAPI()],
+    // bearer() lets non-browser clients (WebSocket, mobile, service-to-service) authenticate with
+    // `Authorization: Bearer <session-token>`. Better Auth verifies the token signature and maps it
+    // to the correctly-named session cookie (incl. the __Secure- prefix under useSecureCookies),
+    // which a hand-rolled synthetic cookie can't do reliably.
+    plugins: [openAPI(), bearer()],
   });
 }
 

--- a/nx.json
+++ b/nx.json
@@ -53,9 +53,11 @@
     "version": {
       "specifierSource": "conventional-commits",
       "currentVersionResolver": "git-tag",
-      "manifestRootsToUpdate": ["."]
+      "fallbackCurrentVersionResolver": "disk",
+      "manifestRootsToUpdate": [".", "apps/api"]
     },
     "changelog": {
+      "automaticFromRef": true,
       "projectChangelogs": false,
       "workspaceChangelog": {
         "file": "{workspaceRoot}/CHANGELOG.md",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,8 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.2)
 
+  apps/api: {}
+
   tools/generators: {}
 
 packages:


### PR DESCRIPTION
Follow-up hardening from the integration + hardcode sweep, plus enabling `nx release`.

## Auth (the standard setup — the previous code was fragile)
The WS auth fallback for non-browser clients hand-rolled a synthetic cookie `better-auth.session_token=<token>`. That is fragile: it hardcodes the cookie name (wrong under `useSecureCookies` → prod expects the `__Secure-` prefix) and ignores that Better Auth cookies are signed. **Fix:** add Better Auth's `bearer()` plugin and forward non-browser WS credentials as `Authorization: Bearer <token>`. Bearer verifies the signature and maps the token to the correctly-named session cookie — the documented, standard pattern for non-cookie clients.

## Service identity in env (was hardcoded + already stale)
`GET /` returned a hardcoded `version: '1.0.0'` (already wrong vs package 1.1.0). Now `name`/`version` come from `APP_NAME`/`APP_VERSION` env; `APP_VERSION` defaults to the built package version; both overridable. **Single source of truth** — no drifting literal.

## nx release setup (first release was misconfigured)
`nx release` couldn't resolve a version (no `apps/api/package.json`, no baseline tag). Configured for this single-version workspace: version carried in `apps/api/package.json`, `fallbackCurrentVersionResolver: disk`, `automaticFromRef` for the first changelog, and root + apps/api manifests bumped in lockstep.

## Drift fix
`DATABASE_APPLICATION_NAME` per service in compose — PrismaService reads it from env directly, so the per-app zod default never applied and worker/scheduler both showed as the api in `pg_stat_activity`.

Local: typecheck/lint/build 21/21, tests 19 projects green; api-client matches fresh codegen.

Deferred (non-blocking DRY, follow-up): pnpm version pinned in 9 spots (CI can read `packageManager`), DATABASE_URL repeated 4× in compose.prod.yml (YAML anchor), byte-size defaults duplicated.