### PR TITLE
fix(docker): make the production stack boot, and generate its environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,9 @@ index.ts           public barrel — re-export only what consumers need
 
 ```bash
 # Bootstrap (after clone)
-cp .env.example .env && pnpm install
+./scripts/gen-env.sh && pnpm install    # writes .env, generates a real BETTER_AUTH_SECRET
 # .env.example documents all required keys; .env is gitignored.
+# Production needs four more per-app files: ./scripts/gen-env.sh --prod (and --check to audit).
 # Run ./scripts/doctor.sh to verify prerequisites + required env vars are set.
 ./scripts/build-dev.sh             # builds + boots full dev stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Welcome. This guide gets you from clone → first PR in under 30 minutes.
 
 ```bash
 # 1. Clone and bootstrap
-cp .env.example .env
+./scripts/gen-env.sh             # creates .env and generates a real BETTER_AUTH_SECRET
 ./scripts/doctor.sh                # ✅ verifies Docker, Node, ports, env vars
 pnpm install
 ./scripts/build-dev.sh             # 🚀 boots full dev stack

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [docs/architecture.md](docs/architecture.md) for the full module map.
 ```bash
 git clone https://github.com/chuanghiduoc/nestjs-fastify-nx.git
 cd nestjs-fastify-nx
-cp .env.example .env
+./scripts/gen-env.sh             # creates .env and generates a real BETTER_AUTH_SECRET
 pnpm install                    # generates Prisma client via postinstall
 
 ./scripts/doctor.sh             # verify prerequisites (Docker, Node, pnpm, ports)

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -112,7 +112,13 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # mc writes its alias config under $HOME before it can talk to the server, and dropping every
+    # capability leaves it unable to create /root/.mc. Point it at the tmpfs instead of handing the
+    # capability back.
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
     environment:
+      MC_CONFIG_DIR: /tmp/.mc
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       STORAGE_BUCKET: ${STORAGE_BUCKET:?STORAGE_BUCKET is required}
@@ -140,6 +146,16 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # clamav's entrypoint creates /run/clamav and drops to the clamav user before starting clamd.
+    # With every capability dropped it cannot, and the container exits 1 with "can't change
+    # ownership of /run/clamav" — which then blocks the worker, since it waits for this to be
+    # healthy. These four are what that setup step needs; clamd itself keeps none of them.
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
     volumes:
       - clamav_signatures:/var/lib/clamav
     healthcheck:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,15 +67,18 @@ docker run --rm \
 
 ## Docker Compose (Production)
 
+Each runtime connects as its own least-privilege Postgres role, so production needs `.env` (compose
+interpolation: role credentials, MinIO root, image refs) plus one mode-0600 file per process
+containing only what that process uses. `gen-env.sh` writes all five with generated secrets and
+the right DSN in each — done by hand it is nine credentials and four DSNs, and compose reports only
+the first missing variable per run.
+
 ```bash
-# Compose interpolation/deploy-only values (DB role passwords + immutable image digests)
-cp .env.example .env
-# Create four mode-0600 runtime files containing only variables used by that process:
-# .env.api, .env.worker, .env.scheduler, .env.migration
-# .env.migration must contain DATABASE_URL for the admin/migration role.
-# .env.api uses API_DB_USER/API_DB_PASSWORD in its DATABASE_URL; .env.worker and
-# .env.scheduler use their corresponding role. Keep STORAGE_* only in api/worker,
-# MAIL_* only in worker, and scheduler-only cron settings in scheduler.
+./scripts/gen-env.sh --prod     # .env + .env.{api,worker,scheduler,migration}
+./scripts/gen-env.sh --check    # list everything still missing, in one pass
+
+# Then replace the placeholders it cannot know: BETTER_AUTH_URL, FRONTEND_BASE_URL,
+# CORS_ORIGINS and MAIL_* must point at your real hosts before this is exposed.
 
 # Start infrastructure + apps
 docker compose --env-file .env -f docker/compose.yml -f docker/compose.prod.yml up -d

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ git clone https://github.com/chuanghiduoc/nestjs-fastify-nx.git
 cd nestjs-fastify-nx
 
 # 2. Copy environment file
