### PR TITLE
ci: pin trivy-action to valid v0.36.0 sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.app }}
 
       - name: Trivy security scan (${{ matrix.app }})
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9af4af0408e91440ef0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: scan-candidate/${{ matrix.app }}:${{ github.sha }}
           format: sarif


### PR DESCRIPTION
## Vấn đề
`release.yml` pin `aquasecurity/trivy-action@6c175e9c4083a92bbca2f9af4af0408e91440ef0` — SHA này không tồn tại (`gh api commits/<sha>` → 422 No commit found), khiến toàn bộ matrix `build-and-push` fail ngay ở bước "Set up job" với `Unable to resolve action ... unable to find version`. Đây là lý do run release đầu tiên của tag `v1.2.0` fail và chưa publish image nào.

## Fix
Pin lại `aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0` — SHA resolve OK (verified qua GitHub API) và kèm comment version như các pin khác trong repo.

## Sau khi merge
Tag `v1.2.0` sẽ được re-point sang commit đã có fix để re-trigger release pipeline (chưa có artifact nào publish dưới v1.2.0 nên move tag an toàn).