### PR TITLE
fix: preserve buffered headers across better-auth hijack and audit hardening

### DIFF
--- a/apps/api/e2e/auth.e2e-spec.ts
+++ b/apps/api/e2e/auth.e2e-spec.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
-import { createTestApp, cookieHeaderFromSetCookies, type TestAppContext } from './test-app';
+import {
+  createTestApp,
+  cookieHeaderFromSetCookies,
+  E2E_CORS_ORIGIN,
+  type TestAppContext,
+} from './test-app';
 
 // Better Auth mounts its own routes under /api/auth/*. They live OUTSIDE the
 // /api/v1 prefix and are not wrapped by ResponseInterceptor — bodies are the
@@ -183,6 +188,19 @@ describe('Auth E2E (Better Auth)', () => {
 
       // Better Auth returns `null` (or empty object) when no session cookie is present.
       expect(res.body === null || Object.keys(res.body ?? {}).length === 0).toBe(true);
+    });
+
+    // Regression: reply.hijack() drops headers buffered via reply.header() (incl. @fastify/cors's
+    // Access-Control-*). The handler flushes them onto the raw response before hijacking; without
+    // that, credentialed cross-origin auth breaks even though the body is correct.
+    it('preserves CORS headers on the hijacked Better Auth response', async () => {
+      const res = await request(ctx.app.getHttpServer())
+        .get('/api/auth/get-session')
+        .set('Origin', E2E_CORS_ORIGIN)
+        .expect(200);
+
+      expect(res.headers['access-control-allow-origin']).toBe(E2E_CORS_ORIGIN);
+      expect(res.headers['access-control-allow-credentials']).toBe('true');
     });
 
     it('returns the active session when cookie is forwarded', async () => {

--- a/apps/api/e2e/test-app.ts
+++ b/apps/api/e2e/test-app.ts
@@ -16,6 +16,7 @@ import { AppModule } from '../src/app/app.module';
 import { registerIdempotency } from '../src/common/idempotency/register-idempotency';
 import { ProblemDetailsValidationPipe } from '../src/common/pipes';
 import { applyFastifyProblemDetailsHook } from '../src/common/filters/fastify-error-handler';
+import { flushBufferedReplyHeaders } from '../src/common/http/flush-reply-headers';
 import { buildProblemDetails } from '../src/common/filters/problem-details.helper';
 
 // In-process stub — e2e covers controller logic, not the S3 wire format.
@@ -218,11 +219,9 @@ export async function createTestApp(): Promise<TestAppContext> {
     if (req.body !== undefined && (req.raw as unknown as { body?: unknown }).body === undefined) {
       (req.raw as unknown as { body: unknown }).body = req.body;
     }
-    // Mirror main.ts: flush headers buffered by @fastify/cors's onRequest hook onto the raw response
-    // before hijack, otherwise Better Auth's node handler drops them from the reply.
-    for (const [name, value] of Object.entries(reply.getHeaders())) {
-      if (value !== undefined) reply.raw.setHeader(name, value);
-    }
+    // Use the SAME production helper main.ts calls, so the CORS regression test exercises the real
+    // hijack header-flush path — not a divergent copy that could stay green after a prod regression.
+    flushBufferedReplyHeaders(reply);
     reply.hijack();
     await betterAuthHandler(req.raw, reply.raw);
   };

--- a/apps/api/e2e/test-app.ts
+++ b/apps/api/e2e/test-app.ts
@@ -70,6 +70,9 @@ const e2eStorageStub: StoragePort = {
     e2eObjects.get(key)?.body.subarray(0, byteCount) ?? Buffer.alloc(0),
 };
 
+// Allowed cross-origin used to assert CORS headers survive the Better Auth hijack path.
+export const E2E_CORS_ORIGIN = 'http://localhost:5173';
+
 export interface TestAppContext {
   app: NestFastifyApplication;
   cleaner: DatabaseCleaner;
@@ -127,6 +130,12 @@ export async function createTestApp(): Promise<TestAppContext> {
   );
   app.setGlobalPrefix('api', { exclude: ['metrics'] });
   app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+  // Mirror main.ts CORS so the hijacked-auth-response header-preservation invariant is covered e2e.
+  app.enableCors({
+    origin: [E2E_CORS_ORIGIN],
+    credentials: true,
+    exposedHeaders: ['Idempotent-Replayed', 'X-Request-Id', 'X-Correlation-Id'],
+  });
   app.useGlobalPipes(new ProblemDetailsValidationPipe());
 
   // Mirror main.ts: mount Better Auth before init so its routes win against the
@@ -208,6 +217,11 @@ export async function createTestApp(): Promise<TestAppContext> {
   const authRouteHandler = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
     if (req.body !== undefined && (req.raw as unknown as { body?: unknown }).body === undefined) {
       (req.raw as unknown as { body: unknown }).body = req.body;
+    }
+    // Mirror main.ts: flush headers buffered by @fastify/cors's onRequest hook onto the raw response
+    // before hijack, otherwise Better Auth's node handler drops them from the reply.
+    for (const [name, value] of Object.entries(reply.getHeaders())) {
+      if (value !== undefined) reply.raw.setHeader(name, value);
     }
     reply.hijack();
     await betterAuthHandler(req.raw, reply.raw);

--- a/apps/api/src/common/bull-board/create-bull-board-plugin.spec.ts
+++ b/apps/api/src/common/bull-board/create-bull-board-plugin.spec.ts
@@ -275,7 +275,7 @@ describe('recordAuthFailure', () => {
   it('throws when the counter reply is not numeric', async () => {
     const redis = { eval: vi.fn().mockResolvedValue(['nope', 1]) } as unknown as Redis;
     await expect(recordAuthFailure(redis, '10.0.0.1')).rejects.toThrow(
-      /Unexpected auth-failure counter reply/,
+      /Unexpected fixed-window counter reply/,
     );
   });
 

--- a/apps/api/src/common/bull-board/create-bull-board-plugin.ts
+++ b/apps/api/src/common/bull-board/create-bull-board-plugin.ts
@@ -9,6 +9,7 @@ import type { Redis } from 'ioredis';
 import { timingSafeEqual } from 'node:crypto';
 import { ERROR_CODES } from '@nestjs-fastify-nx/contracts';
 import { QUEUE_NAMES } from '../../app/constants/queue.constants';
+import { redisFixedWindowIncr } from '../rate-limit/redis-fixed-window';
 import { resolveRequestId } from '../logging/request-id';
 import {
   buildProblemDetails,
@@ -24,12 +25,6 @@ import { resolveFastifyCode, resolveFastifyStatus } from '../filters/fastify-err
 const BULL_BOARD_AUTH_FAILURE_MAX = 10;
 const BULL_BOARD_AUTH_FAILURE_WINDOW_MS = 60_000;
 const AUTH_FAILURE_KEY_PREFIX = 'bull-board:auth-fail:';
-
-// PEXPIRE only on the first hit so a burst cannot keep pushing the window deadline out.
-const AUTH_FAILURE_SCRIPT = `
-local count = redis.call('incr', KEYS[1])
-if count == 1 then redis.call('pexpire', KEYS[1], ARGV[1]) end
-return {count, redis.call('pttl', KEYS[1])}`;
 
 const logger = new Logger('BullBoard');
 
@@ -132,20 +127,11 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 export async function recordAuthFailure(redis: Redis, ip: string): Promise<AuthFailureState> {
-  const [countRaw, ttlRaw] = (await redis.eval(
-    AUTH_FAILURE_SCRIPT,
-    1,
+  return redisFixedWindowIncr(
+    redis,
     `${AUTH_FAILURE_KEY_PREFIX}${ip}`,
-    String(BULL_BOARD_AUTH_FAILURE_WINDOW_MS),
-  )) as [number | string, number | string];
-
-  const count = Number(countRaw);
-  const ttlMs = Number(ttlRaw);
-  // Surface a malformed reply as a store failure rather than silently granting an unbounded budget.
-  if (!Number.isFinite(count)) {
-    throw new Error(`Unexpected auth-failure counter reply: ${String(countRaw)}`);
-  }
-  return { count, ttlMs: Number.isFinite(ttlMs) ? Math.max(0, ttlMs) : 0 };
+    BULL_BOARD_AUTH_FAILURE_WINDOW_MS,
+  );
 }
 
 // Returned so the caller can `return sendProblem(...)` from an async hook — Fastify treats the

--- a/apps/api/src/common/http/flush-reply-headers.spec.ts
+++ b/apps/api/src/common/http/flush-reply-headers.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FastifyReply } from 'fastify';
+import { flushBufferedReplyHeaders } from './flush-reply-headers';
+
+function makeReply(buffered: Record<string, string | number | string[] | undefined>): {
+  reply: FastifyReply;
+  setHeader: ReturnType<typeof vi.fn>;
+} {
+  const setHeader = vi.fn();
+  const reply = {
+    getHeaders: () => buffered,
+    raw: { setHeader },
+  } as unknown as FastifyReply;
+  return { reply, setHeader };
+}
+
+describe('flushBufferedReplyHeaders', () => {
+  it('copies every buffered header onto reply.raw', () => {
+    const { reply, setHeader } = makeReply({
+      'access-control-allow-origin': 'http://localhost:5173',
+      'access-control-allow-credentials': 'true',
+      'x-request-id': 'abc',
+    });
+
+    flushBufferedReplyHeaders(reply);
+
+    expect(setHeader).toHaveBeenCalledWith('access-control-allow-origin', 'http://localhost:5173');
+    expect(setHeader).toHaveBeenCalledWith('access-control-allow-credentials', 'true');
+    expect(setHeader).toHaveBeenCalledWith('x-request-id', 'abc');
+    expect(setHeader).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips undefined header values', () => {
+    const { reply, setHeader } = makeReply({ 'x-present': 'yes', 'x-absent': undefined });
+
+    flushBufferedReplyHeaders(reply);
+
+    expect(setHeader).toHaveBeenCalledExactlyOnceWith('x-present', 'yes');
+  });
+
+  it('preserves array (multi) header values such as set-cookie', () => {
+    const { reply, setHeader } = makeReply({ 'set-cookie': ['a=1', 'b=2'] });
+
+    flushBufferedReplyHeaders(reply);
+
+    expect(setHeader).toHaveBeenCalledWith('set-cookie', ['a=1', 'b=2']);
+  });
+});

--- a/apps/api/src/common/http/flush-reply-headers.ts
+++ b/apps/api/src/common/http/flush-reply-headers.ts
@@ -1,0 +1,13 @@
+import type { FastifyReply } from 'fastify';
+
+// Call immediately before reply.hijack(). hijack() detaches the reply from Fastify's send pipeline,
+// which is the only thing that flushes headers buffered via reply.header() (e.g. @fastify/cors's
+// Access-Control-* set in its onRequest hook, or x-request-id/x-correlation-id). A downstream raw
+// writer such as Better Auth's node handler only merges its own headers onto reply.raw, so anything
+// still buffered is dropped from the response. Copying them onto the raw response first keeps them;
+// the raw writer's own headers still win because it calls setHeader after this.
+export function flushBufferedReplyHeaders(reply: FastifyReply): void {
+  for (const [name, value] of Object.entries(reply.getHeaders())) {
+    if (value !== undefined) reply.raw.setHeader(name, value);
+  }
+}

--- a/apps/api/src/common/rate-limit/redis-fixed-window.spec.ts
+++ b/apps/api/src/common/rate-limit/redis-fixed-window.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+import { FIXED_WINDOW_INCR_SCRIPT, redisFixedWindowIncr } from './redis-fixed-window';
+
+function makeRedis(evalResult: unknown): Redis {
+  return { eval: vi.fn().mockResolvedValue(evalResult) } as unknown as Redis;
+}
+
+describe('redisFixedWindowIncr', () => {
+  it('passes the fixed-window script, key and window (ms) to EVAL', async () => {
+    const redis = makeRedis([1, 60_000]);
+    await redisFixedWindowIncr(redis, 'k', 60_000);
+    expect(redis.eval).toHaveBeenCalledWith(FIXED_WINDOW_INCR_SCRIPT, 1, 'k', '60000');
+  });
+
+  it('coerces string replies (RESP2 returns integers as strings) to numbers', async () => {
+    const redis = makeRedis(['3', '45000']);
+    await expect(redisFixedWindowIncr(redis, 'k', 60_000)).resolves.toEqual({
+      count: 3,
+      ttlMs: 45_000,
+    });
+  });
+
+  it('clamps a negative TTL (key with no expiry: PTTL === -1) to 0', async () => {
+    const redis = makeRedis([2, -1]);
+    await expect(redisFixedWindowIncr(redis, 'k', 60_000)).resolves.toEqual({ count: 2, ttlMs: 0 });
+  });
+
+  it('throws on a malformed count reply instead of granting an unbounded budget', async () => {
+    const redis = makeRedis(['nope', 1000]);
+    await expect(redisFixedWindowIncr(redis, 'k', 60_000)).rejects.toThrow(
+      /Unexpected fixed-window counter reply/,
+    );
+  });
+});

--- a/apps/api/src/common/rate-limit/redis-fixed-window.ts
+++ b/apps/api/src/common/rate-limit/redis-fixed-window.ts
@@ -1,0 +1,36 @@
+import type { Redis } from 'ioredis';
+
+// Fixed-window counter shared by the credential-stuffing limiter (main.ts) and the Bull Board
+// failed-auth budget. INCR the key, then PEXPIRE only on the FIRST hit so a burst cannot keep
+// pushing the window deadline out; return the post-increment count and the remaining TTL.
+export const FIXED_WINDOW_INCR_SCRIPT = `
+local count = redis.call('incr', KEYS[1])
+if count == 1 then redis.call('pexpire', KEYS[1], ARGV[1]) end
+return {count, redis.call('pttl', KEYS[1])}`;
+
+export interface FixedWindowState {
+  count: number;
+  ttlMs: number;
+}
+
+// Throws on a malformed count reply rather than silently granting an unbounded budget — callers
+// decide whether that store failure should fail open or closed.
+export async function redisFixedWindowIncr(
+  redis: Redis,
+  key: string,
+  windowMs: number,
+): Promise<FixedWindowState> {
+  const [countRaw, ttlRaw] = (await redis.eval(
+    FIXED_WINDOW_INCR_SCRIPT,
+    1,
+    key,
+    String(windowMs),
+  )) as [number | string, number | string];
+
+  const count = Number(countRaw);
+  if (!Number.isFinite(count)) {
+    throw new Error(`Unexpected fixed-window counter reply: ${String(countRaw)}`);
+  }
+  const ttlMs = Number(ttlRaw);
+  return { count, ttlMs: Number.isFinite(ttlMs) ? Math.max(0, ttlMs) : 0 };
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -25,6 +25,7 @@ import { setupSwagger } from './common/swagger/swagger.config';
 import { createBullBoardPlugin } from './common/bull-board/create-bull-board-plugin';
 import { registerIdempotency } from './common/idempotency/register-idempotency';
 import { redisFixedWindowIncr } from './common/rate-limit/redis-fixed-window';
+import { flushBufferedReplyHeaders } from './common/http/flush-reply-headers';
 import { applyFastifyProblemDetailsHook } from './common/filters/fastify-error-handler';
 import { buildProblemDetails } from './common/filters/problem-details.helper';
 import type { EnvConfig } from './config/env.validation';
@@ -394,15 +395,10 @@ async function bootstrap() {
       (req.raw as unknown as { body: unknown }).body = req.body;
     }
 
-    // hijack() detaches from Fastify's send pipeline, which is the only thing that flushes headers
-    // buffered via reply.header(). Better Auth's node handler then writes straight to reply.raw and
-    // only MERGES its own headers on the success path, so anything still buffered is dropped —
-    // notably @fastify/cors's Access-Control-* (set in its onRequest hook), which breaks credentialed
-    // cross-origin auth, plus the x-request-id/x-correlation-id set above. Flush them onto the raw
-    // response first; Better Auth's own headers still win via setHeader after this.
-    for (const [name, value] of Object.entries(reply.getHeaders())) {
-      if (value !== undefined) reply.raw.setHeader(name, value);
-    }
+    // Preserve headers buffered by @fastify/cors (Access-Control-*) and the x-request-id/-correlation
+    // headers above across the hijack — Better Auth writes straight to reply.raw and drops whatever is
+    // still buffered. Shared with the e2e test app so the regression test exercises this exact path.
+    flushBufferedReplyHeaders(reply);
     reply.hijack();
 
     let timedOut = false;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -24,6 +24,7 @@ import { ProblemDetailsValidationPipe } from './common/pipes';
 import { setupSwagger } from './common/swagger/swagger.config';
 import { createBullBoardPlugin } from './common/bull-board/create-bull-board-plugin';
 import { registerIdempotency } from './common/idempotency/register-idempotency';
+import { redisFixedWindowIncr } from './common/rate-limit/redis-fixed-window';
 import { applyFastifyProblemDetailsHook } from './common/filters/fastify-error-handler';
 import { buildProblemDetails } from './common/filters/problem-details.helper';
 import type { EnvConfig } from './config/env.validation';
@@ -41,11 +42,6 @@ const BULL_BOARD_CSP =
   "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; " +
   "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; " +
   "img-src 'self' data: https:; font-src 'self' https: data:; connect-src 'self'";
-
-const AUTH_ACCOUNT_RATE_LIMIT_SCRIPT = `
-local count = redis.call('incr', KEYS[1])
-if count == 1 then redis.call('pexpire', KEYS[1], ARGV[1]) end
-return {count, redis.call('pttl', KEYS[1])}`;
 
 startSentry({ serviceName: 'nestjs-fastify-api', profiling: true });
 
@@ -92,6 +88,8 @@ async function bootstrap() {
     'http://127.0.0.1:4200',
     'http://127.0.0.1:5173',
   ];
+  // Prod defaults to an empty allow-list (deny) rather than reflecting the request origin: with
+  // credentials:true, reflecting arbitrary origins would open credentialed cross-site requests (CSRF).
   app.enableCors({
     origin: corsOrigins.length > 0 ? corsOrigins : isProduction ? [] : DEV_ALLOWED_ORIGINS,
     credentials: true,
@@ -179,6 +177,14 @@ async function bootstrap() {
       onError: (message) => app.get(Logger).warn(message),
     });
   }
+
+  // Normalize parser/plugin failures that surface before Nest's exception filter into RFC 9457
+  // problem+json, WITHOUT installing a second Fastify error handler in the same scope (that would
+  // trigger FSTWRN004 and shadow Nest's). Registered before @fastify/compress — like the idempotency
+  // hook above — so its onSend rewrites the UNcompressed body: after compress it could be handed a
+  // gzipped buffer it cannot JSON.parse, dropping the real code/detail and emitting a plaintext body
+  // under a stale Content-Encoding: gzip header.
+  applyFastifyProblemDetailsHook(fastify);
 
   // Load shedding: on event-loop saturation, reply 503 (problem+json) so a load balancer / k8s
   // drains this instance. Heap/RSS caps are env-specific and left off by default.
@@ -273,10 +279,6 @@ async function bootstrap() {
     },
   });
 
-  // Normalize parser/plugin failures that occur before Nest's exception filter without
-  // installing a second Fastify error handler in the same scope (which triggers FSTWRN004).
-  applyFastifyProblemDetailsHook(fastify);
-
   // A second, account-wide bucket complements the per-IP route bucket. Without both, attackers
   // can spray many accounts from one IP or distribute guesses for one account across many IPs.
   // This bucket keys on the request's email, so it only augments credential paths that carry one
@@ -294,17 +296,14 @@ async function bootstrap() {
 
     try {
       const key = `auth:account:${createHash('sha256').update(email).digest('hex')}`;
-      const [countRaw, ttlRaw] = (await rateLimitRedis.eval(
-        AUTH_ACCOUNT_RATE_LIMIT_SCRIPT,
-        1,
+      const { count, ttlMs } = await redisFixedWindowIncr(
+        rateLimitRedis,
         key,
-        String(authRateLimitWindowMs),
-      )) as [number | string, number | string];
-      const count = Number(countRaw);
-      const ttl = Math.max(0, Number(ttlRaw));
+        authRateLimitWindowMs,
+      );
       if (count <= authRateLimitMax) return;
 
-      const retryAfter = Math.max(1, Math.ceil(ttl / 1000));
+      const retryAfter = Math.max(1, Math.ceil(ttlMs / 1000));
       const requestId = resolveRequestId(req.headers);
       (req.raw as { requestId?: string }).requestId = requestId;
       return reply
@@ -393,6 +392,16 @@ async function bootstrap() {
     // Propagate Fastify's parsed body to req.raw so Better Auth's toNodeHandler can read it.
     if (req.body !== undefined && (req.raw as unknown as { body?: unknown }).body === undefined) {
       (req.raw as unknown as { body: unknown }).body = req.body;
+    }
+
+    // hijack() detaches from Fastify's send pipeline, which is the only thing that flushes headers
+    // buffered via reply.header(). Better Auth's node handler then writes straight to reply.raw and
+    // only MERGES its own headers on the success path, so anything still buffered is dropped —
+    // notably @fastify/cors's Access-Control-* (set in its onRequest hook), which breaks credentialed
+    // cross-origin auth, plus the x-request-id/x-correlation-id set above. Flush them onto the raw
+    // response first; Better Auth's own headers still win via setHeader after this.
+    for (const [name, value] of Object.entries(reply.getHeaders())) {
+      if (value !== undefined) reply.raw.setHeader(name, value);
     }
     reply.hijack();
 
@@ -490,7 +499,6 @@ async function bootstrap() {
     );
   }
 
-  // Never reflect arbitrary origins with credentials:true — prevents CSRF via cross-site authenticated requests.
   app.useGlobalPipes(new ProblemDetailsValidationPipe());
 
   if (!isProduction) {

--- a/apps/worker/src/app/processors/upload-verification.processor.ts
+++ b/apps/worker/src/app/processors/upload-verification.processor.ts
@@ -56,10 +56,19 @@ export class UploadVerificationProcessor extends WorkerHost {
       return;
     }
 
-    await this.prisma.db.storedFile.updateMany({
+    const result = await this.prisma.db.storedFile.updateMany({
       where: { key, status: STORED_FILE_STATUS.VERIFYING },
       data: { status: STORED_FILE_STATUS.READY, verifiedAt: new Date(), failureReason: null },
     });
+    if (result.count === 0) {
+      // Mirror reject()'s CAS guard: a duplicate/retried job — or a row already flipped or purged —
+      // is a safe no-op. Log it as skipped rather than reporting a READY flip that never happened.
+      this.logger.warn(
+        { key, declaredContentType, correlationId },
+        'verify-magic-bytes: ready-flip skipped — record not in VERIFYING state (already processed)',
+      );
+      return;
+    }
 
     this.logger.log(
       { key, declaredContentType, correlationId },

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -144,8 +144,8 @@ services:
       redis-queue:
         condition: service_healthy
     restart: unless-stopped
-    # Liveness probe — process is alive. Use /health/ready for K8s readiness;
-    # /health (full) for ops dashboards. Docker should only kill on liveness fail.
+    # Liveness probe — process is alive. Use /api/v1/health/ready for K8s readiness;
+    # /api/v1/health (full) for ops dashboards. Docker should only kill on liveness fail.
     healthcheck:
       test:
         [

--- a/libs/infra/auth/src/lib/roles.guard.ts
+++ b/libs/infra/auth/src/lib/roles.guard.ts
@@ -14,7 +14,10 @@ export class RolesGuard implements CanActivate {
   constructor(private readonly reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    // WS messages are handled at the socket.io layer, not by this HTTP/GraphQL guard.
+    // WS messages are handled at the socket.io layer, not by this HTTP/GraphQL guard. NOTE: WS auth
+    // (createWsAuthMiddleware) only checks session validity + status, NOT role — there is no WS role
+    // primitive today. A @Roles() on a @SubscribeMessage handler would silently no-op here, so add
+    // an explicit role check in the ws middleware before relying on @Roles for a socket event.
     if (context.getType() === 'ws') return true;
 
     // Mirror BetterAuthGuard: a @Public route never populates request.user, so RolesGuard must not

--- a/libs/shared/src/lib/pagination.types.ts
+++ b/libs/shared/src/lib/pagination.types.ts
@@ -18,7 +18,9 @@ export interface Page<T> {
 }
 
 export function buildPageMeta(page: number, pageSize: number, total: number): PageMeta {
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  // Clamp the divisor, not just the result: a pageSize of 0 would make total/pageSize === Infinity,
+  // which Math.max(1, …) cannot rescue and leaves hasNextPage stuck true (mirrors toListResponse).
+  const totalPages = Math.max(1, Math.ceil(total / Math.max(1, pageSize)));
   return {
     page,
     pageSize,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   http-proxy-middleware: ^3.0.6
   '@opentelemetry/core': '>=2.8.0'
   undici: '>=8.5.0'
+  valibot: '>=1.4.2 <2'
 
 importers:
 
@@ -9206,8 +9207,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -13292,7 +13293,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(@typescript/typescript6@6.0.2)
+      valibot: 1.4.2(@typescript/typescript6@6.0.2)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -19231,7 +19232,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.2.0(@typescript/typescript6@6.0.2):
+  valibot@1.4.2(@typescript/typescript6@6.0.2):
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   '@opentelemetry/core': '>=2.8.0'
   undici: '>=8.5.0'
   valibot: '>=1.4.2 <2'
+  '@fastify/static': '>=10.1.2 <11'
 
 importers:
 
@@ -99,7 +100,7 @@ importers:
         version: 13.4.2(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/graphql@13.4.2(@fastify/websocket@11.3.0)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.14.2)(reflect-metadata@0.2.2))(fastify@5.10.0)(graphql@16.14.2)(mercurius@16.10.0(graphql@16.14.2))
       '@nestjs/platform-fastify':
         specifier: ^11.1.28
-        version: 11.1.28(@fastify/static@9.3.0)(@fastify/view@11.1.1)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+        version: 11.1.28(@fastify/static@10.1.2)(@fastify/view@11.1.1)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
       '@nestjs/platform-socket.io':
         specifier: ^11.1.28
         version: 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.28)(rxjs@7.8.2)
@@ -108,7 +109,7 @@ importers:
         version: 6.1.3(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
       '@nestjs/swagger':
         specifier: ^11.4.6
-        version: 11.4.6(@fastify/static@9.3.0)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+        version: 11.4.6(@fastify/static@10.1.2)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@nestjs/terminus':
         specifier: ^11.1.1
         version: 11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@prisma/client@7.9.0(@typescript/typescript6@6.0.2)(prisma@7.9.0(@types/react@19.2.17)(@typescript/typescript6@6.0.2)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)))(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -1864,9 +1865,6 @@ packages:
   '@fastify/static@10.1.2':
     resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
-  '@fastify/static@9.3.0':
-    resolution: {integrity: sha512-9YMYRpCOtMBrqKYWcqiw7ykOrn4D0jogHpJrFS0KGeSuOwzKMM5/mjj7B0CFLVoQ6htqKYw//Zs7APn9DBq05w==}
-
   '@fastify/under-pressure@9.1.0':
     resolution: {integrity: sha512-RTVuCM78MZiTWUJA+0CkN5AHUnLjmY2PKFEm5mVjjmwE8ev/Mk30GvjHyfBYCu65geAJvXnz5DauGm0Tpyl0LA==}
 
@@ -2268,7 +2266,7 @@ packages:
   '@nestjs/platform-fastify@11.1.28':
     resolution: {integrity: sha512-utUfyxRzZsoFxz1GU3Z0OthHpijB605iqtxwFnk9yKowLrU1t1ZkxMUuad/csemImY6AsuaTpTjCecKbmfl+pQ==}
     peerDependencies:
-      '@fastify/static': ^8.0.0 || ^9.0.0
+      '@fastify/static': '>=10.1.2 <11'
       '@fastify/view': ^10.0.0 || ^11.0.0 || ^12.0.0
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
@@ -2303,7 +2301,7 @@ packages:
   '@nestjs/swagger@11.4.6':
     resolution: {integrity: sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==}
     peerDependencies:
-      '@fastify/static': ^8.0.0 || ^9.0.0 || ^10.0.0
+      '@fastify/static': '>=10.1.2 <11'
       '@nestjs/common': ^11.0.1
       '@nestjs/core': ^11.0.1
       class-transformer: '*'
@@ -10596,7 +10594,7 @@ snapshots:
     dependencies:
       '@bull-board/api': 8.1.2(@bull-board/ui@8.1.2)
       '@bull-board/ui': 8.1.2
-      '@fastify/static': 9.3.0
+      '@fastify/static': 10.1.2
       '@fastify/view': 11.1.1
       ejs: 6.0.1
 
@@ -10990,15 +10988,6 @@ snapshots:
       '@fastify/error': 4.2.0
       '@fastify/send': 4.1.0
       content-disposition: 2.0.1
-      fastify-plugin: 6.0.0
-      fastq: 1.20.1
-      glob: 13.0.6
-
-  '@fastify/static@9.3.0':
-    dependencies:
-      '@fastify/accept-negotiator': 2.0.1
-      '@fastify/send': 4.1.0
-      content-disposition: 1.1.0
       fastify-plugin: 6.0.0
       fastq: 1.20.1
       glob: 13.0.6
@@ -11511,7 +11500,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@nestjs/platform-fastify@11.1.28(@fastify/static@9.3.0)(@fastify/view@11.1.1)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)':
+  '@nestjs/platform-fastify@11.1.28(@fastify/static@10.1.2)(@fastify/view@11.1.1)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)':
     dependencies:
       '@fastify/cors': 11.2.0
       '@fastify/formbody': 8.0.2
@@ -11526,7 +11515,7 @@ snapshots:
       reusify: 1.1.0
       tslib: 2.8.1
     optionalDependencies:
-      '@fastify/static': 9.3.0
+      '@fastify/static': 10.1.2
       '@fastify/view': 11.1.1
 
   '@nestjs/platform-socket.io@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.28)(rxjs@7.8.2)':
@@ -11560,7 +11549,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@11.4.6(@fastify/static@9.3.0)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@11.4.6(@fastify/static@10.1.2)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@nestjs/common': 11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -11572,7 +11561,7 @@ snapshots:
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.32.8
     optionalDependencies:
-      '@fastify/static': 9.3.0
+      '@fastify/static': 10.1.2
       class-transformer: 0.5.1
       class-validator: 0.15.1
 
@@ -15184,7 +15173,8 @@ snapshots:
 
   confusing-browser-globals@1.0.11: {}
 
-  content-disposition@1.1.0: {}
+  content-disposition@1.1.0:
+    optional: true
 
   content-disposition@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,3 +77,7 @@ overrides:
   http-proxy-middleware: '^3.0.6'
   '@opentelemetry/core': '>=2.8.0'
   undici: '>=8.5.0'
+  # GHSA-5qjj-4xww-7phc (moderate). Pulled transitively via prisma/@prisma/dev (and better-auth's
+  # validation stack). Capped below the next major so a 2.x can't slip a peer out from under the
+  # toolchain; 1.4.2 is the latest 1.x and carries the fix.
+  valibot: '>=1.4.2 <2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,3 +81,9 @@ overrides:
   # validation stack). Capped below the next major so a 2.x can't slip a peer out from under the
   # toolchain; 1.4.2 is the latest 1.x and carries the fix.
   valibot: '>=1.4.2 <2'
+  # GHSA-83w8-p2f5-377r (high, 7.5) + GHSA-8pvw-jcv7-9cmj (medium). @nestjs/platform-fastify pins an
+  # exact 9.3.0 and @bull-board/fastify wants ^9.1.3, so a plain update can't reach the fix; both use
+  # it as a regular (non-peer) dependency for static asset serving, whose public API is stable across
+  # 9->10 (v10 only raises the engine floor to Fastify 5, already in use — mercurius already resolves
+  # 10.1.2). Capped below the next major. Also dedupes to a single @fastify/static version.
+  '@fastify/static': '>=10.1.2 <11'


### PR DESCRIPTION
## Summary

System-wide audit pass (five parallel review passes across api/common, auth+bootstrap, messaging/workers, DDD modules, and contracts/shared/core/graphql). Every finding below was **verified against live behavior and library source** before fixing; documented-intentional customizations (idempotency plugin, outbox triggers, hijack body-propagation, offset-pagination scaffolding, etc.) were deliberately left as-is.

## Fixes

### 🔴 P0 — CORS/headers lost across the Better Auth hijack (`apps/api/src/main.ts`)
`reply.hijack()` never flushes headers buffered via Fastify's `reply.header()` API, and Better Auth's node handler (`better-call`) only *merges* its own headers onto `reply.raw` on the success path. Result: `@fastify/cors`'s `Access-Control-*` (set in its `onRequest` hook) were **dropped from every successful `/api/auth/*` response**, breaking credentialed cross-origin auth — a topology this app explicitly supports (`CORS_ORIGINS`, cross-origin session cookies).

**Fix:** flush `reply.getHeaders()` onto `reply.raw` just before `reply.hijack()`.

Verified live (before → after):
- Before: `GET /api/auth/get-session` with `Origin` → **no** `access-control-allow-origin`.
- After: `access-control-allow-origin` + `access-control-allow-credentials` present on both `get-session` and `sign-up`. Added an e2e regression test (`auth.e2e-spec.ts`, mirrored CORS + flush into `test-app.ts`).

### 🟠 Defensive ordering — problem-details hook before `@fastify/compress` (`main.ts`)
`applyFastifyProblemDetailsHook` ran *after* compress. Today harmless (compress skips `application/problem+json`), but a latent landmine: any compressible-content-type error body ≥1KB would be gzipped, then the hook would fail to `JSON.parse` the buffer and emit a plaintext body under a stale `Content-Encoding: gzip`. Moved before compress, matching the documented idempotency-hook convention.

### 🟡 DRY — shared `redisFixedWindowIncr` helper (`apps/api/src/common/rate-limit/`)
The credential-stuffing limiter (`main.ts`) and Bull Board's failed-auth budget shipped **byte-identical** fixed-window Redis Lua + parsing. Extracted one unit-tested helper; both call sites now share it.

### 🟡 Latent bug — `buildPageMeta` divisor clamp (`libs/shared`)
`Math.max(1, Math.ceil(total / pageSize))` clamped the *result*, not the divisor: `pageSize: 0` → `Infinity` → `hasNextPage` stuck `true`. Now clamps the divisor, mirroring the already-hardened `toListResponse`.

### 🟢 Observability — upload-verification success-path no-op log (`apps/worker`)
Success path logged a READY flip even when the CAS `updateMany` matched 0 rows (already processed). Now logs a skipped-no-op warning, mirroring the reject path.

### 🟢 Security floor — `valibot >= 1.4.2 <2` (`pnpm-workspace.yaml`)
GHSA-5qjj-4xww-7phc (moderate), pulled transitively via prisma/better-auth. Capped below the next major per the repo's override convention.

### 🟢 Docs/comments
- `compose.prod.yml` healthcheck comment → `/api/v1/health/*` (was missing the prefix; would mislead k8s probe config).
- Moved a stale CORS/CSRF WHY comment to the `enableCors` block.
- Noted the absent WS role-authorization primitive at `RolesGuard`'s ws-bypass (footgun for future `@Roles()` on `@SubscribeMessage`).

## Verification
- `nx affected -t typecheck lint test build` (against `origin/main`) — green.
- `nx run api:e2e` (Testcontainers) — **61 tests pass** (incl. new CORS regression).
- Full `build-dev.sh` docker rebuild + boot — green; smoke test passes.
- Live functional sweep on the rebuilt stack: health (4 probes), Swagger (`/docs`, `/docs-json`), GraphQL (introspection + auth-gated `me`), full auth flow (sign-up → session → users/me), CORS on hijacked responses, sensitive-field redaction, metrics/Bull Board IP guards, RFC 9457 error shape — all pass.

## Notes
No behavior change to the two-tier rate-limit keying, outbox transactionality, or module boundaries. The audit confirmed those (and cursor pagination, CQRS wiring, ws-auth lease/interval cleanup, env-validation parity) correct and consistent with the documented design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved CORS and credential headers for authentication session responses.
  - Improved authentication throttling with consistent fixed-window rate limits.
  - Prevented uploads from being marked ready when verification state has changed.
  - Corrected pagination metadata when page size is zero or invalid.
  - Updated documented production health-check paths to use the versioned API routes.
- **Tests**
  - Added regression coverage for authentication CORS handling and rate-limit edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->