### PR TITLE
fix: preserve response content-type in idempotent late-completion replay

### DIFF
--- a/apps/api/src/common/idempotency/register-idempotency.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.ts
@@ -29,8 +29,9 @@ export interface IdempotencyContext {
   ownerToken: string;
   // Records a 2xx result the onSend hook couldn't — e.g. the handler finished AFTER a 504 timeout
   // already replied, so a retry replays the stored response instead of re-running the mutation.
-  // Best-effort: if the pending lock already expired (handler slower than the lock TTL) it no-ops.
-  completeLate(status: number, value: unknown): Promise<void>;
+  // `contentType` preserves replay fidelity for non-JSON responses (@Header('Content-Type', ...));
+  // omit it to default to application/json. Best-effort: no-ops if the pending lock already expired.
+  completeLate(status: number, value: unknown, contentType?: string): Promise<void>;
 }
 
 interface RequestWithIdempotency extends FastifyRequest {
@@ -142,7 +143,7 @@ export function registerIdempotency(fastify: FastifyInstance, options: Idempoten
         storeKey,
         fingerprint,
         ownerToken,
-        completeLate: async (status, value) => {
+        completeLate: async (status, value, contentType) => {
           if (status < 200 || status >= 300) return;
           // Same capture contract as the onSend hook (replayableBody): undefined => non-capturable
           // (Buffer/stream) — leave the record pending until TTL rather than store a wrong body.
@@ -152,7 +153,7 @@ export function registerIdempotency(fastify: FastifyInstance, options: Idempoten
             await store.complete(storeKey, ownerToken, {
               fingerprint,
               status,
-              contentType: 'application/json',
+              contentType: contentType ?? 'application/json',
               body,
             });
           } catch (err) {

--- a/apps/api/src/common/interceptors/timeout.interceptor.spec.ts
+++ b/apps/api/src/common/interceptors/timeout.interceptor.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { HttpException, type CallHandler, type ExecutionContext } from '@nestjs/common';
+import { HEADERS_METADATA } from '@nestjs/common/constants';
 import type { ConfigService } from '@nestjs/config';
 import type { Reflector } from '@nestjs/core';
 import { firstValueFrom, of, Subject, throwError } from 'rxjs';
@@ -15,9 +16,14 @@ function makeContext(type: 'http' | 'ws', request?: unknown): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
-function makeInterceptor(timeoutMs: number): TimeoutInterceptor {
+function makeInterceptor(
+  timeoutMs: number,
+  headers?: { name: string; value: string }[],
+): TimeoutInterceptor {
   const config = { get: () => timeoutMs } as unknown as ConfigService<EnvConfig, true>;
-  const reflector = { get: () => undefined } as unknown as Reflector;
+  const reflector = {
+    get: (key: unknown) => (key === HEADERS_METADATA ? headers : undefined),
+  } as unknown as Reflector;
   return new TimeoutInterceptor(config, reflector);
 }
 
@@ -94,11 +100,30 @@ describe('TimeoutInterceptor', () => {
       expect((err as HttpException).getStatus()).toBe(504);
       expect(completeLate).not.toHaveBeenCalled();
 
-      // Handler finishes AFTER the 504 — must be recorded with the POST default status (201).
+      // Handler finishes AFTER the 504 — must be recorded with the POST default status (201) and no
+      // explicit content type (defaults to application/json inside completeLate).
       subject.next('late-result');
       subject.complete();
       await tick(0);
-      expect(completeLate).toHaveBeenCalledWith(201, 'late-result');
+      expect(completeLate).toHaveBeenCalledWith(201, 'late-result', undefined);
+    });
+
+    it("replays with the handler's @Header content-type for a late completion", async () => {
+      const completeLate = vi.fn().mockResolvedValue(undefined);
+      const request = { method: 'POST', idempotency: { completeLate } };
+      const subject = new Subject<unknown>();
+      const handler = { handle: () => subject.asObservable() } as unknown as CallHandler;
+      const interceptor = makeInterceptor(50, [{ name: 'Content-Type', value: 'text/csv' }]);
+
+      const settled = firstValueFrom(
+        interceptor.intercept(makeContext('http', request), handler),
+      ).catch((e: unknown) => e);
+      await settled;
+
+      subject.next('a,b,c');
+      subject.complete();
+      await tick(0);
+      expect(completeLate).toHaveBeenCalledWith(201, 'a,b,c', 'text/csv');
     });
 
     it('does not call completeLate when the idempotent handler finishes in time', async () => {

--- a/apps/api/src/common/interceptors/timeout.interceptor.ts
+++ b/apps/api/src/common/interceptors/timeout.interceptor.ts
@@ -6,7 +6,7 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { HTTP_CODE_METADATA } from '@nestjs/common/constants';
+import { HEADERS_METADATA, HTTP_CODE_METADATA } from '@nestjs/common/constants';
 import { Reflector } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
 import { Observable, throwError, TimeoutError } from 'rxjs';
@@ -65,6 +65,7 @@ export class TimeoutInterceptor implements NestInterceptor {
 
     const idempotency = request.idempotency;
     const successStatus = this.resolveSuccessStatus(context, request.method);
+    const contentType = this.resolveContentType(context);
 
     return new Observable<unknown>((subscriber) => {
       let timedOut = false;
@@ -93,7 +94,7 @@ export class TimeoutInterceptor implements NestInterceptor {
           // Late success after the 504 already replied — record it so a retry replays instead of
           // re-running. completeLate swallows its own errors; guard again so nothing escapes here.
           if (lateTimer) clearTimeout(lateTimer);
-          void idempotency.completeLate(successStatus, value).catch(() => undefined);
+          void idempotency.completeLate(successStatus, value, contentType).catch(() => undefined);
           sub.unsubscribe();
         },
         error: (err: unknown) => {
@@ -142,5 +143,16 @@ export class TimeoutInterceptor implements NestInterceptor {
     );
     if (typeof explicit === 'number') return explicit;
     return method === 'POST' ? HttpStatus.CREATED : HttpStatus.OK;
+  }
+
+  // The content type a late completion should replay with: the handler's @Header('Content-Type'),
+  // else undefined so completeLate defaults to application/json. Preserves byte-for-byte replay for
+  // non-JSON responses (a handler that set it imperatively via reply.header is not captured here).
+  private resolveContentType(context: ExecutionContext): string | undefined {
+    const headers = this.reflector.get<{ name: string; value: string }[] | undefined>(
+      HEADERS_METADATA,
+      context.getHandler(),
+    );
+    return headers?.find((header) => header.name.toLowerCase() === 'content-type')?.value;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #127 addressing two CodeRabbit findings on the idempotency-504 late-completion capture that landed **after** #127 was merged.

### Fixed (Major) — content-type replay fidelity
`completeLate` hard-coded `content-type: application/json`. A handler that sets a custom type via `@Header('Content-Type', 'text/csv')` (etc.) and completes **after** a 504 timeout would have its replay stored (and later served) with the wrong content-type — violating the idempotency directory's byte-for-byte replay contract.

`TimeoutInterceptor` now derives the content-type from the handler's `@Header` metadata (`HEADERS_METADATA` via `Reflector`, mirroring how the status is derived from `@HttpCode`) and threads it through `completeLate`, defaulting to `application/json` when no explicit header is set. (A content-type set imperatively via `reply.header(...)` isn't captured — documented in the code.)

### Not changed (Minor) — `subscriber.error()` teardown ordering
CodeRabbit asked whether `subscriber.error()` runs the Observable teardown synchronously (it does). The interceptor is already correct: when the watchdog fires it sets `timedOut = true` **before** `subscriber.error()`, so the synchronous teardown skips `sub.unsubscribe()` (keeping the source alive for the late capture); `lateTimer` is then armed and either fires (unref'd) to release the subscription within a bounded window or is cleared by the late-completion handler — no leak. Replied on the thread with this reasoning.

## Verification
`typecheck` + `lint` + `test` (api, 261 tests incl. new `@Header` case), `build`, `e2e` (60/60) — all green.
