### PR TITLE
fix(outbox): stop users.logged_out firing on session purge and user cascade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -232,7 +232,17 @@ MAILPIT_HTTP_PORT=8025
 # cloud security group or DOCKER-USER rule, not the host firewall.
 API_BIND_HOST=127.0.0.1
 API_PORT=3000
+# Host port the container's Node inspector (9229) is published on. Publishing the port is
+# not enough on its own — Node only opens the inspector when started with --inspect, which
+# is what NODE_DEBUG_OPTIONS below does. Dev overlay only; never set in production.
 API_DEBUG_PORT=9229
+# Injected as NODE_OPTIONS into the dev api container. Empty = inspector OFF (the default).
+# Set to `--inspect=0.0.0.0:9229` to attach a debugger, or `--inspect-brk=0.0.0.0:9229` to
+# pause before the first line. Bind 0.0.0.0, not the default loopback: a debugger on the
+# host cannot reach a listener bound inside the container's own loopback.
+# WARNING: an open inspector is arbitrary code execution on the process — keep
+# API_DEBUG_PORT bound to 127.0.0.1 and never enable this on a shared host.
+NODE_DEBUG_OPTIONS=
 
 # Admin seed (run once at migration)
 # RUN_SEED gates the seed step inside the migration container — set to `true`

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -57,6 +57,13 @@ services:
       NODE_ENV: development
       LOG_PRETTY: 'false'
       TZ: ${TZ:-UTC}
+      # The image only EXPOSEs 9229 and the port is published above — without this the
+      # inspector is never actually opened, so attaching silently fails. Bind 0.0.0.0, not
+      # the default 127.0.0.1: a debugger on the host cannot reach a listener bound to the
+      # container's loopback. Empty by default so the inspector stays OFF unless asked for
+      # (`NODE_DEBUG_OPTIONS=--inspect=0.0.0.0:9229`, or `--inspect-brk=…` to pause on the
+      # first line). It stays a dev-overlay knob and is absent from the production images.
+      NODE_OPTIONS: ${NODE_DEBUG_OPTIONS:-}
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nestjs_db
       REDIS_CACHE_HOST: redis-cache
       # In-network port. Unpinned it falls through to env_file, where the value is the HOST

--- a/libs/infra/messaging/package.json
+++ b/libs/infra/messaging/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@nestjs-fastify-nx/core": "workspace:*",
     "@nestjs-fastify-nx/infra-database": "workspace:*",
-    "@nestjs-fastify-nx/shared": "workspace:*"
+    "@nestjs-fastify-nx/shared": "workspace:*",
+    "@nestjs-fastify-nx/testing": "workspace:*"
   }
 }

