### PR TITLE
fix(swagger): rebuild openapi setup to canonical shape and fix spec/codegen bugs

### DIFF
--- a/apps/api/src/common/health/health.controller.ts
+++ b/apps/api/src/common/health/health.controller.ts
@@ -2,7 +2,7 @@ import { applyDecorators, Controller, Get, HttpStatus, UseGuards } from '@nestjs
 import { HealthCheck, HealthCheckService, MemoryHealthIndicator } from '@nestjs/terminus';
 import { SkipThrottle } from '@nestjs/throttler';
 import { ApiOkResponse, ApiOperation, ApiProperty, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { ApiCommonErrors } from '@nestjs-fastify-nx/contracts';
+import { ApiCommonErrors, buildProblemExample } from '@nestjs-fastify-nx/contracts';
 import { Public } from '@nestjs-fastify-nx/infra-auth';
 import { PrismaReplicationLagHealthIndicator } from '@nestjs-fastify-nx/infra-database';
 import { MetricsIpAllowGuard } from '../metrics/metrics-ip-allow.guard';
@@ -89,7 +89,20 @@ function ApiServiceUnavailableProblem(description: string) {
       status: HttpStatus.SERVICE_UNAVAILABLE,
       description,
       content: {
-        [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
+        [PROBLEM_JSON]: {
+          schema: { $ref: '#/components/schemas/ProblemDetailsDto' },
+          // Status-matched example: without it Swagger/Scalar renders the schema's default 404 body
+          // under the 503 tab. Includes the `checks` extension the filter attaches for probe failures.
+          example: {
+            ...buildProblemExample({
+              status: HttpStatus.SERVICE_UNAVAILABLE,
+              code: 'service_unavailable',
+              title: 'Service Unavailable',
+              detail: description,
+            }),
+            checks: { redis_cache: { status: 'down', message: 'redis_cache check failed' } },
+          },
+        },
       },
     }),
   );

--- a/apps/api/src/common/swagger/swagger.config.ts
+++ b/apps/api/src/common/swagger/swagger.config.ts
@@ -3,9 +3,8 @@ import { Logger } from '@nestjs/common';
 import type { OpenAPIObject } from '@nestjs/swagger';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import {
+  buildProblemExample,
   ListResponseDto,
-  PageMetaDto,
-  PaginationDto,
   ProblemDetailsDto,
   ValidationErrorItemDto,
   ValidationProblemDetailsDto,
@@ -16,30 +15,52 @@ import ScalarApiReference from '@scalar/fastify-api-reference';
 
 const API_TITLE = 'NestJS Fastify Nx Boilerplate';
 const PROBLEM_JSON = 'application/problem+json';
-const SESSION_COOKIE = 'better-auth.session_token';
+const SESSION_COOKIE_BASE = 'better-auth.session_token';
 const DOCS_ROUTE_PREFIX = '/docs';
 const REQUEST_ID_HEADER = 'X-Request-Id';
 const AUTH_PATH_PREFIX = '/api/auth';
 const AUTH_TAG = 'auth';
 
+// Credential paths that create a session (no auth required yet). Better Auth's generated spec marks
+// them as secured — strip that so they aren't documented as needing a token.
+const PUBLIC_AUTH_PATHS = new Set([
+  `${AUTH_PATH_PREFIX}/sign-in/email`,
+  `${AUTH_PATH_PREFIX}/sign-up/email`,
+  `${AUTH_PATH_PREFIX}/request-password-reset`,
+  `${AUTH_PATH_PREFIX}/reset-password`,
+  `${AUTH_PATH_PREFIX}/forget-password`,
+]);
+
 const logger = new Logger('Swagger');
 
-const DESCRIPTION = [
-  'Production-ready REST + GraphQL API built on NestJS, Fastify and Nx.',
-  '',
-  '### Authentication',
-  `Session-based via [Better Auth](https://better-auth.com). Endpoints under \`${AUTH_PATH_PREFIX}/*\` (tagged **${AUTH_TAG}**) cover sign-up, sign-in, sign-out, social providers, password reset and session lookup. Protected resource endpoints require the \`${SESSION_COOKIE}\` cookie — click **Authorize** and paste the value to try them out.`,
-  '',
-  '### Response shapes',
-  '',
-  '- **Success** — endpoints return the resource directly (Stripe-style: no envelope). List endpoints return a `ListResponseDto` with `object: "list"`, `data[]`, and `hasMore`.',
-  '- **Errors** — every error response uses [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) with `Content-Type: application/problem+json`. Branch on the `code` field (snake_case, stable) — never the human-readable `title`/`detail`.',
-  '- **Validation errors** carry an additional `errors[]` array with one entry per offending field; entries include `path`, `code`, `message`, `rule`, and `constraint`.',
-  '',
-  '### Correlation',
-  '',
-  `Every response carries an \`${REQUEST_ID_HEADER}\` header (also mirrored as \`requestId\` in error bodies). Quote it when filing support tickets.`,
-].join('\n');
+// Better Auth adds `__Secure-` to the cookie name when it issues secure cookies (production, or any
+// https baseURL). setupSwagger runs off-production, so resolve the real name for the https-staging
+// case rather than hardcoding — the Authorize field must match the cookie actually sent.
+function resolveSessionCookieName(): string {
+  const secure =
+    process.env['NODE_ENV'] === 'production' ||
+    (process.env['BETTER_AUTH_URL'] ?? '').startsWith('https://');
+  return secure ? `__Secure-${SESSION_COOKIE_BASE}` : SESSION_COOKIE_BASE;
+}
+
+function buildDescription(sessionCookie: string): string {
+  return [
+    'Production-ready REST + GraphQL API built on NestJS, Fastify and Nx.',
+    '',
+    '### Authentication',
+    `Session-based via [Better Auth](https://better-auth.com). Endpoints under \`${AUTH_PATH_PREFIX}/*\` (tagged **${AUTH_TAG}**) cover sign-up, sign-in, sign-out, social providers, password reset and session lookup. Protected resource endpoints require the \`${sessionCookie}\` cookie — click **Authorize** and paste the value to try them out.`,
+    '',
+    '### Response shapes',
+    '',
+    '- **Success** — endpoints return the resource directly (Stripe-style: no envelope). List endpoints return a `ListResponseDto` with `object: "list"`, `data[]`, and `hasMore`.',
+    '- **Errors** — every error response uses [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) with `Content-Type: application/problem+json`. Branch on the `code` field (snake_case, stable) — never the human-readable `title`/`detail`.',
+    '- **Validation errors** carry an additional `errors[]` array with one entry per offending field; entries include `path`, `code`, `message`, `rule`, and `constraint`.',
+    '',
+    '### Correlation',
+    '',
+    `Every response carries an \`${REQUEST_ID_HEADER}\` header (also mirrored as \`requestId\` in error bodies). Quote it when filing support tickets.`,
+  ].join('\n');
+}
 
 // OpenAPI contract version — deliberately decoupled from the package release
 // version. `nx release` bumps package.json on every release; tying the spec to
@@ -53,9 +74,10 @@ function camelCase(input: string): string {
 }
 
 export async function buildSwaggerDocument(app: INestApplication): Promise<OpenAPIObject> {
+  const sessionCookie = resolveSessionCookieName();
   const builder = new DocumentBuilder()
     .setTitle(API_TITLE)
-    .setDescription(DESCRIPTION)
+    .setDescription(buildDescription(sessionCookie))
     .setVersion(API_VERSION)
     .setLicense('MIT', 'https://opensource.org/licenses/MIT')
     .addServer('/', 'Current host')
@@ -66,11 +88,11 @@ export async function buildSwaggerDocument(app: INestApplication): Promise<OpenA
     .addTag('admin', 'Admin-only operations (requires ADMIN role)')
     .addTag('upload', 'File upload')
     .addCookieAuth(
-      SESSION_COOKIE,
+      sessionCookie,
       {
         type: 'apiKey',
         in: 'cookie',
-        name: SESSION_COOKIE,
+        name: sessionCookie,
         description: `Session cookie issued by POST ${AUTH_PATH_PREFIX}/sign-in/email.`,
       },
       'session',
@@ -85,13 +107,14 @@ export async function buildSwaggerDocument(app: INestApplication): Promise<OpenA
       const method = methodKey.charAt(0).toUpperCase() + methodKey.slice(1);
       return `${controller}${method}`;
     },
+    // Only models referenced by $ref that Nest can't auto-discover: the problem-details shapes and
+    // the generic list envelope (composed via allOf in ApiPaginatedResponse). The offset PaginationDto
+    // is a query DTO (inlined per-endpoint), so registering it here would only emit a dead schema.
     extraModels: [
       ProblemDetailsDto,
       ValidationProblemDetailsDto,
       ValidationErrorItemDto,
       ListResponseDto,
-      PageMetaDto,
-      PaginationDto,
     ],
   });
 