-cp .env.example .env
+./scripts/gen-env.sh             # creates .env and generates a real BETTER_AUTH_SECRET
 
 # 3. Start all services (DB + Redis + MinIO + API with hot-reload)
 docker compose --env-file .env -f docker/compose.yml -f docker/compose.dev.yml up

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -101,11 +101,17 @@ export MIGRATION_IMAGE="${PREFIX}/migration:${IMAGE_TAG}"
 # app and uploads SARIF to GitHub Security). Run ./scripts/security/scan-images.sh
 # manually if you need a local pre-push check.
 
+COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-nestjs-fastify-nx}"
+
 if [[ "${NO_UP:-0}" = "1" ]]; then
   echo ""
   sec::ok "Build complete. NO_UP=1 — skipping auto-boot."
+  # The image refs live only in this process, and compose.prod.yml requires them, so the printed
+  # command carries them inline — copying a bare `docker compose up` would fail on the first ${*_IMAGE:?}.
   sec::ok "Bring the stack up manually:"
-  echo "    docker compose --env-file .env -f docker/compose.yml -f docker/compose.prod.yml up -d"
+  echo "    API_IMAGE=${API_IMAGE} WORKER_IMAGE=${WORKER_IMAGE} \\"
+  echo "    SCHEDULER_IMAGE=${SCHEDULER_IMAGE} MIGRATION_IMAGE=${MIGRATION_IMAGE} \\"
+  echo "    docker compose -p ${COMPOSE_PROJECT} --env-file .env -f docker/compose.yml -f docker/compose.prod.yml up -d"
   exit 0
 fi
 
@@ -116,8 +122,6 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 sec::log "Tearing down any previous local stack"
-
-COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-nestjs-fastify-nx}"
 
 # 1. Swarm leftover (swarm-local-test.sh uses SWARM_STACK_NAME, default `app`).
 SWARM_STACK_NAME="${SWARM_STACK_NAME:-app}"
@@ -171,23 +175,6 @@ if [[ $USE_LOCAL_S3 -eq 1 ]] || [[ $USE_LOCAL_SMTP -eq 1 ]]; then
   fi
 else
   sec::log "External S3 + SMTP detected — bundled MinIO / Mailpit skipped"
-fi
-
-# Postgres applies POSTGRES_PASSWORD only when it initialises an empty data directory. A volume
-# left over from an earlier run (the dev stack shares this project name, so it shares this volume)
-# keeps whatever credentials it was created with, and the only symptom is migration retrying P1000
-# until it gives up — a message that points at the credentials rather than at the volume.
-if docker volume inspect "${COMPOSE_PROJECT}_postgres_data" >/dev/null 2>&1; then
-  if ! docker run --rm --network "${COMPOSE_PROJECT}_default" \
-    -e PGPASSWORD="${POSTGRES_ADMIN_PASSWORD:-}" \
-    postgres:18-alpine \
-    psql -h postgres -U "${POSTGRES_ADMIN_USER:-postgres}" -d "${POSTGRES_DB:-nestjs_db}" \
-    -c 'SELECT 1' >/dev/null 2>&1; then
-    sec::warn "An existing ${COMPOSE_PROJECT}_postgres_data volume did not accept the credentials in .env."
-    sec::warn "Postgres ignores POSTGRES_PASSWORD once its data directory exists, so migration will fail with P1000."
-    sec::warn "Either restore the original credentials, or wipe the volume:"
-    sec::warn "    ./scripts/teardown.sh --prod        # removes volumes for this project"
-  fi
 fi
 
 echo ""

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -88,6 +88,15 @@ for svc in api worker scheduler migration; do
   printf '  %-14s %7s MB\n' "$svc" "$size_mb"
 done
 
+# compose.prod.yml pins each service to an immutable ref via ${*_IMAGE:?...} so a real deploy can
+# never boot a floating tag. Those refs are exactly what this script just built, so export them —
+# without this the boot below dies on "MIGRATION_IMAGE is missing a value" no matter how complete
+# the operator's .env is.
+export API_IMAGE="${PREFIX}/api:${IMAGE_TAG}"
+export WORKER_IMAGE="${PREFIX}/worker:${IMAGE_TAG}"
+export SCHEDULER_IMAGE="${PREFIX}/scheduler:${IMAGE_TAG}"
+export MIGRATION_IMAGE="${PREFIX}/migration:${IMAGE_TAG}"
+
 # Image vulnerability scanning is the CI gate's job (release.yml runs Trivy per
 # app and uploads SARIF to GitHub Security). Run ./scripts/security/scan-images.sh
 # manually if you need a local pre-push check.
