### PR TITLE
feat(errors): serve the documentation problem type uris point at

### DIFF
--- a/apps/api/e2e/error-docs.e2e-spec.ts
+++ b/apps/api/e2e/error-docs.e2e-spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { ERROR_CATALOG_ENTRIES, errorTypeSlug } from '@nestjs-fastify-nx/contracts';
+import { createTestApp, type TestAppContext } from './test-app';
+
+// RFC 9457 §3.1.1 expects a problem `type` URI to resolve to human-readable documentation. These
+// specs assert the round trip: the URI an error response advertises is one the api actually serves.
+describe('Error type documentation E2E', () => {
+  let ctx: TestAppContext;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+  }, 60_000);
+
+  afterAll(async () => {
+    await ctx.app.close();
+  });
+
+  it('serves the type URI advertised by a real error response', async () => {
+    const problem = await request(ctx.app.getHttpServer())
+      .get('/api/v1/this-route-does-not-exist')
+      .expect(404);
+
+    const { type } = problem.body as { type: string };
+    expect(type).toMatch(/^\/errors\//);
+
+    const doc = await request(ctx.app.getHttpServer()).get(type).expect(200);
+
+    expect(doc.headers['content-type']).toContain('text/html');
+    expect(doc.text).toContain((problem.body as { code: string }).code);
+  });
+
+  it('documents every catalogued error type', async () => {
+    for (const entry of ERROR_CATALOG_ENTRIES) {
+      const res = await request(ctx.app.getHttpServer())
+        .get(`/errors/${errorTypeSlug(entry.code)}`)
+        .expect(200);
+
+      expect(res.text).toContain(entry.code);
+      expect(res.text).toContain(entry.title);
+    }
+  });
+
+  it('lists all types on the index page', async () => {
+    const res = await request(ctx.app.getHttpServer()).get('/errors').expect(200);
+
+    expect(res.headers['content-type']).toContain('text/html');
+    for (const entry of ERROR_CATALOG_ENTRIES) {
+      expect(res.text).toContain(`/errors/${errorTypeSlug(entry.code)}`);
+    }
+  });
+
+  it('answers an unknown slug with a problem document, not a page', async () => {
+    const res = await request(ctx.app.getHttpServer()).get('/errors/not-a-real-type').expect(404);
+
+    expect(res.headers['content-type']).toContain('application/problem+json');
+  });
+
+  // A plain-object lookup would answer these from the prototype chain and render an empty page.
+  it('does not resolve prototype keys as documentation', async () => {
+    for (const slug of ['__proto__', 'constructor', 'toString']) {
+      await request(ctx.app.getHttpServer()).get(`/errors/${slug}`).expect(404);
+    }
+  });
+
+  it('stays outside the versioned api prefix', async () => {
+    await request(ctx.app.getHttpServer()).get('/api/v1/errors/not-found').expect(404);
+  });
+});

--- a/apps/api/e2e/test-app.ts
+++ b/apps/api/e2e/test-app.ts
@@ -18,6 +18,7 @@ import { registerIdempotency } from '../src/common/idempotency/register-idempote
 import { ProblemDetailsValidationPipe } from '../src/common/pipes';
 import { applyFastifyProblemDetailsHook } from '../src/common/filters/fastify-error-handler';
 import { flushBufferedReplyHeaders } from '../src/common/http/flush-reply-headers';
+import { GLOBAL_PREFIX, GLOBAL_PREFIX_EXCLUDES } from '../src/common/http/global-prefix';
 import { buildProblemDetails } from '../src/common/filters/problem-details.helper';
 
 // In-process stub — e2e covers controller logic, not the S3 wire format.