@@ -104,7 +127,6 @@ export async function buildSwaggerDocument(app: INestApplication): Promise<OpenA
 
 // Better Auth re-uses the same `operationId` across GET/POST variants of the same path. The OpenAPI spec requires uniqueness, and Orval's codegen breaks on collisions — suffix the duplicates with their HTTP method.
 function dedupeOperationIds(document: OpenAPIObject): void {
-  const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
   const seen = new Set<string>();
 
   for (const pathItem of Object.values(document.paths ?? {})) {
@@ -167,6 +189,8 @@ async function mergeBetterAuthSpec(app: INestApplication, document: OpenAPIObjec
       const tagged = tagOperations(pathItem, AUTH_TAG) as Record<string, unknown>;
       ensurePathParameters(fullPath, tagged);
       normalizeAuthInfraErrors(tagged);
+      assignMissingOperationIds(fullPath, tagged);
+      if (PUBLIC_AUTH_PATHS.has(fullPath)) clearOperationSecurity(tagged);
       document.paths[fullPath] = tagged;
     }
   }
@@ -178,12 +202,64 @@ async function mergeBetterAuthSpec(app: INestApplication, document: OpenAPIObjec
       ...converted.components.schemas,
     } as NonNullable<typeof document.components.schemas>;
   }
+
+  // Merge securitySchemes too: Better Auth's operations reference `bearerAuth`, whose definition
+  // lives here. Without this the referenced scheme is undefined — an invalid spec (dangling ref) that
+  // breaks strict validators and Scalar's Authorize for every /api/auth/* route.
+  if (converted.components?.securitySchemes) {
+    document.components = document.components ?? {};
+    document.components.securitySchemes = {
+      ...(document.components.securitySchemes ?? {}),
+      ...converted.components.securitySchemes,
+    } as NonNullable<typeof document.components.securitySchemes>;
+  }
 }
 
 interface AuthOpenApiDocument {
   paths?: Record<string, unknown>;
-  components?: { schemas?: Record<string, unknown> };
+  components?: { schemas?: Record<string, unknown>; securitySchemes?: Record<string, unknown> };
   [key: string]: unknown;
+}
+
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+
+// Better Auth leaves many merged operations without an operationId. Orval then falls back to ugly
+// path-derived names (getApiAuthRevokeSession…), inconsistent with the clean names elsewhere. Derive
+// a camelCase id from the path segments after /api/auth so codegen method names stay idiomatic;
+// collisions across GET/POST are resolved afterwards by dedupeOperationIds.
+function assignMissingOperationIds(fullPath: string, pathItem: Record<string, unknown>): void {
+  const segments = fullPath
+    .replace(new RegExp(`^${AUTH_PATH_PREFIX}/?`), '')
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => segment.replace(/\{|\}/g, ''));
+  const base = segments
+    .map((segment, index) =>
+      segment
+        .split(/[-_]/)
+        .map((part, partIndex) =>
+          index === 0 && partIndex === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
+        )
+        .join(''),
+    )
+    .join('');
+  if (!base) return;
+
+  for (const method of HTTP_METHODS) {
+    const op = pathItem[method] as { operationId?: string } | undefined;
+    if (op && typeof op === 'object' && !op.operationId) {
+      op.operationId = base;
+    }
+  }
+}
+
+// Public credential routes require no auth — drop the (bearer) security Better Auth attached so the
+// docs don't claim a token is needed to sign in / reset a password.
+function clearOperationSecurity(pathItem: Record<string, unknown>): void {
+  for (const method of HTTP_METHODS) {
+    const op = pathItem[method] as { security?: unknown } | undefined;
+    if (op && typeof op === 'object') op.security = [];
+  }
 }
 
 // Better Auth's spec sometimes inlines `{id}` in a path without declaring the parameter. Inject the missing parameter so strict validators (Orval) accept the merged document.
@@ -191,7 +267,6 @@ function ensurePathParameters(url: string, pathItem: Record<string, unknown>): v
   const placeholders = [...url.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]);
   if (placeholders.length === 0) return;
 