--- a/libs/infra/messaging/src/lib/outbox-triggers.integration.spec.ts
+++ b/libs/infra/messaging/src/lib/outbox-triggers.integration.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import {
+  createTestContainers,
+  DatabaseCleaner,
+  deployTestMigrations,
+} from '@nestjs-fastify-nx/testing';
+import type { TestContainers } from '@nestjs-fastify-nx/testing';
+import { PrismaService } from '@nestjs-fastify-nx/infra-database';
+
+/**
+ * The three Better Auth-driven domain events are emitted by Postgres triggers, not by
+ * application code, so nothing in the TypeScript test suite can cover them — they are only
+ * observable against a real database.
+ *
+ * `users.logged_out` in particular guards a regression that is invisible in normal use and
+ * expensive in production: the trigger originally fired on EVERY session delete, so the
+ * scheduler's nightly expired-session purge (up to SESSION_PURGE_BATCH_SIZE x
+ * SESSION_PURGE_MAX_BATCHES = 200,000 rows) and the ON DELETE CASCADE from a user
+ * hard-delete both fabricated logout events. The relay claims strictly in `createdAt` order,
+ * so that backlog also head-of-line blocks every real event behind it.
+ */
+describe('outbox triggers (integration)', () => {
+  let containers: TestContainers;
+  let prisma: PrismaService;
+  let cleaner: DatabaseCleaner;
+
+  beforeAll(async () => {
+    containers = await createTestContainers();
+    const dbUrl = containers.postgres.getConnectionUri();
+    process.env['DATABASE_URL'] = dbUrl;
+    deployTestMigrations(dbUrl);
+    prisma = new PrismaService();
+    await prisma.onModuleInit();
+    cleaner = new DatabaseCleaner(prisma.db);
+  }, 180_000);
+
+  afterAll(async () => {
+    await prisma?.onModuleDestroy();
+    await containers?.teardown();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await cleaner.truncateAll();
+  });
+
+  async function createUser(email: string): Promise<string> {
+    const rows = await prisma.db.$queryRawUnsafe<{ id: string }[]>(
+      `INSERT INTO users (id, name, email, "emailVerified", role, status, "createdAt", "updatedAt")
+       VALUES (uuidv7(), 'trigger probe', $1, true, 'USER', 'ACTIVE', NOW(), NOW())
+       RETURNING id`,
+      email,
+    );
+    const id = rows[0]?.id;
+    // An INSERT ... RETURNING that yields no row means the trigger fixture itself is broken;
+    // fail here with that explanation rather than letting `undefined` surface as an opaque
+    // Postgres cast error several statements later.
+    if (!id) throw new Error(`INSERT ... RETURNING produced no row for ${email}`);
+    return id;
+  }
+
+  // `expiresIn` is an interval literal: a positive one is a live session, a negative one is
+  // the already-expired garbage the scheduler reaps.
+  async function createSession(userId: string, token: string, expiresIn: string): Promise<void> {
+    await prisma.db.$executeRawUnsafe(
+      `INSERT INTO sessions (id, "expiresAt", token, "createdAt", "updatedAt", "userId")
+       VALUES (uuidv7(), NOW() + $1::interval, $2, NOW(), NOW(), $3::uuid)`,
+      expiresIn,
+      token,
+      userId,
+    );
+  }
+
+  async function countEvents(eventType: string): Promise<number> {
+    const rows = await prisma.db.$queryRawUnsafe<{ count: bigint }[]>(
+      `SELECT COUNT(*) AS count FROM outbox_events WHERE "eventType" = $1`,
+      eventType,
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  async function clearOutbox(): Promise<void> {
+    await prisma.db.$executeRawUnsafe(`DELETE FROM outbox_events`);
+  }
+
+  it('emits users.registered on insert', async () => {
+    await createUser('registered@trigger.test');
+    expect(await countEvents('users.registered')).toBe(1);
+  });
+
+  it('emits users.logged_in when a session is created', async () => {
+    const userId = await createUser('login@trigger.test');
+    await clearOutbox();
+    await createSession(userId, 'login-token', '7 days');
+    expect(await countEvents('users.logged_in')).toBe(1);
+  });
+
+  it('emits users.logged_out when a still-valid session is deleted (a real sign-out)', async () => {
+    const userId = await createUser('signout@trigger.test');
+    await createSession(userId, 'signout-token', '7 days');
+    await clearOutbox();
+
+    await prisma.db.$executeRawUnsafe(`DELETE FROM sessions WHERE token = 'signout-token'`);
+
+    expect(await countEvents('users.logged_out')).toBe(1);
+  });
+
+  it('stays silent when the scheduler purges expired sessions', async () => {
+    const userId = await createUser('purge@trigger.test');
+    for (let i = 0; i < 5; i++) {
+      await createSession(userId, `expired-${i}`, '-30 days');
+    }
+    await clearOutbox();
+
+    // The exact statement SessionCleanupTask issues.
+    await prisma.db.$executeRawUnsafe(
+      `DELETE FROM sessions WHERE id IN (
+         SELECT id FROM sessions WHERE "expiresAt" < NOW() - ($1 || ' days')::interval LIMIT $2
+       )`,
+      '1',
+      1_000,
+    );
+
+    expect(await countEvents('users.logged_out')).toBe(0);
+  });
+
+  it('stays silent when sessions cascade from a user hard-delete', async () => {
+    const userId = await createUser('cascade@trigger.test');
+    // Live sessions — so this is isolated from the expiry predicate above and can only be
+    // filtered by the parent-still-exists check.
+    for (let i = 0; i < 3; i++) {
+      await createSession(userId, `cascade-${i}`, '7 days');
+    }
+    await clearOutbox();
+
+    await prisma.db.$executeRawUnsafe(`DELETE FROM users WHERE id = $1::uuid`, userId);
+
+    expect(await countEvents('users.logged_out')).toBe(0);
+  });
+
+  it('still signs out a live session belonging to a user who has other expired ones', async () => {
+    const userId = await createUser('mixed@trigger.test');
+    await createSession(userId, 'mixed-live', '7 days');
+    await createSession(userId, 'mixed-expired', '-30 days');
+    await clearOutbox();
+
+    await prisma.db.$executeRawUnsafe(
+      `DELETE FROM sessions WHERE token IN ('mixed-live', 'mixed-expired')`,
+    );
+
+    // Exactly one: the live row, not the expired one deleted in the same statement.
+    expect(await countEvents('users.logged_out')).toBe(1);
+  });
+});

--- a/libs/infra/messaging/tsconfig.lib.json
+++ b/libs/infra/messaging/tsconfig.lib.json
@@ -22,13 +22,16 @@
   ],
   "references": [
     {
-      "path": "../../core/tsconfig.lib.json"
+      "path": "../../testing/tsconfig.lib.json"
     },
     {
       "path": "../../shared/tsconfig.lib.json"
     },
     {
       "path": "../database/tsconfig.lib.json"
+    },
+    {
+      "path": "../../core/tsconfig.lib.json"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@nestjs-fastify-nx/shared':
         specifier: workspace:*
         version: link:../../shared
+      '@nestjs-fastify-nx/testing':
+        specifier: workspace:*
+        version: link:../../testing
 
   libs/infra/observability:
     devDependencies:

--- a/prisma/migrations/20260726120000_fix_logged_out_trigger_scope/migration.sql
+++ b/prisma/migrations/20260726120000_fix_logged_out_trigger_scope/migration.sql
@@ -1,0 +1,71 @@
+-- Stop `users.logged_out` from firing on session rows that nobody logged out of.
+--
+-- The trigger was `AFTER DELETE ON sessions FOR EACH ROW` with no predicate, so it
+-- treated EVERY session deletion as a sign-out. Two callers delete sessions without a
+-- user ever signing out:
+--
+--   1. SessionCleanupTask (scheduler, 03:30 UTC) batch-deletes sessions whose
+--      `expiresAt` is already past — Better Auth never reaps them itself. At the
+--      defaults that is SESSION_PURGE_BATCH_SIZE x SESSION_PURGE_MAX_BATCHES =
+--      200,000 rows per run, so one nightly purge could inject 200,000 fabricated
+--      logout events.
+--
+--   2. `ON DELETE CASCADE` from `sessions.userId`. CleanupTask.purgeInactiveUsers
+--      hard-deletes inactive users, cascading into their sessions — emitting logout
+--      events whose `aggregateId` points at a user row that no longer exists.
+--
+-- The blast radius is larger than log noise. The relay claims strictly
+-- `ORDER BY "createdAt", id` at OUTBOX_BATCH_SIZE (50) per OUTBOX_POLL_INTERVAL_MS
+-- (1s), so 200,000 garbage rows are ~66 minutes of head-of-line blocking: a real
+-- `users.registered` created at 03:31 waits behind all of them, and its welcome email
+-- is delayed by the length of the backlog. Every one of those events also reaches
+-- AuditLogListener's `users.*` subscription, writing a matching audit_logs row.
+--
+-- Two discriminators, both verified against the running database:
+--   * `WHEN (OLD."expiresAt" > NOW())` — an already-expired session is garbage being
+--     collected. A user cannot log out of a session that had stopped authenticating
+--     them. A genuine sign-out always deletes a still-valid row.
+--   * `EXISTS (SELECT 1 FROM users ...)` — inside the child's AFTER DELETE trigger the
+--     parent is already gone during a cascade (returns false), while a direct session
+--     delete still sees it (returns true). That separates "user deleted" from
+--     "user signed out".
+
+CREATE OR REPLACE FUNCTION emit_user_logged_out_outbox()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Cascade from a user hard-delete, not a sign-out. Attributing a logout to an
+  -- aggregate that no longer exists produces an event no consumer can act on.
+  IF NOT EXISTS (SELECT 1 FROM "users" WHERE "id" = OLD."userId") THEN
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO "outbox_events" ("id", "eventType", "aggregateId", "payload", "attempts")
+  VALUES (
+    uuidv7(),
+    'users.logged_out',
+    OLD."userId"::text,
+    jsonb_build_object(
+      'schemaVersion', 1,
+      'eventId', uuidv7()::text,
+      'occurredAt', to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+      'payload', jsonb_strip_nulls(jsonb_build_object(
+        'tokenId', OLD."id"::text,
+        'ip', OLD."ipAddress",
+        'userAgent', OLD."userAgent",
+        'sessionExpiresAt', to_char(OLD."expiresAt" AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      ))
+    ),
+    0
+  );
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- The WHEN predicate is on the trigger, not inside the function, so Postgres skips the
+-- function call entirely for expired rows — the nightly purge pays no per-row cost.
+DROP TRIGGER IF EXISTS user_logged_out_outbox ON "sessions";
+CREATE TRIGGER user_logged_out_outbox
+AFTER DELETE ON "sessions"
+FOR EACH ROW
+WHEN (OLD."expiresAt" > NOW())
+EXECUTE FUNCTION emit_user_logged_out_outbox();

--- a/scripts/pg-backup.sh
+++ b/scripts/pg-backup.sh
@@ -38,10 +38,25 @@ case "$cmd" in
     out_file="${out_dir}/${PG_DB}-${stamp}.dump"
     echo "Backing up ${PG_DB} → ${out_file}"
     # -Fc = custom format (compressed, selective restore). Stream to the host file.
-    compose exec -T "$PG_SERVICE" pg_dump -U "$PG_USER" -d "$PG_DB" -Fc > "$out_file"
-    # Fail loud if the dump is empty/truncated rather than leaving a useless file.
+    # `|| rc=$?` instead of a bare call: under `set -e` a failing pg_dump would abort the
+    # script here, leaving the truncated file the redirect already created — the exact
+    # "useless file" the check below exists to prevent.
+    rc=0
+    compose exec -T "$PG_SERVICE" pg_dump -U "$PG_USER" -d "$PG_DB" -Fc > "$out_file" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      echo "ERROR: pg_dump exited ${rc} — backup FAILED" >&2
+      rm -f "$out_file"
+      exit 1
+    fi
     if [ ! -s "$out_file" ]; then
       echo "ERROR: dump is empty — backup FAILED" >&2
+      rm -f "$out_file"
+      exit 1
+    fi
+    # A non-empty file can still be a truncated stream. pg_restore -l parses the custom-format
+    # archive's table of contents, so it fails on a partial dump that the size check accepts.
+    if ! compose exec -T "$PG_SERVICE" pg_restore -l < "$out_file" > /dev/null 2>&1; then
+      echo "ERROR: dump is unreadable by pg_restore — truncated or corrupt. Backup FAILED" >&2
       rm -f "$out_file"
       exit 1
     fi


### PR DESCRIPTION
## Summary

Closes the audit gap I left open in #131. That pass covered ~24k LOC of TypeScript
and explicitly deferred `docker/`, `.github/workflows/`, `scripts/` and the
migration SQL. Deferring them was mine to close, not to leave — this is that work.
It found one significant bug plus two smaller ones.

### 1. `users.logged_out` fired on every session delete, not on sign-out

`user_logged_out_outbox` was `AFTER DELETE ON sessions FOR EACH ROW` with no
predicate, so it treated **any** session row disappearing as a logout. Two callers
delete sessions with nobody signing out:

| Caller | Volume |
|---|---|
| `SessionCleanupTask` — nightly purge of already-expired sessions (Better Auth never reaps them itself) | `SESSION_PURGE_BATCH_SIZE × SESSION_PURGE_MAX_BATCHES` = **200,000 rows/run** at the defaults |
| `ON DELETE CASCADE` from `sessions.userId`, when `CleanupTask.purgeInactiveUsers` hard-deletes a user | every live session of each purged user |

Reproduced before writing any fix — 3 expired sessions purged produced 3 logout
events, and a user hard-delete produced one per cascaded session with an
`aggregateId` pointing at a row that no longer exists.

**This is not just log noise.** The relay claims strictly `ORDER BY "createdAt", id`
at `OUTBOX_BATCH_SIZE` (50) per `OUTBOX_POLL_INTERVAL_MS` (1 s), so a 200,000-row
backlog is **~66 minutes of head-of-line blocking**: a genuine `users.registered`
created at 03:31 waits behind all of it and its welcome email is delayed by the
length of the backlog. Every fabricated event also reaches `AuditLogListener`'s
`users.*` subscription, writing a matching `audit_logs` row.

Two discriminators, both verified against a live database first:

- **`WHEN (OLD."expiresAt" > NOW())`** on the trigger — an already-expired session
  is garbage being collected; nobody can log out of a session that had stopped
  authenticating them. On the *trigger*, not inside the function, so Postgres skips
  the call entirely and the nightly purge pays no per-row cost.
- **`EXISTS (SELECT 1 FROM users …)`** inside the function — during a cascade the
  parent is already gone (`false`), while a direct session delete still sees it
  (`true`). That separates "user deleted" from "user signed out".

> [!WARNING]
> **Contains a migration** — `20260726120000_fix_logged_out_trigger_scope`.
> `CREATE OR REPLACE FUNCTION` + trigger re-create. No table touched, no lock of
> consequence, no backfill. Pre-existing bogus rows are left alone: they are
> already-recorded history, and the operator can prune them with
> `DELETE FROM outbox_events WHERE "eventType" = 'users.logged_out' AND "processedAt" IS NULL`
> if a purge backlog is currently draining.

### 2. Node inspector was published but never opened

`Dockerfile` `EXPOSE 3000 9229` and `compose.dev.yml` published
`${API_DEBUG_PORT:-9229}:9229` — but `CMD` is a plain `node dist/main.js` and
`NODE_OPTIONS` appears nowhere in the repo (grep was empty). The port was mapped
to a listener that never existed, so attaching a debugger silently failed.

Added an opt-in `NODE_DEBUG_OPTIONS` passed through as `NODE_OPTIONS`, **empty by
default** so the inspector stays off unless asked for. Documented in `.env.example`
including why it must bind `0.0.0.0` (a listener on the container's loopback is
unreachable from the host) and the warning that an open inspector is arbitrary code
execution on the process.

### 3. `pg-backup.sh` could leave the partial dump it promised to delete

The script documents "Fail loud if the dump is empty/truncated", but:

- it only tested `-s` (empty), which a **truncated** dump passes; and
- under `set -e` a failing `pg_dump` aborted the script *before* that check ran,
  leaving on disk exactly the partial file the redirect had already created.

Now captures the exit code explicitly, and validates the archive with
`pg_restore -l` — which parses the custom-format table of contents and so rejects a
truncated stream that the size check accepts.

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] refactor — no behavior change
- [ ] perf — performance improvement
- [ ] docs — documentation only
- [ ] test — tests only
- [ ] chore / build / ci — tooling, infra, dependencies

## Affected scope

`prisma/` (**migration**), `libs/infra/messaging` (integration spec + workspace dep),
`docker/compose.dev.yml`, `scripts/pg-backup.sh`, `.env.example`

## Checklist

- [x] Conventional Commits in branch history (`feat:`, `fix:`, `chore:`, …)
- [x] `pnpm nx affected -t lint test build` passes locally
- [x] Updated relevant `.md` files (README, docs/, CHANGELOG)
- [x] No `TODO` / `FIXME` left in production code
- [x] No JWT / refresh-token plumbing reintroduced (auth is Better Auth cookies)
- [x] Module boundaries respected (`scope:modules` does not import another `scope:modules`)
- [x] Added/updated tests where it makes sense

## Screenshots / logs

<details>
<summary><b>The bug, reproduced before the fix</b></summary>

```
-- 3 expired sessions, then the exact DELETE SessionCleanupTask issues
sau khi tạo:   users.logged_in 3 | users.registered 1
sau khi PURGE: users.logged_in 3 | users.logged_out 3 | users.registered 1
                                   ^^^^^^^^^^^^^^^^^^ nobody signed out

-- user hard-delete, 2 live sessions cascading
users.logged_out | 2 | agg=019f9f59   (user row already gone)
```

</details>

<details>
<summary><b>After the fix — all four scenarios</b></summary>

```
1. real sign-out            -> 1 event  (expected 1)
2. purge 50 expired sessions-> 0 events (expected 0)
3. user delete, 5 cascaded  -> 0 events (expected 0)
4. other events unaffected  -> users.logged_in, users.registered
```

Trigger definition in the running stack after the migration container applied it:

```
 user_logged_out_outbox | has WHEN clause = t
```

</details>

<details>
<summary><b>Inspector, before and after</b></summary>

```
default (NODE_DEBUG_OPTIONS unset):
  NODE_OPTIONS=[]                                    inspector closed

NODE_DEBUG_OPTIONS='--inspect=0.0.0.0:9229':
  $ curl http://127.0.0.1:9229/json/version
  { "Browser": "node.js/v24.18.0", "Protocol-Version": "1.1" }
```

Restored to default afterwards and re-verified the port is closed again.

</details>

<details>
<summary><b>Test coverage added</b></summary>

New `outbox-triggers.integration.spec.ts` (real Postgres via Testcontainers) — a
trigger is invisible to the unit suite, so this is the only place the behaviour can
be pinned:

| Test | Asserts |
|---|---|
| `emits users.registered on insert` | baseline, unchanged |
| `emits users.logged_in when a session is created` | baseline, unchanged |
| `emits users.logged_out when a still-valid session is deleted` | real sign-out still works |
| `stays silent when the scheduler purges expired sessions` | regression #1 |
| `stays silent when sessions cascade from a user hard-delete` | regression #2 |
| `still signs out a live session belonging to a user who has other expired ones` | the predicate is per-row, not per-statement |

`libs/infra/messaging` gained a `workspace:*` dev-dependency on
`@nestjs-fastify-nx/testing`; `nx sync` updated the project reference. The spec file
matches `*.spec.ts`, which `eslint.config.mjs` exempts from the boundary rules.

</details>

**Gate:** typecheck + lint + test + build green across 21 projects ·
`infra-messaging` integration 6/6 against real Postgres · `build-dev.sh` rebuilds
and boots the stack with the migration applied by the migration container and the
smoke test passing.

## Reviewer notes

1. The `WHEN` clause is on the **trigger**, deliberately, not an `IF` at the top of
   the function. On the function it would still pay a plpgsql call per purged row —
   200,000 of them — for a result that is always "skip".
2. Existing bogus `users.logged_out` rows are **not** cleaned up by this migration.
   They are recorded history, and a blind `DELETE` would race a relay that may be
   mid-drain. The prune statement is in the migration comment if an operator wants it.
3. `expiresAt > NOW()` is evaluated at delete time, so a session that expires
   *between* a user's last request and their explicit sign-out click emits nothing.
   That is intended: by then the session was no longer authenticating anyone.