@@ -131,7 +132,7 @@ export async function createTestApp(): Promise<TestAppContext> {
   const app = moduleRef.createNestApplication<NestFastifyApplication>(
     new FastifyAdapter({ bodyLimit: 64 * 1024 }),
   );
-  app.setGlobalPrefix('api', { exclude: ['metrics'] });
+  app.setGlobalPrefix(GLOBAL_PREFIX, { exclude: [...GLOBAL_PREFIX_EXCLUDES] });
   app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
   // Mirror main.ts CORS so the hijacked-auth-response header-preservation invariant is covered e2e.
   app.enableCors({

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { AdminModule } from '@nestjs-fastify-nx/composition-admin';
 import { AuditLogModule } from '@nestjs-fastify-nx/modules-audit-log';
 import { LoggingModule } from '../common/logging/logging.module';
 import { HealthModule } from '../common/health/health.module';
+import { ErrorDocsModule } from '../common/errors/error-docs.module';
 import { MetricsModule } from '../common/metrics/metrics.module';
 import { ThrottlerModule } from '../common/throttler/throttler.module';
 import { UploadModule } from '@nestjs-fastify-nx/modules-upload';
@@ -37,6 +38,7 @@ import { AppController } from './app.controller';
     ThrottlerModule,
     LoggingModule,
     HealthModule,
+    ErrorDocsModule,
     DatabaseModule,
     RedisQueueModule,
     MessagingModule,

--- a/apps/api/src/common/errors/error-docs.controller.ts
+++ b/apps/api/src/common/errors/error-docs.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, NotFoundException, Param, Res, VERSION_NEUTRAL } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { Public } from '@nestjs-fastify-nx/infra-auth';
+import { findErrorTypeDoc } from '@nestjs-fastify-nx/contracts';
+import type { FastifyReply } from 'fastify';
+import { renderErrorDocPage, renderErrorIndexPage } from './error-docs.page';
+
+const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';
+// The catalog only changes with a deploy, and a client reading it is already handling an error —
+// caching keeps that lookup off the critical path.
+const CACHE_CONTROL = 'public, max-age=3600';
+
+// Serves the human-readable documentation RFC 9457 §3.1.1 expects a `type` URI to resolve to.
+// VERSION_NEUTRAL plus the setGlobalPrefix exclude keep it at `/errors/...`, which is exactly the
+// URI the filter already emits — versioning it would turn every `type` into a dead link.
+@ApiExcludeController()
+@Public()
+@Controller({ path: 'errors', version: VERSION_NEUTRAL })
+export class ErrorDocsController {
+  @Get()
+  index(@Res() reply: FastifyReply): void {
+    reply.header('Content-Type', HTML_CONTENT_TYPE);
+    reply.header('Cache-Control', CACHE_CONTROL);
+    reply.send(renderErrorIndexPage());
+  }
+
+  @Get(':slug')
+  show(@Param('slug') slug: string, @Res() reply: FastifyReply): void {
+    const doc = findErrorTypeDoc(slug);
+    if (!doc) {
+      throw new NotFoundException();
+    }
+
+    reply.header('Content-Type', HTML_CONTENT_TYPE);
+    reply.header('Cache-Control', CACHE_CONTROL);
+    reply.send(renderErrorDocPage(doc));
+  }
+}

--- a/apps/api/src/common/errors/error-docs.module.ts
+++ b/apps/api/src/common/errors/error-docs.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ErrorDocsController } from './error-docs.controller';
+
+@Module({
+  controllers: [ErrorDocsController],
+})
+export class ErrorDocsModule {}

--- a/apps/api/src/common/errors/error-docs.page.ts
+++ b/apps/api/src/common/errors/error-docs.page.ts
@@ -1,0 +1,60 @@
+import {
+  ERROR_CATALOG_ENTRIES,
+  errorTypeSlug,
+  type ErrorTypeDoc,
+} from '@nestjs-fastify-nx/contracts';
+
+// Production CSP allows neither inline <style> nor inline <script>, so these pages are plain
+// semantic HTML. Nothing here interpolates caller-controlled input — an unknown slug is answered
+// with a 404 problem document before any rendering happens.
+const DOC_HEAD = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">`;
+
+function layout(title: string, body: string): string {
+  return `${DOC_HEAD}<title>${title}</title></head>
+<body>
+${body}
+<hr>
+<p><small>Error responses follow <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457</a>
+(<code>application/problem+json</code>). Include the <code>requestId</code> from the response body
+when reporting a problem.</small></p>
+</body>
+</html>`;
+}
+
+export function renderErrorDocPage(doc: ErrorTypeDoc): string {
+  return layout(
+    `${doc.title} — API errors`,
+    `<h1>${doc.title}</h1>
+<dl>
+<dt>Error code</dt><dd><code>${doc.code}</code></dd>
+<dt>HTTP status</dt><dd>${doc.status}</dd>
+</dl>
+<h2>What it means</h2>
+<p>${doc.meaning}</p>
+<h2>How to resolve it</h2>
+<p>${doc.resolution}</p>
+<p><a href="/errors">All error types</a></p>`,
+  );
+}
+
+export function renderErrorIndexPage(): string {
+  const rows = ERROR_CATALOG_ENTRIES.map(
+    (doc) =>
+      `<tr><td>${doc.status}</td><td><a href="/errors/${errorTypeSlug(doc.code)}"><code>${doc.code}</code></a></td><td>${doc.title}</td></tr>`,
+  ).join('\n');
+
+  return layout(
+    'API error types',
+    `<h1>API error types</h1>
+<p>Every error response carries a <code>type</code> URI pointing at one of these pages, and a
+<code>code</code> that is stable across releases — key client-side handling off <code>code</code>.</p>
+<table>
+<thead><tr><th>Status</th><th>Code</th><th>Meaning</th></tr></thead>
+<tbody>
+${rows}
+</tbody>
+</table>`,
+  );
+}

--- a/apps/api/src/common/http/global-prefix.ts
+++ b/apps/api/src/common/http/global-prefix.ts
@@ -1,0 +1,7 @@
+// Shared by main.ts and the e2e harness. Keeping the exclude list in one place is what stops a
+// route from being reachable in production and 404 in tests, or the reverse.
+export const GLOBAL_PREFIX = 'api';
+
+// `metrics` is scraped by Prometheus at a fixed path; `errors/*` is where the RFC 9457 `type` URIs
+// in error bodies already point. Both would break if the prefix were applied.
+export const GLOBAL_PREFIX_EXCLUDES = ['metrics', 'errors', 'errors/:slug'] as const;

--- a/apps/api/src/common/swagger/codegen-app-parity.spec.ts
+++ b/apps/api/src/common/swagger/codegen-app-parity.spec.ts
@@ -11,11 +11,13 @@ import { CodegenAppModule } from './codegen-app.module';
 //   - GraphqlModule       — Mercurius opens its own HTTP listener
 //   - WebsocketModule     — Socket.io adapter would start emitting
 //   - MetricsModule       — only loaded when ENABLE_METRICS=true
+//   - ErrorDocsModule     — serves HTML documentation for problem `type` URIs, not a JSON API surface
 const KNOWN_EXCLUSIONS_FROM_CODEGEN = new Set<string>([
   'SentryModule',
   'GraphqlModule',
   'WebsocketModule',
   'MetricsModule',
+  'ErrorDocsModule',
 ]);
 
 type ModuleRef = { module?: { name: string }; name?: string } | { name: string };

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -31,6 +31,7 @@ import { createBullBoardPlugin } from './common/bull-board/create-bull-board-plu
 import { registerIdempotency } from './common/idempotency/register-idempotency';
 import { redisFixedWindowIncr } from './common/rate-limit/redis-fixed-window';
 import { flushBufferedReplyHeaders } from './common/http/flush-reply-headers';
+import { GLOBAL_PREFIX, GLOBAL_PREFIX_EXCLUDES } from './common/http/global-prefix';
 import { applyFastifyProblemDetailsHook } from './common/filters/fastify-error-handler';
 import { buildProblemDetails } from './common/filters/problem-details.helper';
 import { maskBetterAuthServerResponse } from './common/filters/better-auth-response';
@@ -79,7 +80,7 @@ async function bootstrap() {
   app.useLogger(app.get(Logger));
   app.enableShutdownHooks();
   // URI versioning keeps /api/v1/... compatible with existing clients while opening a clean path for v2 alongside v1.
-  app.setGlobalPrefix('api', { exclude: ['metrics'] });
+  app.setGlobalPrefix(GLOBAL_PREFIX, { exclude: [...GLOBAL_PREFIX_EXCLUDES] });
   app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
 
   const fastify = app.getHttpAdapter().getInstance();

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -154,9 +154,9 @@ safe because command handlers roll back their transaction on error.
 
 ## Error documentation
 
-| Variable              | Default              | Required | Description                                                                                                                                                                                                                                                                                   |
-| --------------------- | -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERROR_DOCS_BASE_URL` | `/errors` (relative) | No       | Base URL used to build the `type` field of RFC 9457 Problem Details responses (`<base>/<code-with-dashes>`). RFC 9457 §3.1 allows relative URIs — leave unset in dev. Set to an absolute URL (e.g. `https://docs.example.com/errors`) in production if you publish error documentation pages. |
+| Variable              | Default              | Required | Description                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERROR_DOCS_BASE_URL` | `/errors` (relative) | No       | Base URL used to build the `type` field of RFC 9457 Problem Details responses (`<base>/<code-with-dashes>`). Left unset, the api serves the documentation itself at `/errors` and `/errors/<slug>`, which is what RFC 9457 §3.1.1 expects the URI to resolve to. Point it at an absolute URL only if you publish those pages elsewhere — the built-in ones stay reachable either way. |
 
 ## Mail (SMTP)
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -75,6 +75,11 @@ Add the constant first, then use it.
 RFC 9457 `application/problem+json`, emitted by `GlobalExceptionFilter`. Nothing else builds an
 error body.
 
+The `type` URI resolves: `GET /errors/<slug>` returns a page explaining what the code means and what
+the client should do, and `GET /errors` lists every type. The pages are generated from
+`ERROR_CATALOG` in `libs/contracts`, and a unit test fails if a value in `ERROR_CODES` has no entry —
+so a new code cannot ship undocumented.
+
 ```json
 {
   "type": "/errors/invalid-cursor",

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -13,7 +13,13 @@ export {
   ValidationProblemDetailsDto,
   ValidationErrorItemDto,
 } from './lib/errors/problem-details.dto';
-export { ERROR_CODES, errorTypeUrl, type ErrorCode } from './lib/errors/error-codes';
+export { ERROR_CODES, errorTypeSlug, errorTypeUrl, type ErrorCode } from './lib/errors/error-codes';
+export {
+  ERROR_CATALOG,
+  ERROR_CATALOG_ENTRIES,
+  findErrorTypeDoc,
+  type ErrorTypeDoc,
+} from './lib/errors/error-catalog';
 export { I18N_KEYS, type I18nKey } from './lib/i18n-keys';
 export {
   ApiCommonErrors,

--- a/libs/contracts/src/lib/errors/error-catalog.spec.ts
+++ b/libs/contracts/src/lib/errors/error-catalog.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { ERROR_CODES } from './error-codes';
+import { errorTypeUrl } from './error-codes';
+import { ERROR_CATALOG, ERROR_CATALOG_ENTRIES, findErrorTypeDoc } from './error-catalog';
+
+describe('error catalog', () => {
+  it('documents every error code', () => {
+    const documented = new Set(ERROR_CATALOG_ENTRIES.map((doc) => doc.code));
+    const undocumented = Object.values(ERROR_CODES).filter((code) => !documented.has(code));
+
+    expect(undocumented).toEqual([]);
+  });
+
+  it('documents nothing that is not an error code', () => {
+    const known = new Set<string>(Object.values(ERROR_CODES));
+    const unknown = ERROR_CATALOG_ENTRIES.filter((doc) => !known.has(doc.code));
+
+    expect(unknown).toEqual([]);
+  });
+
+  // The slug is what the served route is keyed by, so a collision would silently hide a page.
+  it('derives a unique slug per code', () => {
+    expect(ERROR_CATALOG.size).toBe(ERROR_CATALOG_ENTRIES.length);
+  });
+
+  it('is reachable through the slug the type URI ends with', () => {
+    for (const doc of ERROR_CATALOG_ENTRIES) {
+      const slug = errorTypeUrl(doc.code).split('/').pop() as string;
+
+      expect(findErrorTypeDoc(slug)).toBe(doc);
+    }
+  });
+
+  it('carries a plausible status for every entry', () => {
+    for (const doc of ERROR_CATALOG_ENTRIES) {
+      expect(doc.status).toBeGreaterThanOrEqual(400);
+      expect(doc.status).toBeLessThan(600);
+      expect(doc.title.length).toBeGreaterThan(0);
+      expect(doc.meaning.length).toBeGreaterThan(0);
+      expect(doc.resolution.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns nothing for an unknown slug', () => {
+    expect(findErrorTypeDoc('nope')).toBeUndefined();
+    expect(findErrorTypeDoc('__proto__')).toBeUndefined();
+  });
+});

--- a/libs/contracts/src/lib/errors/error-catalog.ts
+++ b/libs/contracts/src/lib/errors/error-catalog.ts
@@ -1,0 +1,250 @@
+import { ERROR_CODES, errorTypeSlug, type ErrorCode } from './error-codes';
+
+// RFC 9457 §3.1.1: a problem type URI SHOULD resolve to human-readable documentation. This catalog
+// is that documentation — the api serves it at the same `/errors/<slug>` the `type` member points
+// at, so a client hitting an unfamiliar error can follow the URI instead of guessing.
+export interface ErrorTypeDoc {
+  readonly code: ErrorCode;
+  // The status this code is emitted with. A few codes are reachable from more than one status;
+  // `status` records the canonical one and `meaning` calls out the exception.
+  readonly status: number;
+  readonly title: string;
+  readonly meaning: string;
+  readonly resolution: string;
+}
+
+const DOCS: readonly ErrorTypeDoc[] = [
+  {
+    code: ERROR_CODES.BAD_REQUEST,
+    status: 400,
+    title: 'Bad request',
+    meaning:
+      'The request could not be understood — a header, query string or body failed to parse.',
+    resolution: 'Fix the request syntax. Retrying the same bytes will fail identically.',
+  },
+  {
+    code: ERROR_CODES.UNAUTHORIZED,
+    status: 401,
+    title: 'Unauthorized',
+    meaning:
+      'No valid session. The `better-auth.session_token` cookie is absent, expired or was revoked.',
+    resolution: 'Sign in again via POST /api/auth/sign-in/email, then replay the request.',
+  },
+  {
+    code: ERROR_CODES.FORBIDDEN,
+    status: 403,
+    title: 'Forbidden',
+    meaning: 'The session is valid but lacks the role or ownership the route requires.',
+    resolution: 'Do not retry with the same account. Request access, or act as the owning user.',
+  },
+  {
+    code: ERROR_CODES.NOT_FOUND,
+    status: 404,
+    title: 'Not found',
+    meaning:
+      'The resource does not exist, or the caller is not allowed to learn that it does. Both cases answer identically on purpose — a distinguishable 403 would leak existence.',
+    resolution: 'Check the identifier. Do not infer from a 404 that the resource never existed.',
+  },
+  {
+    code: ERROR_CODES.METHOD_NOT_ALLOWED,
+    status: 405,
+    title: 'Method not allowed',
+    meaning: 'The path exists but not for this HTTP method.',
+    resolution: 'Use a method listed for the route in the OpenAPI spec.',
+  },
+  {
+    code: ERROR_CODES.CONFLICT,
+    status: 409,
+    title: 'Conflict',
+    meaning:
+      'The request collided with current state — a duplicate unique value, a stale version, or work already in flight.',
+    resolution: 'Re-read the resource and decide from its current state before retrying.',
+  },
+  {
+    code: ERROR_CODES.UNPROCESSABLE_ENTITY,
+    status: 422,
+    title: 'Unprocessable entity',
+    meaning: 'The request parsed correctly but broke a rule the server enforces.',
+    resolution: 'Correct the offending field. The same payload will keep failing.',
+  },
+  {
+    code: ERROR_CODES.RATE_LIMITED,
+    status: 429,
+    title: 'Too many requests',
+    meaning: 'A rate-limit bucket for this caller is exhausted.',
+    resolution: 'Wait the number of seconds in the `Retry-After` response header, then retry.',
+  },
+  {
+    code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+    status: 500,
+    title: 'Internal server error',
+    meaning:
+      'An unhandled failure. The response body is deliberately generic in every environment; the cause is recorded server-side against `requestId`.',
+    resolution: 'Retry once. If it persists, report the `requestId` from the response body.',
+  },
+  {
+    code: ERROR_CODES.SERVICE_UNAVAILABLE,
+    status: 503,
+    title: 'Service unavailable',
+    meaning: 'A dependency the request needs (database, cache, queue) is not currently reachable.',
+    resolution: 'Retry with backoff. This condition is expected to be transient.',
+  },
+  {
+    code: ERROR_CODES.REQUEST_TIMEOUT,
+    status: 504,
+    title: 'Request timeout',
+    meaning:
+      'The handler exceeded HTTP_REQUEST_TIMEOUT_MS. Only the client wait was aborted — server-side work may still complete.',
+    resolution:
+      'Retry idempotent requests freely. For mutations, send an `Idempotency-Key` so a retry cannot duplicate the effect.',
+  },
+  {
+    code: ERROR_CODES.NOT_IMPLEMENTED,
+    status: 501,
+    title: 'Not implemented',
+    meaning: 'The route exists but its handler is a scaffold that was never filled in.',
+    resolution: 'Not a client error — the endpoint is unfinished. Do not retry.',
+  },
+  {
+    code: ERROR_CODES.ROUTE_NOT_FOUND,
+    status: 404,
+    title: 'Route not found',
+    meaning: 'No route matches this path. An unmatched method on an existing path also lands here.',
+    resolution: 'Check the path and version prefix (`/api/v1/...`) against the OpenAPI spec.',
+  },
+  {
+    code: ERROR_CODES.VALIDATION_FAILED,
+    status: 422,
+    title: 'Validation failed',
+    meaning:
+      'One or more fields failed validation. The `errors[]` extension lists each one with a `path` and a stable `code`; rejected values are never echoed back.',
+    resolution:
+      'Fix every entry in `errors[]`. Key client-side messages off `code`, not `message`.',
+  },
+  {
+    code: ERROR_CODES.PAYLOAD_TOO_LARGE,
+    status: 413,
+    title: 'Payload too large',
+    meaning:
+      'The body exceeded HTTP_BODY_LIMIT_BYTES, or an upload exceeded UPLOAD_MAX_FILE_BYTES.',
+    resolution: 'Send a smaller body. Large files go through the presign flow, not a direct POST.',
+  },
+  {
+    code: ERROR_CODES.UNSUPPORTED_MEDIA_TYPE,
+    status: 415,
+    title: 'Unsupported media type',
+    meaning: 'The `Content-Type` is not one this route accepts.',
+    resolution: 'Send `application/json` unless the route documents otherwise.',
+  },
+  {
+    code: ERROR_CODES.BUSINESS_RULE_VIOLATION,
+    status: 422,
+    title: 'Business rule violation',
+    meaning: 'A domain rule rejected the request. `errors[]` names the rule that fired.',
+    resolution: 'Change the request so it satisfies the rule. Retrying unchanged cannot succeed.',
+  },
+  {
+    code: ERROR_CODES.IDEMPOTENCY_KEY_INVALID,
+    status: 400,
+    title: 'Invalid idempotency key',
+    meaning: 'The `Idempotency-Key` header is empty, too long, or contains disallowed characters.',
+    resolution: 'Send an opaque key such as a UUID.',
+  },
+  {
+    code: ERROR_CODES.IDEMPOTENCY_KEY_CONFLICT,
+    status: 409,
+    title: 'Idempotency key in flight',
+    meaning: 'A request with this key is still being processed.',
+    resolution: 'Wait and retry with the same key — the stored response is replayed once it lands.',
+  },
+  {
+    code: ERROR_CODES.IDEMPOTENCY_KEY_MISMATCH,
+    status: 422,
+    title: 'Idempotency key reused with a different body',
+    meaning: 'This key was already used for a different payload. Replaying it would be ambiguous.',
+    resolution: 'Use a fresh key for a different request body.',
+  },
+  {
+    code: ERROR_CODES.USER_NOT_FOUND,
+    status: 404,
+    title: 'User not found',
+    meaning: 'No user matches the supplied identifier.',
+    resolution: 'Verify the id. Ids in this API are UUID v7.',
+  },
+  {
+    code: ERROR_CODES.USER_ALREADY_EXISTS,
+    status: 409,
+    title: 'User already exists',
+    meaning: 'The email is already registered.',
+    resolution: 'Sign in instead, or start a password reset.',
+  },
+  {
+    code: ERROR_CODES.INVALID_AUDIT_LOG_ID,
+    status: 400,
+    title: 'Invalid audit log id',
+    meaning: 'The audit log id is not a value the database can accept as a UUID.',
+    resolution: 'Pass an id taken verbatim from a previous list response.',
+  },
+  {
+    code: ERROR_CODES.INVALID_CURSOR,
+    status: 400,
+    title: 'Invalid cursor',
+    meaning:
+      'The `startingAfter` cursor did not decode. Cursors are opaque `base64url(timestamp:id)` values and are not constructible by hand.',
+    resolution: 'Restart pagination without a cursor, then follow the value the API returns.',
+  },
+  {
+    code: ERROR_CODES.UPLOAD_MIME_NOT_ALLOWED,
+    status: 422,
+    title: 'Upload media type not allowed',
+    meaning: 'The declared content type is outside the upload allow-list.',
+    resolution: 'Upload a permitted type. The allow-list is enforced by magic bytes, not by name.',
+  },
+  {
+    code: ERROR_CODES.UPLOAD_SIZE_OUT_OF_RANGE,
+    status: 422,
+    title: 'Upload size out of range',
+    meaning: 'The declared or actual object size is zero, or above UPLOAD_MAX_FILE_BYTES.',
+    resolution: 'Send a non-empty object within the documented limit.',
+  },
+  {
+    code: ERROR_CODES.UPLOAD_MAGIC_BYTES_UNKNOWN,
+    status: 422,
+    title: 'Upload file signature unrecognised',
+    meaning: 'The leading bytes match no known signature, so the real type cannot be established.',
+    resolution: 'Upload an intact file of a supported type.',
+  },
+  {
+    code: ERROR_CODES.UPLOAD_MAGIC_BYTES_MISMATCH,
+    status: 422,
+    title: 'Upload file signature mismatch',
+    meaning: 'The bytes belong to a different type than the one declared at presign time.',
+    resolution: 'Declare the true content type, or upload the file the declaration described.',
+  },
+  {
+    code: ERROR_CODES.UPLOAD_COMMIT_FAILED,
+    status: 409,
+    title: 'Upload commit failed',
+    meaning: 'The object could not be moved out of quarantine into its committed location.',
+    resolution: 'Retry the confirm call. Presign again if it keeps failing.',
+  },
+  {
+    code: ERROR_CODES.UPLOAD_IN_PROGRESS,
+    status: 409,
+    title: 'Upload already in progress',
+    meaning: 'This object is already being verified by the worker.',
+    resolution: 'Wait for verification to settle before confirming again.',
+  },
+];
+
+// A Map, not a plain object: the slug comes straight off the URL, and an object lookup would answer
+// `__proto__`/`constructor` with something truthy from the prototype chain and render a junk page.
+export const ERROR_CATALOG: ReadonlyMap<string, ErrorTypeDoc> = new Map(
+  DOCS.map((doc) => [errorTypeSlug(doc.code), doc]),
+);
+
+export const ERROR_CATALOG_ENTRIES: readonly ErrorTypeDoc[] = DOCS;
+
+export function findErrorTypeDoc(slug: string): ErrorTypeDoc | undefined {
+  return ERROR_CATALOG.get(slug);
+}

--- a/libs/contracts/src/lib/errors/error-codes.ts
+++ b/libs/contracts/src/lib/errors/error-codes.ts
@@ -39,8 +39,13 @@ export const ERROR_CODES = {
 
 export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
 
+// The path segment a `type` URI ends with, and the key the api serves its documentation under.
+export function errorTypeSlug(code: string): string {
+  return code.replace(/_/g, '-');
+}
+
 // RFC 9457 §3.1 type URI. Set ERROR_DOCS_BASE_URL for absolute URIs.
 export function errorTypeUrl(code: string): string {
   const base = process.env['ERROR_DOCS_BASE_URL']?.trim() || '/errors';
-  return `${base.replace(/\/+$/, '')}/${code.replace(/_/g, '-')}`;
+  return `${base.replace(/\/+$/, '')}/${errorTypeSlug(code)}`;
 }


### PR DESCRIPTION
## What

Every error response advertises an RFC 9457 `type` URI (`/errors/<slug>`). None of them resolved — `GET /errors/validation-failed` answered 404. RFC 9457 §3.1.1 says that URI SHOULD point at human-readable documentation, so the api now serves it.

- `GET /errors` — index of every error type
- `GET /errors/<slug>` — what the code means, and what the client should do

## Notes

- The catalog lives in `libs/contracts` next to `ERROR_CODES`, so Swagger examples and the pages share one source. A unit test fails if a code has no entry — a new code cannot ship undocumented.
- Lookup goes through a `Map`: a plain object would resolve `/errors/__proto__` off the prototype chain and render an empty page. Covered by both unit and e2e specs.
- `GLOBAL_PREFIX_EXCLUDES` is now one constant. `main.ts` and the e2e harness held drifted copies, which is why the route 404'd in tests while working in the app.
- Pages are plain semantic HTML — production CSP allows neither inline `<style>` nor inline `<script>`.

## Verified

- `nx affected -t lint test build typecheck` green
- `nx run api:e2e` — 67/67, including a spec that reads the `type` off a real error response and follows it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public HTML documentation for API error types at `/errors` and `/errors/<slug>`.
  * Added an index listing all documented error types, including guidance on meanings, resolutions, and request IDs.
  * Added RFC 9457-compatible error type links and consistent error URL slugs.

* **Documentation**
  * Documented error documentation endpoints and configuration behavior.

* **Bug Fixes**
  * Improved handling of unknown and invalid error-documentation slugs with proper 404 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->