@@ -164,11 +173,38 @@ else
   sec::log "External S3 + SMTP detected — bundled MinIO / Mailpit skipped"
 fi
 
+# Postgres applies POSTGRES_PASSWORD only when it initialises an empty data directory. A volume
+# left over from an earlier run (the dev stack shares this project name, so it shares this volume)
+# keeps whatever credentials it was created with, and the only symptom is migration retrying P1000
+# until it gives up — a message that points at the credentials rather than at the volume.
+if docker volume inspect "${COMPOSE_PROJECT}_postgres_data" >/dev/null 2>&1; then
+  if ! docker run --rm --network "${COMPOSE_PROJECT}_default" \
+    -e PGPASSWORD="${POSTGRES_ADMIN_PASSWORD:-}" \
+    postgres:18-alpine \
+    psql -h postgres -U "${POSTGRES_ADMIN_USER:-postgres}" -d "${POSTGRES_DB:-nestjs_db}" \
+    -c 'SELECT 1' >/dev/null 2>&1; then
+    sec::warn "An existing ${COMPOSE_PROJECT}_postgres_data volume did not accept the credentials in .env."
+    sec::warn "Postgres ignores POSTGRES_PASSWORD once its data directory exists, so migration will fail with P1000."
+    sec::warn "Either restore the original credentials, or wipe the volume:"
+    sec::warn "    ./scripts/teardown.sh --prod        # removes volumes for this project"
+  fi
+fi
+
 echo ""
 sec::log "Booting prod stack"
 if ! docker compose -p "$COMPOSE_PROJECT" --env-file .env "${COMPOSE_FILES[@]}" \
   up -d --remove-orphans --wait --wait-timeout "${PROD_STARTUP_TIMEOUT_SECONDS:-120}"; then
   sec::err "Production stack did not become healthy"
+  # Postgres applies POSTGRES_PASSWORD only when it initialises an empty data directory. A volume
+  # left from an earlier run — the dev stack shares this project name, so it shares this volume —
+  # keeps the credentials it was created with, and the only symptom is migration retrying P1000.
+  if docker volume inspect "${COMPOSE_PROJECT}_postgres_data" >/dev/null 2>&1; then
+    sec::warn "If the migration logs below show P1000 (authentication failed): the existing"
+    sec::warn "${COMPOSE_PROJECT}_postgres_data volume was initialised with different credentials."
+    sec::warn "Postgres ignores POSTGRES_PASSWORD once its data directory exists. Wipe it with"
+    sec::warn "    ./scripts/teardown.sh --prod"
+    sec::warn "or restore the credentials that volume was created with."
+  fi
   docker compose -p "$COMPOSE_PROJECT" --env-file .env "${COMPOSE_FILES[@]}" ps -a || true
   docker compose -p "$COMPOSE_PROJECT" --env-file .env "${COMPOSE_FILES[@]}" logs \
     --tail=100 api worker scheduler migration minio-init || true

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -111,7 +111,7 @@ if [[ "${NO_UP:-0}" = "1" ]]; then
   sec::ok "Bring the stack up manually:"
   echo "    API_IMAGE=${API_IMAGE} WORKER_IMAGE=${WORKER_IMAGE} \\"
   echo "    SCHEDULER_IMAGE=${SCHEDULER_IMAGE} MIGRATION_IMAGE=${MIGRATION_IMAGE} \\"
-  echo "    docker compose -p ${COMPOSE_PROJECT} --env-file .env -f docker/compose.yml -f docker/compose.prod.yml up -d"
+  echo "    docker compose -p \"${COMPOSE_PROJECT}\" --env-file .env -f docker/compose.yml -f docker/compose.prod.yml up -d"
   exit 0
 fi
 

--- a/scripts/gen-env.sh
+++ b/scripts/gen-env.sh
@@ -66,11 +66,20 @@ set_env_value() {
   fi
 }
 