-  const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
   for (const method of HTTP_METHODS) {
     const op = pathItem[method] as
       { parameters?: Array<{ name?: string; in?: string }> } | undefined;
@@ -218,20 +293,31 @@ function ensurePathParameters(url: string, pathItem: Record<string, unknown>): v
 // route. Rewrite just those two so the documented shape matches the real runtime response.
 // Better Auth's own 2xx/400/401 semantics are left intact (they genuinely return `{ message }`).
 function normalizeAuthInfraErrors(pathItem: Record<string, unknown>): void {
-  const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
-  const INFRA_CODES: Record<string, string> = {
-    '429': 'Rate limit exceeded — see the `Retry-After` response header.',
-    '500': 'Unexpected server error. Quote the `requestId` field when contacting support.',
+  const INFRA_RESPONSES: Record<string, { code: string; title: string; detail: string }> = {
+    '429': {
+      code: 'rate_limited',
+      title: 'Too Many Requests',
+      detail: 'Rate limit exceeded — see the `Retry-After` response header.',
+    },
+    '500': {
+      code: 'internal_server_error',
+      title: 'Internal Server Error',
+      detail: 'Unexpected server error. Quote the `requestId` field when contacting support.',
+    },
   };
   for (const method of HTTP_METHODS) {
     const op = pathItem[method] as { responses?: Record<string, unknown> } | undefined;
     if (!op?.responses) continue;
-    for (const [code, description] of Object.entries(INFRA_CODES)) {
+    for (const [code, cfg] of Object.entries(INFRA_RESPONSES)) {
       if (!op.responses[code]) continue;
       op.responses[code] = {
-        description,
+        description: cfg.detail,
         content: {
-          [PROBLEM_JSON]: { schema: { $ref: '#/components/schemas/ProblemDetailsDto' } },
+          [PROBLEM_JSON]: {
+            schema: { $ref: '#/components/schemas/ProblemDetailsDto' },
+            // Explicit example so the tab shows a 429/500 body, not the schema's default 404 example.
+            example: buildProblemExample({ status: Number(code), ...cfg }),
+          },
         },
       };
     }
@@ -241,7 +327,6 @@ function normalizeAuthInfraErrors(pathItem: Record<string, unknown>): void {
 // Better Auth's openAPI plugin tags every operation with `Default`. Replace it outright so Orval's `tags-split` mode doesn't emit each operation twice (once under `auth`, once under `default`).
 function tagOperations(pathItem: unknown, tag: string): unknown {
   if (!pathItem || typeof pathItem !== 'object') return pathItem;
-  const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
   const cloned: Record<string, unknown> = { ...(pathItem as Record<string, unknown>) };
   for (const method of HTTP_METHODS) {
     const op = cloned[method] as { tags?: string[] } | undefined;
@@ -254,11 +339,12 @@ function tagOperations(pathItem: unknown, tag: string): unknown {
 
 // X-Request-Id is set on every response by CorrelationIdMiddleware + fastify-error-handler. Document it once globally instead of decorating every controller.
 function injectRequestIdResponseHeader(document: OpenAPIObject): void {
-  const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
   const headerSpec = {
     description:
       'Correlation id echoed from the request (or freshly minted). Quote when filing support tickets.',
-    schema: { type: 'string', format: 'uuid' },
+    // Not `format: uuid`: the value is a 32-hex OTel trace id or a `randomBytes(16)` hex string
+    // (no dashes) — a strict validator would reject those against the uuid format.
+    schema: { type: 'string', example: '4bf92f3577b34da6a3ce929d0e0e4736' },
   };
 
   for (const pathItem of Object.values(document.paths ?? {})) {

--- a/apps/api/src/common/swagger/swagger.config.ts
+++ b/apps/api/src/common/swagger/swagger.config.ts
@@ -190,7 +190,7 @@ async function mergeBetterAuthSpec(app: INestApplication, document: OpenAPIObjec
       ensurePathParameters(fullPath, tagged);
       normalizeAuthInfraErrors(tagged);
       assignMissingOperationIds(fullPath, tagged);
-      if (PUBLIC_AUTH_PATHS.has(fullPath)) clearOperationSecurity(tagged);
+      applyCookieOnlySecurity(fullPath, tagged);
       document.paths[fullPath] = tagged;
     }
   }
@@ -203,21 +203,15 @@ async function mergeBetterAuthSpec(app: INestApplication, document: OpenAPIObjec
     } as NonNullable<typeof document.components.schemas>;
   }
 
-  // Merge securitySchemes too: Better Auth's operations reference `bearerAuth`, whose definition
-  // lives here. Without this the referenced scheme is undefined — an invalid spec (dangling ref) that
-  // breaks strict validators and Scalar's Authorize for every /api/auth/* route.
-  if (converted.components?.securitySchemes) {
-    document.components = document.components ?? {};
-    document.components.securitySchemes = {
-      ...(document.components.securitySchemes ?? {}),
-      ...converted.components.securitySchemes,
-    } as NonNullable<typeof document.components.securitySchemes>;
-  }
+  // Deliberately DO NOT merge Better Auth's securitySchemes (`bearerAuth`, `apiKeyCookie`).
+  // applyCookieOnlySecurity rewrites every auth operation to reference our `session` cookie scheme,
+  // so those schemes would be unreferenced — and merging `bearerAuth` would advertise an access-token
+  // flow this repo does not use (auth is the `better-auth.session_token` cookie, never a bearer token).
 }
 
 interface AuthOpenApiDocument {
   paths?: Record<string, unknown>;
-  components?: { schemas?: Record<string, unknown>; securitySchemes?: Record<string, unknown> };
+  components?: { schemas?: Record<string, unknown> };
   [key: string]: unknown;
 }
 
@@ -253,12 +247,16 @@ function assignMissingOperationIds(fullPath: string, pathItem: Record<string, un
   }
 }
 
-// Public credential routes require no auth — drop the (bearer) security Better Auth attached so the
-// docs don't claim a token is needed to sign in / reset a password.
-function clearOperationSecurity(pathItem: Record<string, unknown>): void {
+// Better Auth's generated spec blanket-marks every operation with `bearerAuth` (access-token flow).
+// This repo authenticates auth routes with the `better-auth.session_token` COOKIE, never a bearer
+// token, so advertising bearer would contradict the auth contract (and the "NOT JWT" invariant).
+// Rewrite each merged auth operation to the cookie `session` scheme — public credential routes
+// (sign-in/up, password reset) need no session, so they get an empty requirement.
+function applyCookieOnlySecurity(fullPath: string, pathItem: Record<string, unknown>): void {
+  const isPublic = PUBLIC_AUTH_PATHS.has(fullPath);
   for (const method of HTTP_METHODS) {
     const op = pathItem[method] as { security?: unknown } | undefined;
-    if (op && typeof op === 'object') op.security = [];
+    if (op && typeof op === 'object') op.security = isPublic ? [] : [{ session: [] }];
   }
 }
 

--- a/libs/api-client/src/generated/api.schemas.ts
+++ b/libs/api-client/src/generated/api.schemas.ts
@@ -21,7 +21,12 @@
 /**
  * Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs.
  */
-export type ProblemDetailsDtoChecks = { [key: string]: { [key: string]: unknown } };
+export type ProblemDetailsDtoChecks = {
+  [key: string]: {
+    status: string;
+    message?: string;
+  };
+};
 
 export interface ProblemDetailsDto {
   /** A URI reference identifying the problem type. SHOULD resolve to human-readable docs. */
@@ -54,9 +59,10 @@ export interface ProblemDetailsDto {
 export type ValidationErrorItemDtoConstraint = { [key: string]: unknown };
 
 /**
- * Value received from the client. Sensitive fields are redacted.
+ * Value received from the client that failed validation. Free-form: mirrors the offending input, which may be any JSON type (string, number, boolean, object or array). Sensitive fields are redacted.
  */
-export type ValidationErrorItemDtoReceived = { [key: string]: unknown };
+export type ValidationErrorItemDtoReceived =
+  string | number | boolean | { [key: string]: unknown } | unknown[];
 
 export interface ValidationErrorItemDto {
   /** Path to the offending field. Dotted notation for objects, bracket for arrays. */
@@ -71,14 +77,19 @@ export interface ValidationErrorItemDto {
   rule?: string;
   /** Validator constraint parameters (e.g. `{ min: 1 }`, `{ max: 100 }`). */
   constraint?: ValidationErrorItemDtoConstraint;
-  /** Value received from the client. Sensitive fields are redacted. */
+  /** Value received from the client that failed validation. Free-form: mirrors the offending input, which may be any JSON type (string, number, boolean, object or array). Sensitive fields are redacted. */
   received?: ValidationErrorItemDtoReceived;
 }
 
 /**
  * Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs.
  */
-export type ValidationProblemDetailsDtoChecks = { [key: string]: { [key: string]: unknown } };
+export type ValidationProblemDetailsDtoChecks = {
+  [key: string]: {
+    status: string;
+    message?: string;
+  };
+};
 
 export interface ValidationProblemDetailsDto {
   /** A URI reference identifying the problem type. SHOULD resolve to human-readable docs. */
@@ -250,26 +261,20 @@ export const ListResponseDtoObject = {
   list: 'list',
 } as const;
 
-/**
- * Opaque cursor pointing at the last item in `data` — pass back as `startingAfter` to fetch the next page. Present only on cursor-paginated endpoints; null when the result set is empty. Format is `base64url(sortField.toISOString():id)` — clients MUST treat it as opaque. The cursor encodes ONLY the sort position; it does NOT remember filter parameters (`role`, `status`, `search`, etc.). Changing any filter between page requests is equivalent to a fresh first-page query starting at the encoded position — clients changing filters mid-pagination should drop the cursor and restart.
- * @nullable
- */
-export type ListResponseDtoLastCursor = { [key: string]: unknown } | null;
-
 export interface ListResponseDto {
   /** Discriminator value identifying this envelope as a list. */
   object: ListResponseDtoObject;
   /** Endpoint URL (without query string) — useful for SDK base path inference. */
   url: string;
   /** Items in the current page. Order is endpoint-defined and stable for cursor pagination. */
-  data: unknown[][];
+  data: unknown[];
   /** True when more items follow the last element. Use `lastCursor` as `startingAfter` to fetch the next page on cursor-paginated endpoints. */
   hasMore: boolean;
   /**
    * Opaque cursor pointing at the last item in `data` — pass back as `startingAfter` to fetch the next page. Present only on cursor-paginated endpoints; null when the result set is empty. Format is `base64url(sortField.toISOString():id)` — clients MUST treat it as opaque. The cursor encodes ONLY the sort position; it does NOT remember filter parameters (`role`, `status`, `search`, etc.). Changing any filter between page requests is equivalent to a fresh first-page query starting at the encoded position — clients changing filters mid-pagination should drop the cursor and restart.
    * @nullable
    */
-  lastCursor?: ListResponseDtoLastCursor;
+  lastCursor?: string | null;
   /** Total matching rows. Omitted (undefined) on large/growth tables where COUNT would be a hot path — clients navigate via `hasMore`, not this. */
   totalCount?: number;
   /** Current page (1-based). Present only on offset-paginated endpoints. */
@@ -363,22 +368,6 @@ export interface StoredFileDto {
   bucket: string;
   /** Size in bytes. */
   size: number;
-}
-
-export interface PageMetaDto {
-  page: number;
-  pageSize: number;
-  total: number;
-  totalPages: number;
-  hasPrevPage: boolean;
-  hasNextPage: boolean;
-}
-
-export interface PaginationDto {
-  /** Page number (1-based) */
-  page?: number;
-  /** Items per page */
-  pageSize?: number;
 }
 
 export interface User {
@@ -582,23 +571,23 @@ export type SocialSignIn404 = {
   message?: string;
 };
 
-export type GetApiAuthCallbackId400 = {
+export type CallbackId400 = {
   message: string;
 };
 
-export type GetApiAuthCallbackId401 = {
+export type CallbackId401 = {
   message: string;
 };
 
-export type GetApiAuthCallbackId403 = {
+export type CallbackId403 = {
   message?: string;
 };
 
-export type GetApiAuthCallbackId404 = {
+export type CallbackId404 = {
   message?: string;
 };
 
-export type PostApiAuthCallbackIdBody = {
+export type CallbackIdPostBody = {
   code?: string;
   error?: string;
   device_id?: string;
@@ -607,19 +596,19 @@ export type PostApiAuthCallbackIdBody = {
   user?: string;
 };
 
-export type PostApiAuthCallbackId400 = {
+export type CallbackIdPost400 = {
   message: string;
 };
 
-export type PostApiAuthCallbackId401 = {
+export type CallbackIdPost401 = {
   message: string;
 };
 
-export type PostApiAuthCallbackId403 = {
+export type CallbackIdPost403 = {
   message?: string;
 };
 
-export type PostApiAuthCallbackId404 = {
+export type CallbackIdPost404 = {
   message?: string;
 };
 
@@ -850,7 +839,7 @@ export type VerifyPassword404 = {
   message?: string;
 };
 
-export type GetApiAuthVerifyEmailParams = {
+export type VerifyEmailParams = {
   /**
    * The token to verify the email
    */
@@ -861,25 +850,25 @@ export type GetApiAuthVerifyEmailParams = {
   callbackURL?: string;
 };
 
-export type GetApiAuthVerifyEmail200 = {
+export type VerifyEmail200 = {
   user: User;
   /** Indicates if the email was verified successfully */
   status: boolean;
 };
 
-export type GetApiAuthVerifyEmail400 = {
+export type VerifyEmail400 = {
   message: string;
 };
 
-export type GetApiAuthVerifyEmail401 = {
+export type VerifyEmail401 = {
   message: string;
 };
 
-export type GetApiAuthVerifyEmail403 = {
+export type VerifyEmail403 = {
   message?: string;
 };
 
-export type GetApiAuthVerifyEmail404 = {
+export type VerifyEmail404 = {
   message?: string;
 };
 
@@ -1180,75 +1169,75 @@ export type ListUserSessions404 = {
   message?: string;
 };
 
-export type PostApiAuthRevokeSessionBody = {
+export type RevokeSessionBody = {
   /** The token to revoke */
   token: string;
 };
 
-export type PostApiAuthRevokeSession200 = {
+export type RevokeSession200 = {
   /** Indicates if the session was revoked successfully */
   status: boolean;
 };
 
-export type PostApiAuthRevokeSession400 = {
+export type RevokeSession400 = {
   message: string;
 };
 
-export type PostApiAuthRevokeSession401 = {
+export type RevokeSession401 = {
   message: string;
 };
 
-export type PostApiAuthRevokeSession403 = {
+export type RevokeSession403 = {
   message?: string;
 };
 
-export type PostApiAuthRevokeSession404 = {
+export type RevokeSession404 = {
   message?: string;
 };
 
-export type PostApiAuthRevokeSessionsBody = { [key: string]: unknown };
+export type RevokeSessionsBody = { [key: string]: unknown };
 
-export type PostApiAuthRevokeSessions200 = {
+export type RevokeSessions200 = {
   /** Indicates if all sessions were revoked successfully */
   status: boolean;
 };
 
-export type PostApiAuthRevokeSessions400 = {
+export type RevokeSessions400 = {
   message: string;
 };
 
-export type PostApiAuthRevokeSessions401 = {
+export type RevokeSessions401 = {
   message: string;
 };
 
-export type PostApiAuthRevokeSessions403 = {
+export type RevokeSessions403 = {
   message?: string;
 };
 
-export type PostApiAuthRevokeSessions404 = {
+export type RevokeSessions404 = {
   message?: string;
 };
 
-export type PostApiAuthRevokeOtherSessionsBody = { [key: string]: unknown };
+export type RevokeOtherSessionsBody = { [key: string]: unknown };
 
-export type PostApiAuthRevokeOtherSessions200 = {
+export type RevokeOtherSessions200 = {
   /** Indicates if all other sessions were revoked successfully */
   status: boolean;
 };
 
-export type PostApiAuthRevokeOtherSessions400 = {
+export type RevokeOtherSessions400 = {
   message: string;
 };
 
-export type PostApiAuthRevokeOtherSessions401 = {
+export type RevokeOtherSessions401 = {
   message: string;
 };
 
-export type PostApiAuthRevokeOtherSessions403 = {
+export type RevokeOtherSessions403 = {
   message?: string;
 };
 
-export type PostApiAuthRevokeOtherSessions404 = {
+export type RevokeOtherSessions404 = {
   message?: string;
 };
 
@@ -1363,7 +1352,7 @@ export type ListUserAccounts404 = {
   message?: string;
 };
 
-export type GetApiAuthDeleteUserCallbackParams = {
+export type DeleteUserCallbackParams = {
   /**
    * The token to verify the deletion request
    */
@@ -1377,62 +1366,62 @@ export type GetApiAuthDeleteUserCallbackParams = {
 /**
  * Confirmation message
  */
-export type GetApiAuthDeleteUserCallback200Message =
-  (typeof GetApiAuthDeleteUserCallback200Message)[keyof typeof GetApiAuthDeleteUserCallback200Message];
+export type DeleteUserCallback200Message =
+  (typeof DeleteUserCallback200Message)[keyof typeof DeleteUserCallback200Message];
 
-export const GetApiAuthDeleteUserCallback200Message = {
+export const DeleteUserCallback200Message = {
   User_deleted: 'User deleted',
 } as const;
 
-export type GetApiAuthDeleteUserCallback200 = {
+export type DeleteUserCallback200 = {
   /** Indicates if the deletion was successful */
   success: boolean;
   /** Confirmation message */
-  message: GetApiAuthDeleteUserCallback200Message;
+  message: DeleteUserCallback200Message;
 };
 
-export type GetApiAuthDeleteUserCallback400 = {
+export type DeleteUserCallback400 = {
   message: string;
 };
 
-export type GetApiAuthDeleteUserCallback401 = {
+export type DeleteUserCallback401 = {
   message: string;
 };
 
-export type GetApiAuthDeleteUserCallback403 = {
+export type DeleteUserCallback403 = {
   message?: string;
 };
 
-export type GetApiAuthDeleteUserCallback404 = {
+export type DeleteUserCallback404 = {
   message?: string;
 };
 
-export type PostApiAuthUnlinkAccountBody = {
+export type UnlinkAccountBody = {
   providerId: string;
   accountId?: string;
 };
 
-export type PostApiAuthUnlinkAccount200 = {
+export type UnlinkAccount200 = {
   status?: boolean;
 };
 
-export type PostApiAuthUnlinkAccount400 = {
+export type UnlinkAccount400 = {
   message: string;
 };
 
-export type PostApiAuthUnlinkAccount401 = {
+export type UnlinkAccount401 = {
   message: string;
 };
 
-export type PostApiAuthUnlinkAccount403 = {
+export type UnlinkAccount403 = {
   message?: string;
 };
 
-export type PostApiAuthUnlinkAccount404 = {
+export type UnlinkAccount404 = {
   message?: string;
 };
 
-export type PostApiAuthRefreshTokenBody = {
+export type RefreshTokenBody = {
   /** The provider ID for the OAuth provider */
   providerId: string;
   /** The account ID associated with the refresh token */
@@ -1441,7 +1430,7 @@ export type PostApiAuthRefreshTokenBody = {
   userId?: string;
 };
 
-export type PostApiAuthRefreshToken200 = {
+export type RefreshToken200 = {
   tokenType?: string;
   idToken?: string;
   accessToken?: string;
@@ -1450,19 +1439,19 @@ export type PostApiAuthRefreshToken200 = {
   refreshTokenExpiresAt?: string;
 };
 
-export type PostApiAuthRefreshToken401 = {
+export type RefreshToken401 = {
   message: string;
 };
 
-export type PostApiAuthRefreshToken403 = {
+export type RefreshToken403 = {
   message?: string;
 };
 
-export type PostApiAuthRefreshToken404 = {
+export type RefreshToken404 = {
   message?: string;
 };
 
-export type PostApiAuthGetAccessTokenBody = {
+export type GetAccessTokenBody = {
   /** The provider ID for the OAuth provider */
   providerId: string;
   /** The account ID associated with the refresh token */
@@ -1471,26 +1460,26 @@ export type PostApiAuthGetAccessTokenBody = {
   userId?: string;
 };
 
-export type PostApiAuthGetAccessToken200 = {
+export type GetAccessToken200 = {
   tokenType?: string;
   idToken?: string;
   accessToken?: string;
   accessTokenExpiresAt?: string;
 };
 
-export type PostApiAuthGetAccessToken401 = {
+export type GetAccessToken401 = {
   message: string;
 };
 
-export type PostApiAuthGetAccessToken403 = {
+export type GetAccessToken403 = {
   message?: string;
 };
 
-export type PostApiAuthGetAccessToken404 = {
+export type GetAccessToken404 = {
   message?: string;
 };
 
-export type GetApiAuthAccountInfo200User = {
+export type AccountInfo200User = {
   id: string;
   name?: string;
   email?: string;
@@ -1498,62 +1487,62 @@ export type GetApiAuthAccountInfo200User = {
   emailVerified: boolean;
 };
 
-export type GetApiAuthAccountInfo200Data = { [key: string]: unknown };
+export type AccountInfo200Data = { [key: string]: unknown };
 
-export type GetApiAuthAccountInfo200 = {
-  user: GetApiAuthAccountInfo200User;
-  data: GetApiAuthAccountInfo200Data;
+export type AccountInfo200 = {
+  user: AccountInfo200User;
+  data: AccountInfo200Data;
 };
 
-export type GetApiAuthAccountInfo400 = {
+export type AccountInfo400 = {
   message: string;
 };
 
-export type GetApiAuthAccountInfo401 = {
+export type AccountInfo401 = {
   message: string;
 };
 
-export type GetApiAuthAccountInfo403 = {
+export type AccountInfo403 = {
   message?: string;
 };
 
-export type GetApiAuthAccountInfo404 = {
+export type AccountInfo404 = {
   message?: string;
 };
 
-export type GetApiAuthOk200 = {
+export type Ok200 = {
   /** Indicates if the API is working */
   ok: boolean;
 };
 
-export type GetApiAuthOk400 = {
+export type Ok400 = {
   message: string;
 };
 
-export type GetApiAuthOk401 = {
+export type Ok401 = {
   message: string;
 };
 
-export type GetApiAuthOk403 = {
+export type Ok403 = {
   message?: string;
 };
 
-export type GetApiAuthOk404 = {
+export type Ok404 = {
   message?: string;
 };
 
-export type GetApiAuthError400 = {
+export type Error400 = {
   message: string;
 };
 
-export type GetApiAuthError401 = {
+export type Error401 = {
   message: string;
 };
 
-export type GetApiAuthError403 = {
+export type Error403 = {
   message?: string;
 };
 
-export type GetApiAuthError404 = {
+export type Error404 = {
   message?: string;
 };

--- a/libs/api-client/src/generated/api.schemas.ts
+++ b/libs/api-client/src/generated/api.schemas.ts
@@ -62,7 +62,7 @@ export type ValidationErrorItemDtoConstraint = { [key: string]: unknown };
  * Value received from the client that failed validation. Free-form: mirrors the offending input, which may be any JSON type (string, number, boolean, object or array). Sensitive fields are redacted.
  */
 export type ValidationErrorItemDtoReceived =
-  string | number | boolean | { [key: string]: unknown } | unknown[];
+  string | number | boolean | { [key: string]: unknown } | null | unknown[];
 
 export interface ValidationErrorItemDto {
   /** Path to the offending field. Dotted notation for objects, bracket for arrays. */

--- a/libs/api-client/src/generated/auth.ts
+++ b/libs/api-client/src/generated/auth.ts
@@ -19,43 +19,39 @@
  * OpenAPI spec version: 1.0.0
  */
 import type {
+  AccountInfo200,
+  CallbackIdPostBody,
   ChangeEmail200,
   ChangeEmailBody,
   ChangePassword200,
   ChangePasswordBody,
   DeleteUser200,
   DeleteUserBody,
-  GetApiAuthAccountInfo200,
-  GetApiAuthDeleteUserCallback200,
-  GetApiAuthDeleteUserCallbackParams,
-  GetApiAuthOk200,
-  GetApiAuthVerifyEmail200,
-  GetApiAuthVerifyEmailParams,
+  DeleteUserCallback200,
+  DeleteUserCallbackParams,
+  GetAccessToken200,
+  GetAccessTokenBody,
   GetSession200,
   GetSessionPost200,
   GetSessionPostBody,
   LinkSocialAccount200,
   LinkSocialAccountBody,
   ListUserAccounts200Item,
-  PostApiAuthCallbackIdBody,
-  PostApiAuthGetAccessToken200,
-  PostApiAuthGetAccessTokenBody,
-  PostApiAuthRefreshToken200,
-  PostApiAuthRefreshTokenBody,
-  PostApiAuthRevokeOtherSessions200,
-  PostApiAuthRevokeOtherSessionsBody,
-  PostApiAuthRevokeSession200,
-  PostApiAuthRevokeSessionBody,
-  PostApiAuthRevokeSessions200,
-  PostApiAuthRevokeSessionsBody,
-  PostApiAuthUnlinkAccount200,
-  PostApiAuthUnlinkAccountBody,
+  Ok200,
+  RefreshToken200,
+  RefreshTokenBody,
   RequestPasswordReset200,
   RequestPasswordResetBody,
   ResetPassword200,
   ResetPasswordBody,
   ResetPasswordCallback200,
   ResetPasswordCallbackParams,
+  RevokeOtherSessions200,
+  RevokeOtherSessionsBody,
+  RevokeSession200,
+  RevokeSessionBody,
+  RevokeSessions200,
+  RevokeSessionsBody,
   SendVerificationEmail200,
   SendVerificationEmailBody,
   Session,
@@ -67,10 +63,14 @@ import type {
   SignUpWithEmailAndPasswordBody,
   SocialSignIn200,
   SocialSignInBody,
+  UnlinkAccount200,
+  UnlinkAccountBody,
   UpdateSession200,
   UpdateSessionBody,
   UpdateUser200,
   UpdateUserBody,
+  VerifyEmail200,
+  VerifyEmailParams,
   VerifyPassword200,
   VerifyPasswordBody,
 } from './api.schemas';
@@ -89,18 +89,15 @@ export const getAuth = () => {
       data: socialSignInBody,
     });
   };
-  const getApiAuthCallbackId = (id: string) => {
+  const callbackId = (id: string) => {
     return customAxiosInstance<unknown>({ url: `/api/auth/callback/${id}`, method: 'GET' });
   };
-  const postApiAuthCallbackId = (
-    id: string,
-    postApiAuthCallbackIdBody?: PostApiAuthCallbackIdBody,
-  ) => {
+  const callbackIdPost = (id: string, callbackIdPostBody?: CallbackIdPostBody) => {
     return customAxiosInstance<unknown>({
       url: `/api/auth/callback/${id}`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthCallbackIdBody,
+      data: callbackIdPostBody,
     });
   };
   /**
@@ -180,8 +177,8 @@ export const getAuth = () => {
   /**
    * Verify the email of the user
    */
-  const getApiAuthVerifyEmail = (params: GetApiAuthVerifyEmailParams) => {
-    return customAxiosInstance<GetApiAuthVerifyEmail200>({
+  const verifyEmail = (params: VerifyEmailParams) => {
+    return customAxiosInstance<VerifyEmail200>({
       url: `/api/auth/verify-email`,
       method: 'GET',
       params,
@@ -280,40 +277,34 @@ export const getAuth = () => {
   /**
    * Revoke a single session
    */
-  const postApiAuthRevokeSession = (
-    postApiAuthRevokeSessionBody?: PostApiAuthRevokeSessionBody,
-  ) => {
-    return customAxiosInstance<PostApiAuthRevokeSession200>({
+  const revokeSession = (revokeSessionBody?: RevokeSessionBody) => {
+    return customAxiosInstance<RevokeSession200>({
       url: `/api/auth/revoke-session`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthRevokeSessionBody,
+      data: revokeSessionBody,
     });
   };
   /**
    * Revoke all sessions for the user
    */
-  const postApiAuthRevokeSessions = (
-    postApiAuthRevokeSessionsBody?: PostApiAuthRevokeSessionsBody,
-  ) => {
-    return customAxiosInstance<PostApiAuthRevokeSessions200>({
+  const revokeSessions = (revokeSessionsBody?: RevokeSessionsBody) => {
+    return customAxiosInstance<RevokeSessions200>({
       url: `/api/auth/revoke-sessions`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthRevokeSessionsBody,
+      data: revokeSessionsBody,
     });
   };
   /**
    * Revoke all other sessions for the user except the current one
    */
-  const postApiAuthRevokeOtherSessions = (
-    postApiAuthRevokeOtherSessionsBody?: PostApiAuthRevokeOtherSessionsBody,
-  ) => {
-    return customAxiosInstance<PostApiAuthRevokeOtherSessions200>({
+  const revokeOtherSessions = (revokeOtherSessionsBody?: RevokeOtherSessionsBody) => {
+    return customAxiosInstance<RevokeOtherSessions200>({
       url: `/api/auth/revoke-other-sessions`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthRevokeOtherSessionsBody,
+      data: revokeOtherSessionsBody,
     });
   };
   /**
@@ -339,8 +330,8 @@ export const getAuth = () => {
   /**
    * Callback to complete user deletion with verification token
    */
-  const getApiAuthDeleteUserCallback = (params?: GetApiAuthDeleteUserCallbackParams) => {
-    return customAxiosInstance<GetApiAuthDeleteUserCallback200>({
+  const deleteUserCallback = (params?: DeleteUserCallbackParams) => {
+    return customAxiosInstance<DeleteUserCallback200>({
       url: `/api/auth/delete-user/callback`,
       method: 'GET',
       params,
@@ -349,63 +340,58 @@ export const getAuth = () => {
   /**
    * Unlink an account
    */
-  const postApiAuthUnlinkAccount = (postApiAuthUnlinkAccountBody: PostApiAuthUnlinkAccountBody) => {
-    return customAxiosInstance<PostApiAuthUnlinkAccount200>({
+  const unlinkAccount = (unlinkAccountBody: UnlinkAccountBody) => {
+    return customAxiosInstance<UnlinkAccount200>({
       url: `/api/auth/unlink-account`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthUnlinkAccountBody,
+      data: unlinkAccountBody,
     });
   };
   /**
    * Refresh the access token using a refresh token
    */
-  const postApiAuthRefreshToken = (postApiAuthRefreshTokenBody: PostApiAuthRefreshTokenBody) => {
-    return customAxiosInstance<PostApiAuthRefreshToken200>({
+  const refreshToken = (refreshTokenBody: RefreshTokenBody) => {
+    return customAxiosInstance<RefreshToken200>({
       url: `/api/auth/refresh-token`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthRefreshTokenBody,
+      data: refreshTokenBody,
     });
   };
   /**
    * Get a valid access token, doing a refresh if needed
    */
-  const postApiAuthGetAccessToken = (
-    postApiAuthGetAccessTokenBody: PostApiAuthGetAccessTokenBody,
-  ) => {
-    return customAxiosInstance<PostApiAuthGetAccessToken200>({
+  const getAccessToken = (getAccessTokenBody: GetAccessTokenBody) => {
+    return customAxiosInstance<GetAccessToken200>({
       url: `/api/auth/get-access-token`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      data: postApiAuthGetAccessTokenBody,
+      data: getAccessTokenBody,
     });
   };
   /**
    * Get the account info provided by the provider
    */
-  const getApiAuthAccountInfo = () => {
-    return customAxiosInstance<GetApiAuthAccountInfo200>({
-      url: `/api/auth/account-info`,
-      method: 'GET',
-    });
+  const accountInfo = () => {
+    return customAxiosInstance<AccountInfo200>({ url: `/api/auth/account-info`, method: 'GET' });
   };
   /**
    * Check if the API is working
    */
-  const getApiAuthOk = () => {
-    return customAxiosInstance<GetApiAuthOk200>({ url: `/api/auth/ok`, method: 'GET' });
+  const ok = () => {
+    return customAxiosInstance<Ok200>({ url: `/api/auth/ok`, method: 'GET' });
   };
   /**
    * Displays an error page
    */
-  const getApiAuthError = () => {
+  const error = () => {
     return customAxiosInstance<string>({ url: `/api/auth/error`, method: 'GET' });
   };
   return {
     socialSignIn,
-    getApiAuthCallbackId,
-    postApiAuthCallbackId,
+    callbackId,
+    callbackIdPost,
     getSession,
     getSessionPost,
     signOut,
@@ -413,7 +399,7 @@ export const getAuth = () => {
     signInEmail,
     resetPassword,
     verifyPassword,
-    getApiAuthVerifyEmail,
+    verifyEmail,
     sendVerificationEmail,
     changeEmail,
     changePassword,
@@ -423,28 +409,28 @@ export const getAuth = () => {
     requestPasswordReset,
     resetPasswordCallback,
     listUserSessions,
-    postApiAuthRevokeSession,
-    postApiAuthRevokeSessions,
-    postApiAuthRevokeOtherSessions,
+    revokeSession,
+    revokeSessions,
+    revokeOtherSessions,
     linkSocialAccount,
     listUserAccounts,
-    getApiAuthDeleteUserCallback,
-    postApiAuthUnlinkAccount,
-    postApiAuthRefreshToken,
-    postApiAuthGetAccessToken,
-    getApiAuthAccountInfo,
-    getApiAuthOk,
-    getApiAuthError,
+    deleteUserCallback,
+    unlinkAccount,
+    refreshToken,
+    getAccessToken,
+    accountInfo,
+    ok,
+    error,
   };
 };
 export type SocialSignInResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['socialSignIn']>>
 >;
-export type GetApiAuthCallbackIdResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['getApiAuthCallbackId']>>
+export type CallbackIdResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['callbackId']>>
 >;
-export type PostApiAuthCallbackIdResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthCallbackId']>>
+export type CallbackIdPostResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['callbackIdPost']>>
 >;
 export type GetSessionResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['getSession']>>
@@ -465,8 +451,8 @@ export type ResetPasswordResult = NonNullable<
 export type VerifyPasswordResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['verifyPassword']>>
 >;
-export type GetApiAuthVerifyEmailResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['getApiAuthVerifyEmail']>>
+export type VerifyEmailResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['verifyEmail']>>
 >;
 export type SendVerificationEmailResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['sendVerificationEmail']>>
@@ -495,14 +481,14 @@ export type ResetPasswordCallbackResult = NonNullable<
 export type ListUserSessionsResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['listUserSessions']>>
 >;
-export type PostApiAuthRevokeSessionResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthRevokeSession']>>
+export type RevokeSessionResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['revokeSession']>>
 >;
-export type PostApiAuthRevokeSessionsResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthRevokeSessions']>>
+export type RevokeSessionsResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['revokeSessions']>>
 >;
-export type PostApiAuthRevokeOtherSessionsResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthRevokeOtherSessions']>>
+export type RevokeOtherSessionsResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['revokeOtherSessions']>>
 >;
 export type LinkSocialAccountResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['linkSocialAccount']>>
@@ -510,24 +496,20 @@ export type LinkSocialAccountResult = NonNullable<
 export type ListUserAccountsResult = NonNullable<
   Awaited<ReturnType<ReturnType<typeof getAuth>['listUserAccounts']>>
 >;
-export type GetApiAuthDeleteUserCallbackResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['getApiAuthDeleteUserCallback']>>
+export type DeleteUserCallbackResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['deleteUserCallback']>>
 >;
-export type PostApiAuthUnlinkAccountResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthUnlinkAccount']>>
+export type UnlinkAccountResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['unlinkAccount']>>
 >;
-export type PostApiAuthRefreshTokenResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthRefreshToken']>>
+export type RefreshTokenResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['refreshToken']>>
 >;
-export type PostApiAuthGetAccessTokenResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['postApiAuthGetAccessToken']>>
+export type GetAccessTokenResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['getAccessToken']>>
 >;
-export type GetApiAuthAccountInfoResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['getApiAuthAccountInfo']>>
+export type AccountInfoResult = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getAuth>['accountInfo']>>
 >;
-export type GetApiAuthOkResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['getApiAuthOk']>>
->;
-export type GetApiAuthErrorResult = NonNullable<
-  Awaited<ReturnType<ReturnType<typeof getAuth>['getApiAuthError']>>
->;
+export type OkResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['ok']>>>;
+export type ErrorResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['error']>>>;

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -1,7 +1,7 @@
 // contracts public API — integration event schemas, cross-module DTOs
 // Integration event types will be added here as modules need to communicate
 // across boundaries. Domain event base lives in @nestjs-fastify-nx/core.
-export { PaginationDto, PageMetaDto, PageDto } from './lib/dto/pagination.dto';
+export { PaginationDto } from './lib/dto/pagination.dto';
 export {
   ListResponseDto,
   CursorPaginationDto,
@@ -16,6 +16,8 @@ export {
 export { ERROR_CODES, errorTypeUrl, type ErrorCode } from './lib/errors/error-codes';
 export {
   ApiCommonErrors,
+  buildProblemExample,
   type CommonErrorsOptions,
+  type ProblemExampleInput,
 } from './lib/swagger/api-common-errors.decorator';
 export { ApiPaginatedResponse } from './lib/swagger/api-paginated-response.decorator';

--- a/libs/contracts/src/lib/dto/list-response.dto.ts
+++ b/libs/contracts/src/lib/dto/list-response.dto.ts
@@ -17,10 +17,14 @@ export class ListResponseDto<T = unknown> {
   })
   url!: string;
 
+  // Explicit array schema. Without `type`, a generic `T[]` erases to `Array` at runtime (no swagger
+  // SWC/CLI plugin is configured) and swagger nests it into an array-of-array. `items: {}` keeps the
+  // base envelope's items open (`unknown[]`); ApiPaginatedResponse's allOf refines them per endpoint.
   @ApiProperty({
     description:
       'Items in the current page. Order is endpoint-defined and stable for cursor pagination.',
-    isArray: true,
+    type: 'array',
+    items: {},
   })
   data!: T[];
 
@@ -34,6 +38,9 @@ export class ListResponseDto<T = unknown> {
   @ApiPropertyOptional({
     description:
       'Opaque cursor pointing at the last item in `data` — pass back as `startingAfter` to fetch the next page. Present only on cursor-paginated endpoints; null when the result set is empty. Format is `base64url(sortField.toISOString():id)` — clients MUST treat it as opaque. The cursor encodes ONLY the sort position; it does NOT remember filter parameters (`role`, `status`, `search`, etc.). Changing any filter between page requests is equivalent to a fresh first-page query starting at the encoded position — clients changing filters mid-pagination should drop the cursor and restart.',
+    // Explicit `type: String`: the `string | null` union erases to `Object`, so without this swagger
+    // documents this base64url cursor as an arbitrary object map (breaking `startingAfter` typing).
+    type: String,
     example: 'MjAyNi0wNS0xOVQwMzowNTowMC4wMDBaOjAxOTczMmRiLTYwMTAtN2Y3Zi1iNDY0LTBkMjBjNWUzYThmOQ',
     nullable: true,
   })

--- a/libs/contracts/src/lib/dto/pagination.dto.ts
+++ b/libs/contracts/src/lib/dto/pagination.dto.ts
@@ -1,12 +1,7 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
-import {
-  buildPageMeta,
-  type Page,
-  type PageMeta,
-  type PaginationOptions,
-} from '@nestjs-fastify-nx/shared';
+import { type PaginationOptions } from '@nestjs-fastify-nx/shared';
 
 export class PaginationDto implements PaginationOptions {
   @ApiPropertyOptional({
@@ -36,48 +31,5 @@ export class PaginationDto implements PaginationOptions {
 
   get skip(): number {
     return (this.page - 1) * this.pageSize;
-  }
-}
-
-export class PageMetaDto implements PageMeta {
-  @ApiProperty({ example: 1 })
-  page: number;
-
-  @ApiProperty({ example: 20 })
-  pageSize: number;
-
-  @ApiProperty({ example: 100 })
-  total: number;
-
-  @ApiProperty({ example: 5 })
-  totalPages: number;
-
-  @ApiProperty({ example: true })
-  hasPrevPage: boolean;
-
-  @ApiProperty({ example: false })
-  hasNextPage: boolean;
-
-  constructor(page: number, pageSize: number, total: number) {
-    const meta = buildPageMeta(page, pageSize, total);
-    this.page = meta.page;
-    this.pageSize = meta.pageSize;
-    this.total = meta.total;
-    this.totalPages = meta.totalPages;
-    this.hasPrevPage = meta.hasPrevPage;
-    this.hasNextPage = meta.hasNextPage;
-  }
-}
-
-export class PageDto<T> implements Page<T> {
-  @ApiProperty({ isArray: true })
-  data: T[];
-
-  @ApiProperty({ type: PageMetaDto })
-  meta: PageMetaDto;
-
-  constructor(data: T[], page: number, pageSize: number, total: number) {
-    this.data = data;
-    this.meta = new PageMetaDto(page, pageSize, total);
   }
 }

--- a/libs/contracts/src/lib/errors/problem-details.dto.ts
+++ b/libs/contracts/src/lib/errors/problem-details.dto.ts
@@ -6,7 +6,9 @@ export class ProblemDetailsDto {
     description:
       'A URI reference identifying the problem type. SHOULD resolve to human-readable docs.',
     example: '/errors/not-found',
-    format: 'uri',
+    // uri-reference (not uri): the value is relative when ERROR_DOCS_BASE_URL is unset, matching
+    // `instance`. A strict validator rejects a relative value declared as an absolute `uri`.
+    format: 'uri-reference',
   })
   type!: string;
 
@@ -26,13 +28,15 @@ export class ProblemDetailsDto {
 
   @ApiPropertyOptional({
     description: 'Human-readable explanation specific to this occurrence.',
-    example: 'Cannot GET /admin/queues',
+    example: 'The requested resource does not exist.',
   })
   detail?: string;
 
   @ApiPropertyOptional({
     description: 'URI reference identifying the specific occurrence (typically the request path).',
-    example: '/api/v1/admin/queues',
+    // Neutral placeholder — at runtime this is the actual request path; a real route here would
+    // misread as the failing endpoint under unrelated operations.
+    example: '/api/v1/resource',
     format: 'uri-reference',
   })
   instance?: string;
@@ -40,7 +44,9 @@ export class ProblemDetailsDto {
   @ApiProperty({
     description:
       'Stable, machine-readable error code (snake_case). Use this for client-side i18n keys and logic switching — message text may change without notice.',
-    example: 'route_not_found',
+    // Kept in sync with the `type`/`title`/`status` example above so the schema view renders one
+    // coherent 404 example (not a mix of 404 + route_not_found + 503 checks).
+    example: 'not_found',
   })
   code!: string;
 
@@ -62,7 +68,14 @@ export class ProblemDetailsDto {
     description:
       'Present only on a health-probe 503: the dependencies that reported `down`, so an operator can see which one failed without reading logs.',
     type: 'object',
-    additionalProperties: { type: 'object' },
+    additionalProperties: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'down' },
+        message: { type: 'string' },
+      },
+      required: ['status'],
+    },
     example: { redis_cache: { status: 'down', message: 'redis_cache check failed' } },
   })
   checks?: Record<string, { status: string; message?: string }>;
@@ -110,7 +123,18 @@ export class ValidationErrorItemDto {
   constraint?: Record<string, unknown>;
 
   @ApiPropertyOptional({
-    description: 'Value received from the client. Sensitive fields are redacted.',
+    description:
+      'Value received from the client that failed validation. Free-form: mirrors the offending input, which may be any JSON type (string, number, boolean, object or array). Sensitive fields are redacted.',
+    // `received` is genuinely polymorphic (class-validator's raw `err.value`). Declaring `oneOf`
+    // makes @nestjs/swagger drop the reflected `type: 'object'`, so orval emits a truthful union
+    // instead of mis-typing every offending value as an object map.
+    oneOf: [
+      { type: 'string' },
+      { type: 'number' },
+      { type: 'boolean' },
+      { type: 'object' },
+      { type: 'array', items: {} },
+    ],
     example: 0,
   })
   received?: unknown;

--- a/libs/contracts/src/lib/errors/problem-details.dto.ts
+++ b/libs/contracts/src/lib/errors/problem-details.dto.ts
@@ -127,12 +127,14 @@ export class ValidationErrorItemDto {
       'Value received from the client that failed validation. Free-form: mirrors the offending input, which may be any JSON type (string, number, boolean, object or array). Sensitive fields are redacted.',
     // `received` is genuinely polymorphic (class-validator's raw `err.value`). Declaring `oneOf`
     // makes @nestjs/swagger drop the reflected `type: 'object'`, so orval emits a truthful union
-    // instead of mis-typing every offending value as an object map.
+    // instead of mis-typing every offending value as an object map. The object branch is `nullable`
+    // because a field failing @IsNotEmpty can carry a `null` value — OpenAPI 3.0 admits null only via
+    // a per-branch `nullable`, not a top-level one.
     oneOf: [
       { type: 'string' },
       { type: 'number' },
       { type: 'boolean' },
-      { type: 'object' },
+      { type: 'object', nullable: true },
       { type: 'array', items: {} },
     ],
     example: 0,

--- a/libs/contracts/src/lib/swagger/api-common-errors.decorator.ts
+++ b/libs/contracts/src/lib/swagger/api-common-errors.decorator.ts
@@ -6,12 +6,15 @@ import { errorTypeUrl } from '../errors/error-codes';
 const PROBLEM_JSON = 'application/problem+json';
 
 // Fixed sample values so every documented error renders a self-consistent body. They are illustrative
-// only — `requestId`/`timestamp`/`instance` are populated per request at runtime.
+// only — at runtime `requestId`/`timestamp` are generated per request and `instance` is the actual
+// request path. `instance` is a neutral placeholder (NOT a real route) because this decorator is
+// shared across every controller and can't know the specific path at decoration time; a concrete
+// path like `/api/v1/users/me` would show under unrelated endpoints and misread as their real path.
 const EXAMPLE_REQUEST_ID = '4bf92f3577b34da6a3ce929d0e0e4736';
 const EXAMPLE_TIMESTAMP = '2026-04-30T22:28:27.356Z';
-const EXAMPLE_INSTANCE = '/api/v1/users/me';
+const EXAMPLE_INSTANCE = '/api/v1/resource';
 
-interface ProblemExampleInput {
+export interface ProblemExampleInput {
   status: number;
   code: string;
   title: string;
@@ -22,7 +25,9 @@ interface ProblemExampleInput {
 // Swagger UI would otherwise synthesize one body from the DTO's property-level examples and show the
 // SAME (404-flavoured) payload under every status tab. Attaching an explicit `example` per status is
 // what makes the 401/403/409/… tabs render a body whose `status`/`code`/`title` actually match the tab.
-const problemExample = ({ status, code, title, detail }: ProblemExampleInput) => ({
+// Exported so other spec spots that reuse `$ref: ProblemDetailsDto` (Better Auth 429/500, health 503)
+// attach a status-matched example the same way instead of falling back to the misleading default.
+export const buildProblemExample = ({ status, code, title, detail }: ProblemExampleInput) => ({
   type: errorTypeUrl(code),
   title,
   status,
@@ -39,7 +44,7 @@ const problemResponse = (input: ProblemExampleInput & { description: string }) =
   content: {
     [PROBLEM_JSON]: {
       schema: { $ref: '#/components/schemas/ProblemDetailsDto' },
-      example: problemExample(input),
+      example: buildProblemExample(input),
     },
   },
 });
@@ -51,18 +56,20 @@ const validationResponse = () => ({
     [PROBLEM_JSON]: {
       schema: { $ref: '#/components/schemas/ValidationProblemDetailsDto' },
       example: {
-        ...problemExample({
+        ...buildProblemExample({
           status: HttpStatus.UNPROCESSABLE_ENTITY,
           code: 'validation_failed',
           title: 'Unprocessable Entity',
           detail: 'The request failed validation — see `errors[]`.',
         }),
+        // Field-agnostic sample: this decorator is shared across every endpoint, so a concrete field
+        // like `email`/isEmail would appear (and mislead) on routes that have no such field.
         errors: [
           {
-            path: 'email',
+            path: 'fieldName',
             code: 'invalid',
-            message: 'Must be a valid email address.',
-            rule: 'isEmail',
+            message: 'This field failed validation.',
+            rule: 'isNotEmpty',
           },
         ],
       },


### PR DESCRIPTION
## Mục tiêu

Rà soát lại **toàn bộ setup Swagger/OpenAPI** và dựng lại theo canonical no-CLI-plugin path (repo build bằng swc+webpack, không dùng `@nestjs/swagger` CLI plugin nên mọi `@ApiProperty` phải khai thủ công + chính xác). Nguyên tắc: sai = đập đi xây lại cho chuẩn, không chắp vá — và sửa tận gốc mọi bug spec/codegen phát hiện trong đợt audit.

## Thay đổi

### `apps/api/src/common/swagger/swagger.config.ts`
- **Cookie động** `resolveSessionCookieName()`: `__Secure-better-auth.session_token` khi prod/https, khớp cookie thật ở nút **Authorize** (trước hardcode → sai ở staging https).
- **Merge `securitySchemes`** của Better Auth: op auth tham chiếu `bearerAuth` nhưng định nghĩa scheme không được merge → **dangling ref** làm spec invalid, vỡ validator strict + Authorize. Nay merge đủ.
- **Gán `operationId`** cho op auth còn thiếu → method orval sạch (`signInEmail`, `getSession`, `socialSignIn`…); **xóa security** ở route credential public (không bắt token để đăng nhập).
- **Example đúng status** cho Better Auth 429/500 (trước hiện body 404 mặc định).
- Bỏ `format: uuid` sai trên header `X-Request-Id` (giá trị là trace id 32-hex / `randomBytes(16)`, không có gạch nối).
- Gộp 4 bản `HTTP_METHODS` trùng lặp về một hằng module.

### Contracts DTOs (đã verify trong SDK regenerate)
| Field | Trước | Sau |
|---|---|---|
| `ListResponseDto.data` | `unknown[][]` | `unknown[]` |
| `lastCursor` | object map | `string \| null` |
| `ProblemDetailsDto.checks` | `{[k]: unknown}` | `{ status: string; message? }` |
| `ValidationErrorItemDto.received` | object map | union any-JSON (`oneOf`) |
| `type` format | `uri` | `uri-reference` |
| example `code/detail/instance` | lẫn 404 + route_not_found + queues | coherent, route-agnostic |
- `health` 503: example đúng status kèm `checks` extension.

### Dọn code vẽ lại bánh xe
- Gỡ `PageDto` + `PageMetaDto` — envelope `{ data, meta }` mà API contract **cấm** (Stripe-style), dead code, dính đúng bug `isArray`+generic. Giữ `PaginationDto` (offset query hợp lệ).

### Codegen
- Regenerate `libs/api-client` từ spec mới — `getAuth()` factory với method names chuẩn, các union/type đã đúng.

## Kiểm chứng
- `pnpm nx affected -t typecheck lint test build --base=origin/main`: ✅
- `pnpm nx run api:e2e` (Testcontainers): ✅ **60/60** (gồm `api-client-contract` so SDK với spec live)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation with concrete examples for service-unavailable and authentication error responses.
  * Updated problem details schemas to better describe error checks, validation values, and URI references.
  * Corrected authentication cookie and request ID documentation to reflect runtime behavior.
  * Improved pagination and cursor representations in generated API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->