-# Fills a key only when it is missing or still holds the example's placeholder.
+# Reads a key from .env.example, so a value the operator never changed can be told apart from one
+# they deliberately set.
+example_value() {
+  [[ -f .env.example ]] || return 0
+  sed -nE "s/^${1}=(.*)$/\1/p" .env.example | tail -1
+}
+
+# Fills a key only when it is missing or still holds the example's placeholder. The placeholder case
+# matters most for BETTER_AUTH_SECRET: keeping it would give every clone of this repo the same
+# session-signing key.
 ensure_secret() {
   local key="$1" bytes="${2:-24}" current
   current="$(env_value "$key")"
-  if [[ -n "$current" && $FORCE -eq 0 ]]; then
+  if [[ -n "$current" && "$current" != "$(example_value "$key")" && $FORCE -eq 0 ]]; then
     return 0
   fi
   set_env_value "$key" "$(random_secret "$bytes")"
@@ -113,6 +122,10 @@ if [[ ! -f .env ]]; then
   sec::ok "Created .env from .env.example"
 fi
 
+# .env ends up holding the same real credentials as the per-app files, so it gets the same mode.
+# Skipped under --check, which must not touch anything.
+[[ $CHECK_ONLY -eq 1 ]] || chmod 600 .env 2>/dev/null || true
+
 if [[ $CHECK_ONLY -eq 1 ]]; then
   MISSING=()
   for key in BETTER_AUTH_SECRET POSTGRES_ADMIN_USER POSTGRES_ADMIN_PASSWORD \
@@ -126,9 +139,22 @@ if [[ $CHECK_ONLY -eq 1 ]]; then
     sec::warn "Missing from .env: ${MISSING[*]}"
     sec::log "Run ./scripts/gen-env.sh --prod to fill them in."
   fi
+
+  MISSING_FILES=()
   for f in .env.api .env.worker .env.scheduler .env.migration; do
-    [[ -f "$f" ]] && sec::ok "$f present" || sec::warn "$f missing (needed by compose.prod.yml)"
+    if [[ -f "$f" ]]; then
+      sec::ok "$f present"
+    else
+      sec::warn "$f missing (needed by compose.prod.yml)"
+      MISSING_FILES+=("$f")
+    fi
   done
+
+  # A preflight that always exits 0 cannot gate anything — CI and build-prod.sh rely on the status.
+  if [[ ${#MISSING[@]} -gt 0 || ${#MISSING_FILES[@]} -gt 0 ]]; then
+    sec::err "Environment is incomplete for a production boot."
+    exit 1
+  fi
   exit 0
 fi
 

--- a/scripts/gen-env.sh
+++ b/scripts/gen-env.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Generates the environment files the stack needs, with real secrets.
+#
+# Dev needs one .env and the example's defaults are already usable. Production needs that same .env
+# (compose reads the DB role names, MinIO root credentials and image refs from it) PLUS one file per
+# app, because each runtime connects as its own least-privilege Postgres role. Assembling those by
+# hand means writing nine credentials and four DSNs consistently — and compose reports only the
+# FIRST missing one per run, so getting it wrong costs a boot cycle per mistake.
+#
+# Usage:
+#   ./scripts/gen-env.sh                 # dev: create .env from .env.example if absent
+#   ./scripts/gen-env.sh --prod          # also write .env.{api,worker,scheduler,migration}
+#   ./scripts/gen-env.sh --prod --force  # overwrite files that already exist
+#   ./scripts/gen-env.sh --check         # report what is missing, write nothing
+#
+# Existing values are never overwritten without --force: re-running is safe, and a placeholder that
+# was already replaced with a real secret stays put.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/security/_lib.sh"
+cd "$(sec::repo_root)"
+
+MODE="dev"
+FORCE=0
+CHECK_ONLY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --help | -h)
+      sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --prod) MODE="prod" ;;
+    --force) FORCE=1 ;;
+    --check) CHECK_ONLY=1 ;;
+    *)
+      sec::err "Unknown argument: $arg  (try --help)"
+      exit 1
+      ;;
+  esac
+done
+
+# openssl is not guaranteed on a dev box; node is, because the repo cannot be built without it.
+random_secret() {
+  node -e "process.stdout.write(require('node:crypto').randomBytes(${1:-24}).toString('base64url'))"
+}
+
+# Reads a key from .env, returning empty when absent or commented out.
+env_value() {
+  [[ -f .env ]] || return 0
+  sed -nE "s/^${1}=(.*)$/\1/p" .env | tail -1
+}
+
+# Sets a key in .env: replaces the line when present, appends when not. Values are written verbatim,
+# so anything containing '&' or '\' would corrupt a sed replacement — assignment goes through awk.
+set_env_value() {
+  local key="$1" value="$2"
+  if grep -qE "^${key}=" .env; then
+    awk -v key="$key" -v value="$value" \
+      'BEGIN { FS = "=" } $1 == key { print key "=" value; next } { print }' .env > .env.tmp
+    mv .env.tmp .env
+  else
+    printf '%s=%s\n' "$key" "$value" >> .env
+  fi
+}
+
+# Fills a key only when it is missing or still holds the example's placeholder.
+ensure_secret() {
+  local key="$1" bytes="${2:-24}" current
+  current="$(env_value "$key")"
+  if [[ -n "$current" && $FORCE -eq 0 ]]; then
+    return 0
+  fi
+  set_env_value "$key" "$(random_secret "$bytes")"
+  GENERATED+=("$key")
+}
+
+ensure_value() {
+  local key="$1" value="$2" current
+  current="$(env_value "$key")"
+  if [[ -n "$current" && $FORCE -eq 0 ]]; then
+    return 0
+  fi
+  set_env_value "$key" "$value"
+  GENERATED+=("$key")
+}
+
+write_file() {
+  local path="$1" content="$2"
+  if [[ -f "$path" && $FORCE -eq 0 ]]; then
+    sec::warn "$path exists — left untouched (use --force to regenerate)"
+    return 0
+  fi
+  printf '%s\n' "$content" > "$path"
+  chmod 600 "$path" 2>/dev/null || true
+  WROTE+=("$path")
+}
+
+GENERATED=()
+WROTE=()
+
+# ---------------------------------------------------------------------------
+# .env — used by every mode. Compose interpolates from it; the dev stack reads it directly.
+# ---------------------------------------------------------------------------
+if [[ ! -f .env ]]; then
+  if [[ $CHECK_ONLY -eq 1 ]]; then
+    sec::err ".env is missing — run ./scripts/gen-env.sh to create it"
+    exit 1
+  fi
+  cp .env.example .env
+  sec::ok "Created .env from .env.example"
+fi
+
+if [[ $CHECK_ONLY -eq 1 ]]; then
+  MISSING=()
+  for key in BETTER_AUTH_SECRET POSTGRES_ADMIN_USER POSTGRES_ADMIN_PASSWORD \
+    API_DB_USER API_DB_PASSWORD WORKER_DB_USER WORKER_DB_PASSWORD \
+    SCHEDULER_DB_USER SCHEDULER_DB_PASSWORD MINIO_ROOT_USER MINIO_ROOT_PASSWORD; do
+    [[ -n "$(env_value "$key")" ]] || MISSING+=("$key")
+  done
+  if [[ ${#MISSING[@]} -eq 0 ]]; then
+    sec::ok "All production-required keys are present in .env"
+  else
+    sec::warn "Missing from .env: ${MISSING[*]}"
+    sec::log "Run ./scripts/gen-env.sh --prod to fill them in."
+  fi
+  for f in .env.api .env.worker .env.scheduler .env.migration; do
+    [[ -f "$f" ]] && sec::ok "$f present" || sec::warn "$f missing (needed by compose.prod.yml)"
+  done
+  exit 0
+fi
+
+# A dev secret still has to be a real secret: BETTER_AUTH_SECRET signs session cookies, and the
+# example ships a placeholder that would otherwise be shared by every clone of this repo.
+ensure_secret BETTER_AUTH_SECRET 32
+
+if [[ "$MODE" == "dev" ]]; then
+  sec::ok "Dev environment ready."
+  [[ ${#GENERATED[@]} -gt 0 ]] && sec::log "Generated: ${GENERATED[*]}"
+  sec::log "Next: ./scripts/doctor.sh && ./scripts/build-dev.sh"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Production: role credentials in .env, then one env file per runtime.
+# ---------------------------------------------------------------------------
+POSTGRES_DB_VALUE="$(env_value POSTGRES_DB)"
+POSTGRES_DB_VALUE="${POSTGRES_DB_VALUE:-nestjs_db}"
+ensure_value POSTGRES_DB "$POSTGRES_DB_VALUE"
+
+# db-grants provisions these three roles; each app then connects as exactly one of them.
+ensure_value POSTGRES_ADMIN_USER postgres
+ensure_secret POSTGRES_ADMIN_PASSWORD 24
+ensure_value API_DB_USER api_user
+ensure_secret API_DB_PASSWORD 24
+ensure_value WORKER_DB_USER worker_user
+ensure_secret WORKER_DB_PASSWORD 24
+ensure_value SCHEDULER_DB_USER scheduler_user
+ensure_secret SCHEDULER_DB_PASSWORD 24
+
+ensure_value MINIO_ROOT_USER minio_admin
+ensure_secret MINIO_ROOT_PASSWORD 24
+ensure_value STORAGE_BUCKET uploads
+ensure_secret BULL_BOARD_PASSWORD 18
+ensure_value BULL_BOARD_USER admin
+
+ADMIN_USER="$(env_value POSTGRES_ADMIN_USER)"
+ADMIN_PASSWORD="$(env_value POSTGRES_ADMIN_PASSWORD)"
+DB_NAME="$(env_value POSTGRES_DB)"
+AUTH_SECRET="$(env_value BETTER_AUTH_SECRET)"
+MINIO_USER="$(env_value MINIO_ROOT_USER)"
+MINIO_PASSWORD="$(env_value MINIO_ROOT_PASSWORD)"
+BUCKET="$(env_value STORAGE_BUCKET)"
+BOARD_USER="$(env_value BULL_BOARD_USER)"
+BOARD_PASSWORD="$(env_value BULL_BOARD_PASSWORD)"
+
+# Passwords are generated base64url, so they carry no character the DSN would have to escape.
+dsn_for() {
+  printf 'postgresql://%s:%s@postgres:5432/%s' "$1" "$2" "$DB_NAME"
+}
+
+API_DSN="$(dsn_for "$(env_value API_DB_USER)" "$(env_value API_DB_PASSWORD)")"
+WORKER_DSN="$(dsn_for "$(env_value WORKER_DB_USER)" "$(env_value WORKER_DB_PASSWORD)")"
+SCHEDULER_DSN="$(dsn_for "$(env_value SCHEDULER_DB_USER)" "$(env_value SCHEDULER_DB_PASSWORD)")"
+ADMIN_DSN="$(dsn_for "$ADMIN_USER" "$ADMIN_PASSWORD")"
+
+SHARED_STORAGE="STORAGE_ENDPOINT=http://minio:9000
+STORAGE_ACCESS_KEY=${MINIO_USER}
+STORAGE_SECRET_KEY=${MINIO_PASSWORD}
+STORAGE_BUCKET=${BUCKET}
+STORAGE_REGION=us-east-1"
+
+SHARED_MAIL="MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_DEFAULT_EMAIL=noreply@example.com"
+
+write_file .env.api "# Generated by scripts/gen-env.sh — the api connects as its own least-privilege role.
+NODE_ENV=production
+PORT=3000
+DATABASE_URL=${API_DSN}
+BETTER_AUTH_SECRET=${AUTH_SECRET}
+# Both must point at real hosts before this is exposed: BETTER_AUTH_URL is the api origin and
+# FRONTEND_BASE_URL is the SPA that renders the reset/verify/delete pages linked from emails.
+BETTER_AUTH_URL=http://localhost:3000
+FRONTEND_BASE_URL=http://localhost:4200
+CORS_ORIGINS=http://localhost:4200
+# Durable, crash-safe domain events — required in production by env validation.
+EVENT_PUBLISHER_DRIVER=outbox
+${SHARED_STORAGE}
+${SHARED_MAIL}
+BULL_BOARD_USER=${BOARD_USER}
+BULL_BOARD_PASSWORD=${BOARD_PASSWORD}
+# Empty fails closed (no metrics). Widen to your pod CIDR when scraping from outside the host.
+METRICS_ALLOW_CIDRS=127.0.0.1/32"
+
+write_file .env.worker "# Generated by scripts/gen-env.sh — the worker connects as its own least-privilege role.
+NODE_ENV=production
+DATABASE_URL=${WORKER_DSN}
+BETTER_AUTH_SECRET=${AUTH_SECRET}
+FRONTEND_BASE_URL=http://localhost:4200
+${SHARED_STORAGE}
+${SHARED_MAIL}
+# Uploads are scanned before they leave quarantine; env validation requires this in production.
+MALWARE_SCANNER_ENABLED=true
+MALWARE_SCANNER_HOST=malware-scanner
+MALWARE_SCANNER_PORT=3310"
+
+write_file .env.scheduler "# Generated by scripts/gen-env.sh — the scheduler connects as its own least-privilege role.
+NODE_ENV=production
+DATABASE_URL=${SCHEDULER_DSN}
+BETTER_AUTH_SECRET=${AUTH_SECRET}
+EVENT_PUBLISHER_DRIVER=outbox
+${SHARED_STORAGE}
+${SHARED_MAIL}"
+
+write_file .env.migration "# Generated by scripts/gen-env.sh — migrations run as the admin role that owns the schema.
+NODE_ENV=production
+DATABASE_URL=${ADMIN_DSN}
+# DDL is session-scoped, so it must bypass a transaction-mode pooler when one is deployed.
+DATABASE_DIRECT_URL=${ADMIN_DSN}
+RUN_SEED=false"
+
+echo ""
+sec::ok "Production environment ready."
+[[ ${#GENERATED[@]} -gt 0 ]] && sec::log "Generated secrets in .env: ${GENERATED[*]}"
+[[ ${#WROTE[@]} -gt 0 ]] && sec::log "Wrote: ${WROTE[*]}"
+sec::warn "These files contain real credentials and are gitignored — never commit them."
+sec::log "Before exposing this stack, replace BETTER_AUTH_URL / FRONTEND_BASE_URL / CORS_ORIGINS"
+sec::log "and MAIL_* in .env.api and .env.worker with your real hosts."
+sec::log "Next: ./scripts/build-prod.sh"

--- a/tools/scripts/clean-workspace.js
+++ b/tools/scripts/clean-workspace.js
@@ -1,6 +1,6 @@
 const { spawnSync } = require('node:child_process');
 const { existsSync, globSync, rmSync } = require('node:fs');
-const { dirname, isAbsolute, relative, resolve } = require('node:path');
+const { isAbsolute, relative, resolve, sep } = require('node:path');
 
 const workspaceRoot = resolve(__dirname, '../..');
 const nxCli = resolve(workspaceRoot, 'node_modules/nx/bin/nx.js');
@@ -16,8 +16,16 @@ if (existsSync(nxCli)) {
 }
 
 const generatedOutputs = globSync(
-  ['apps/*/out-tsc', 'libs/*/out-tsc', 'libs/*/*/out-tsc', 'tools/*/out-tsc'],
-  { cwd: workspaceRoot },
+  [
+    'apps/*/out-tsc',
+    'libs/*/out-tsc',
+    'libs/*/*/out-tsc',
+    'tools/*/out-tsc',
+    // tsc --build keeps its incremental state next to the config, and a stale one makes a
+    // "clean" build silently skip work that the deleted outputs no longer back.
+    '**/*.tsbuildinfo',
+  ],
+  { cwd: workspaceRoot, exclude: (name) => name === 'node_modules' },
 );
 
 const disposablePaths = [
@@ -27,8 +35,11 @@ const disposablePaths = [
   '.nx/workspace-data',
   '.cache/webpack',
   'node_modules/.vite',
+  'node_modules/.cache',
   ...generatedOutputs,
 ];
+
+const failures = [];
 
 for (const entry of disposablePaths) {
   const target = resolve(workspaceRoot, entry);
@@ -37,16 +48,34 @@ for (const entry of disposablePaths) {
   if (
     fromRoot === '' ||
     fromRoot === '..' ||
-    fromRoot.startsWith(`..${require('node:path').sep}`) ||
+    fromRoot.startsWith(`..${sep}`) ||
     isAbsolute(fromRoot)
   ) {
     throw new Error(`Refusing to remove path outside the workspace: ${target}`);
   }
 
-  rmSync(target, {
-    recursive: true,
-    force: true,
-    maxRetries: 5,
-    retryDelay: 200,
-  });
+  try {
+    rmSync(target, {
+      recursive: true,
+      force: true,
+      // Windows holds a handle briefly after the daemon exits; one second of retries was not
+      // enough and the resulting EPERM aborted the whole loop, leaving later paths untouched.
+      maxRetries: 20,
+      retryDelay: 250,
+    });
+  } catch (error) {
+    // Collect and continue: one locked path must not stop the rest of the clean.
+    failures.push({ path: fromRoot, message: error.message });
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`clean: could not remove ${failure.path} — ${failure.message}`);
+  }
+  console.error(
+    'clean: something still holds these paths open. Close editors/terminals using the workspace ' +
+      '(and any running `nx serve`), then re-run `pnpm clean`.',
+  );
+  process.exit(1);
 }


### PR DESCRIPTION
Ran `build-prod.sh` on a wiped machine (no `node_modules`, no `dist`, no `.nx`, no volumes). It failed four times, each on something different. All four are fixed and the full stack now boots.

## What was broken

**1. The script built images it never told compose about.** It tags `ghcr.io/<ns>/<app>:latest`, but `compose.prod.yml` pins every service to `${*_IMAGE:?...}` and the script never exported those four refs — so the boot died on `MIGRATION_IMAGE is missing a value` regardless of how complete `.env` was.

**2. clamav could not start, so the worker never did.** `cap_drop: ALL` removes what its entrypoint needs to create `/run/clamav`; it exited 1 with `can't change ownership of /run/clamav`. The worker `depends_on` it being healthy, so the worker sat in `Created` forever. Hardening is kept — the five capabilities that setup step actually needs are added back, and clamd itself keeps none of them.

**3. `minio-init` could not write `mc`'s alias config** under the same dropped capabilities. It now writes to tmpfs via `MC_CONFIG_DIR` instead of getting the capability back.

**4. Building the environment by hand was the real barrier.** Each runtime connects as its own least-privilege Postgres role, so production needs `.env` plus four per-app files — nine credentials and four DSNs kept consistent. Compose reports only the **first** missing variable per run, so every mistake costs a boot cycle. That is what made `db-grants` feel unusable.

## `scripts/gen-env.sh`

```bash
./scripts/gen-env.sh              # dev: .env + a real BETTER_AUTH_SECRET
./scripts/gen-env.sh --prod       # + .env.{api,worker,scheduler,migration}, secrets generated
./scripts/gen-env.sh --check      # everything still missing, in one pass
./scripts/gen-env.sh --prod --force
```

Each app file carries the DSN for that app's own role and nothing else. Existing values survive re-runs unless `--force` is passed, so a real secret already in place is never clobbered. Secrets come from `node:crypto` base64url, which also keeps them free of characters a DSN would have to escape.

## Also fixed

`pnpm clean` aborted on the first locked path (`.nx/workspace-data`, held by Nx's daemon on Windows) and silently left everything after it in place. It now reports what it could not remove and continues, and clears `*.tsbuildinfo` too — a stale one makes a "clean" build trust outputs that no longer exist. Worth noting `nx reset` fails the same way on Windows, so this is Nx behaviour rather than a repo bug.

## Verified end to end

From a wiped machine: `pnpm install` (12s) → `doctor.sh` all green → `build-dev.sh` (51s, smoke passed) → `gen-env.sh --prod` → `build-prod.sh`:

```
api            Up (healthy)     db-grants      Exited (0)
worker         Up (healthy)     migration      Exited (0)
scheduler      Up (healthy)     minio-init     Exited (0)
malware-scanner Up (healthy)    postgres/redis/minio/mailpit  Up (healthy)

Production smoke passed (live=200, ready=200, docs hidden=404)
```

Roles provisioned by `db-grants`: `api_user`, `worker_user`, `scheduler_user`. Least-privilege confirmed against the live database:

```sql
has_schema_privilege('scheduler_user','public','CREATE')                      -- f
has_schema_privilege('api_user','public','CREATE')                            -- f
has_function_privilege('scheduler_user','ensure_audit_log_partition(...)')     -- t
```

Semgrep: 0 findings. `actionlint`: unchanged. Full gate green across 21 projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated environment setup with generated secrets and production service-specific configuration files.
  * Added validation and forced-regeneration options for environment configuration.
  * Added production startup checks and clearer database credential mismatch guidance.

* **Documentation**
  * Updated setup and deployment instructions to use the automated environment generator.
  * Documented required production URL, CORS, and mail configuration.

* **Bug Fixes**
  * Improved production container startup compatibility.
  * Enhanced workspace cleanup reliability and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->