### PR TITLE
fix(storage): make the s3 adapter portable off minio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,12 @@ STORAGE_SECRET_KEY=minioadmin
 STORAGE_BUCKET=uploads
 # Region tag used by the S3 client; MinIO ignores it but real AWS / Cloudflare R2 require a real value.
 STORAGE_REGION=us-east-1
+# Path-style (bucket in the path) is what self-hosted backends serve. Set false for real AWS S3,
+# which documents virtual-hosted-style as the supported form.
+STORAGE_FORCE_PATH_STYLE=true
+# WHEN_SUPPORTED (default) makes the SDK send an x-amz-checksum-crc32 on every upload. Set
+# WHEN_REQUIRED for backends that reject it — older Ceph RGW, Backblaze B2, some S3 gateways.
+STORAGE_CHECKSUM_MODE=WHEN_SUPPORTED
 # Browser upload policy and download URL lifetimes. Keep these short because the
 # URLs are bearer credentials; clients can request a fresh URL when needed.
 UPLOAD_PRESIGN_EXPIRES_SECONDS=300

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -66,6 +66,11 @@ const envSchema = z
     STORAGE_PUBLIC_ENDPOINT: z.string().optional(),
     STORAGE_BUCKET: z.string().default('uploads'),
     STORAGE_REGION: z.string().default('us-east-1'),
+    // Self-hosted backends serve path-style; real AWS S3 documents virtual-hosted-style.
+    STORAGE_FORCE_PATH_STYLE: z.enum(['true', 'false']).default('true'),
+    // WHEN_REQUIRED stops the SDK attaching x-amz-checksum-crc32, which some S3-compatible
+    // backends reject outright.
+    STORAGE_CHECKSUM_MODE: z.enum(['WHEN_SUPPORTED', 'WHEN_REQUIRED']).default('WHEN_SUPPORTED'),
     STORAGE_ACCESS_KEY: z.string().default('minioadmin'),
     STORAGE_SECRET_KEY: z.string().default('minioadmin'),
     STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS: z.coerce

--- a/apps/scheduler/src/config/env.validation.ts
+++ b/apps/scheduler/src/config/env.validation.ts
@@ -32,6 +32,11 @@ const schedulerEnvSchema = z
     STORAGE_PUBLIC_ENDPOINT: z.string().optional(),
     STORAGE_BUCKET: z.string().default('uploads'),
     STORAGE_REGION: z.string().default('us-east-1'),
+    // Self-hosted backends serve path-style; real AWS S3 documents virtual-hosted-style.
+    STORAGE_FORCE_PATH_STYLE: z.enum(['true', 'false']).default('true'),
+    // WHEN_REQUIRED stops the SDK attaching x-amz-checksum-crc32, which some S3-compatible
+    // backends reject outright.
+    STORAGE_CHECKSUM_MODE: z.enum(['WHEN_SUPPORTED', 'WHEN_REQUIRED']).default('WHEN_SUPPORTED'),
     STORAGE_ACCESS_KEY: z.string().default('minioadmin'),
     STORAGE_SECRET_KEY: z.string().default('minioadmin'),
     STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS: z.coerce

--- a/apps/worker/src/config/env.validation.ts
+++ b/apps/worker/src/config/env.validation.ts
@@ -34,6 +34,11 @@ const workerEnvSchema = z
     STORAGE_PUBLIC_ENDPOINT: z.string().optional(),
     STORAGE_BUCKET: z.string().default('uploads'),
     STORAGE_REGION: z.string().default('us-east-1'),
+    // Self-hosted backends serve path-style; real AWS S3 documents virtual-hosted-style.
+    STORAGE_FORCE_PATH_STYLE: z.enum(['true', 'false']).default('true'),
+    // WHEN_REQUIRED stops the SDK attaching x-amz-checksum-crc32, which some S3-compatible
+    // backends reject outright.
+    STORAGE_CHECKSUM_MODE: z.enum(['WHEN_SUPPORTED', 'WHEN_REQUIRED']).default('WHEN_SUPPORTED'),
     STORAGE_ACCESS_KEY: z.string().default('minioadmin'),
     STORAGE_SECRET_KEY: z.string().default('minioadmin'),
     STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS: z.coerce

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -20,7 +20,7 @@ services:
         [ "$$connected" = 1 ] || { echo 'minio-init: cannot reach minio after 30s'; exit 1; };
         mc mb --ignore-existing \"local/$$STORAGE_BUCKET\";
         mc ilm rule remove --all --force \"local/$$STORAGE_BUCKET\" 2>/dev/null || true;
-        mc ilm rule add --expire-days "$$MINIO_ORPHAN_EXPIRY_DAYS" --tags 'committed=false' \"local/$$STORAGE_BUCKET\";
+        mc ilm rule add --expire-days "$$MINIO_ORPHAN_EXPIRY_DAYS" --prefix 'uploads/' \"local/$$STORAGE_BUCKET\";
         echo 'bucket ready: '$$STORAGE_BUCKET
       "
 

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -135,7 +135,7 @@ services:
         [ "$$connected" = 1 ] || { echo 'minio-init: cannot reach minio after 30s'; exit 1; };
         mc mb --ignore-existing \"local/$$STORAGE_BUCKET\";
         mc ilm rule remove --all --force \"local/$$STORAGE_BUCKET\" 2>/dev/null || true;
-        mc ilm rule add --expire-days "$$MINIO_ORPHAN_EXPIRY_DAYS" --tags 'committed=false' \"local/$$STORAGE_BUCKET\";
+        mc ilm rule add --expire-days "$$MINIO_ORPHAN_EXPIRY_DAYS" --prefix 'uploads/' \"local/$$STORAGE_BUCKET\";
         echo 'bucket ready: '$$STORAGE_BUCKET
       "
 

--- a/docker/compose.swarm-local-test.yml
+++ b/docker/compose.swarm-local-test.yml
@@ -56,7 +56,7 @@ services:
         [ "$$connected" = 1 ] || { echo 'minio-init: cannot reach minio after 30s'; exit 1; };
         mc mb --ignore-existing \"local/$$STORAGE_BUCKET\";
         mc ilm rule remove --all --force \"local/$$STORAGE_BUCKET\" 2>/dev/null || true;
-        mc ilm rule add --expire-days "$$MINIO_ORPHAN_EXPIRY_DAYS" --tags 'committed=false' \"local/$$STORAGE_BUCKET\";
+        mc ilm rule add --expire-days "$$MINIO_ORPHAN_EXPIRY_DAYS" --prefix 'uploads/' \"local/$$STORAGE_BUCKET\";
         echo 'bucket ready: '$$STORAGE_BUCKET
       "
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:RELEASE.2025-05-24T17-08-30Z@sha256:a616cd8f37758b0296db62cc9e6af05a074e844cc7b5c0a0e62176d73828d440
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:a1a8bd4ac40ad7881a245bab97323e18f971e4d4cba2c2007ec1bedd21cbaba2
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -38,22 +38,24 @@ Copy `.env.example` to `.env` and fill in the values.
 | `WS_CONNECTION_LIMIT_PER_IP` | `50`        | No       | Maximum active WebSocket leases per resolved client IP         |
 | `WS_SESSION_REVALIDATE_MS`   | `60000`     | No       | Recheck active sessions and renew socket leases; max 5 minutes |
 
-## Storage (MinIO / S3)
+## Storage (S3-compatible)
 
-| Variable                               | Default                 | Required             | Description                                                                                                                                                             |
-| -------------------------------------- | ----------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STORAGE_ENDPOINT`                     | `http://localhost:9000` | Yes                  | S3-compatible endpoint (app → storage)                                                                                                                                  |
-| `STORAGE_PUBLIC_ENDPOINT`              | _(unset)_               | No                   | Browser-facing endpoint for presigned URLs; set when the app reaches storage at an internal hostname (e.g. `http://minio:9000` in containers) the browser can't resolve |
-| `STORAGE_ACCESS_KEY`                   | `minioadmin`            | Yes (rotate in prod) | Access key                                                                                                                                                              |
-| `STORAGE_SECRET_KEY`                   | `minioadmin`            | Yes (rotate in prod) | Secret key                                                                                                                                                              |
-| `STORAGE_BUCKET`                       | `uploads`               | Yes                  | Default bucket name                                                                                                                                                     |
-| `STORAGE_REGION`                       | `us-east-1`             | No                   | S3 region                                                                                                                                                               |
-| `UPLOAD_PRESIGN_EXPIRES_SECONDS`       | `300`                   | No                   | Presigned POST policy lifetime (60–3600 seconds)                                                                                                                        |
-| `STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS` | `3600`                  | No                   | Signed download URL lifetime (60–86400 seconds)                                                                                                                         |
-| `MALWARE_SCANNER_ENABLED`              | `false`                 | Prod                 | Enable ClamAV scanning before an upload can become `READY`                                                                                                              |
-| `MALWARE_SCANNER_HOST`                 | `localhost`             | No                   | ClamAV daemon host (production worker uses the internal `malware-scanner` service)                                                                                      |
-| `MALWARE_SCANNER_PORT`                 | `3310`                  | No                   | ClamAV TCP port                                                                                                                                                         |
-| `MALWARE_SCANNER_TIMEOUT_MS`           | `30000`                 | No                   | Maximum scan duration before the file remains quarantined                                                                                                               |
+| Variable                               | Default                 | Required             | Description                                                                                                                                                                                                                          |
+| -------------------------------------- | ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `STORAGE_ENDPOINT`                     | `http://localhost:9000` | Yes                  | S3-compatible endpoint (app → storage)                                                                                                                                                                                               |
+| `STORAGE_PUBLIC_ENDPOINT`              | _(unset)_               | No                   | Browser-facing endpoint for presigned URLs; set when the app reaches storage at an internal hostname (e.g. `http://minio:9000` in containers) the browser can't resolve                                                              |
+| `STORAGE_ACCESS_KEY`                   | `minioadmin`            | Yes (rotate in prod) | Access key                                                                                                                                                                                                                           |
+| `STORAGE_SECRET_KEY`                   | `minioadmin`            | Yes (rotate in prod) | Secret key                                                                                                                                                                                                                           |
+| `STORAGE_BUCKET`                       | `uploads`               | Yes                  | Default bucket name                                                                                                                                                                                                                  |
+| `STORAGE_REGION`                       | `us-east-1`             | No                   | S3 region                                                                                                                                                                                                                            |
+| `STORAGE_FORCE_PATH_STYLE`             | `true`                  | No                   | Path-style addressing (`endpoint/bucket/key`), which every self-hosted backend serves. Set `false` against real AWS S3, which documents virtual-hosted-style as the supported form                                                   |
+| `STORAGE_CHECKSUM_MODE`                | `WHEN_SUPPORTED`        | No                   | `WHEN_SUPPORTED` lets the SDK attach `x-amz-checksum-crc32` to every upload (AWS S3 and current MinIO accept it). `WHEN_REQUIRED` stops sending it for backends that reject the header — older Ceph RGW, Backblaze B2, some gateways |
+| `UPLOAD_PRESIGN_EXPIRES_SECONDS`       | `300`                   | No                   | Presigned POST policy lifetime (60–3600 seconds)                                                                                                                                                                                     |
+| `STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS` | `3600`                  | No                   | Signed download URL lifetime (60–86400 seconds)                                                                                                                                                                                      |
+| `MALWARE_SCANNER_ENABLED`              | `false`                 | Prod                 | Enable ClamAV scanning before an upload can become `READY`                                                                                                                                                                           |
+| `MALWARE_SCANNER_HOST`                 | `localhost`             | No                   | ClamAV daemon host (production worker uses the internal `malware-scanner` service)                                                                                                                                                   |
+| `MALWARE_SCANNER_PORT`                 | `3310`                  | No                   | ClamAV TCP port                                                                                                                                                                                                                      |
+| `MALWARE_SCANNER_TIMEOUT_MS`           | `30000`                 | No                   | Maximum scan duration before the file remains quarantined                                                                                                                                                                            |
 
 **Upload pattern** — clients call `POST /api/v1/upload/presign` to receive a
 short-lived (5 min) S3 presigned-POST policy, upload the bytes browser→S3
@@ -69,6 +71,19 @@ Confirmed objects are tracked in `stored_files`: `FINALIZING` before the S3 copy
 `VERIFYING` after durable BullMQ enqueue, then `READY` or `REJECTED` in the worker.
 The scheduler removes stale records, committed objects belonging to deleted users,
 and objects rejected by verification.
+
+**Which backend to run.** The bundled MinIO is a development convenience, not a recommendation:
+upstream archived the repository in February 2026, the last published image is
+`RELEASE.2025-09-07`, and there will be no further security patches. The adapter itself is plain
+S3 — nothing in it is MinIO-specific — so production should point `STORAGE_ENDPOINT` at AWS S3,
+Cloudflare R2, or a maintained self-hosted backend.
+
+SeaweedFS (Apache-2.0, actively maintained) was verified against this exact flow — presigned POST,
+`HeadObject`, `CopyObject` with `CopySourceIfMatch`, ranged reads, and the SDK's default CRC32
+checksum all pass. It needs an S3 identity configured (`-s3.config`) and, since it has no `mc`,
+its own bucket creation and lifecycle setup. The one thing no portable backend accepts is a
+`tagging` field inside a POST policy, which is why staging objects are separated by the `uploads/`
+key prefix and the orphan-expiry lifecycle rule filters on that prefix instead of on a tag.
 
 ## Authentication (Better Auth)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,9 +16,15 @@ pre-commit:
   commands:
     # Lint + format staged files only (eslint --fix + prettier). Fast: touches
     # just what you're committing.
+    # Skipped on merge/rebase like the two below: those stage every file the merge touches (hundreds
+    # on a release merge), and ESLint's type-aware pass holds a program for all of them in one
+    # process — enough to exhaust the default heap. The content was already linted on its own commit.
     lint-staged:
       priority: 1
       run: pnpm lint-staged
+      skip:
+        - merge
+        - rebase
     # Typecheck affected projects. --uncommitted scopes to your working-tree
     # changes and cache hits keep repeat commits cheap; glob skips it entirely
     # when the commit has no TS. --output-style=stream prints the real tsc error.

--- a/libs/infra/storage/src/lib/s3-storage.adapter.spec.ts
+++ b/libs/infra/storage/src/lib/s3-storage.adapter.spec.ts
@@ -9,7 +9,27 @@ import {
   HeadObjectCommand,
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
+import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
 import { S3StorageAdapter } from './s3-storage.adapter';
+
+type PostParams = { Fields?: Record<string, string>; Conditions?: unknown[] };
+
+// The adapter keeps its clients private, and the SDK normalises each config value into either a
+// literal or a provider function — so read it back the same way the SDK would.
+async function resolvedClientConfig(
+  adapter: S3StorageAdapter,
+): Promise<{ forcePathStyle: boolean; requestChecksumCalculation: string }> {
+  const config = (adapter as unknown as { client: { config: Record<string, unknown> } }).client
+    .config;
+  const read = async (key: string): Promise<unknown> => {
+    const value = config[key];
+    return typeof value === 'function' ? await (value as () => Promise<unknown>)() : value;
+  };
+  return {
+    forcePathStyle: (await read('forcePathStyle')) as boolean,
+    requestChecksumCalculation: (await read('requestChecksumCalculation')) as string,
+  };
+}
 
 // `getSignedUrl` from @aws-sdk/s3-request-presigner is a static helper —
 // stub it before importing the adapter so getSignedUrl() returns a stable
@@ -25,13 +45,14 @@ vi.mock('@aws-sdk/s3-presigned-post', () => ({
   }),
 }));
 
-function makeConfigService(): ConfigService {
+function makeConfigService(overrides: Record<string, string> = {}): ConfigService {
   const env: Record<string, string> = {
     STORAGE_ENDPOINT: 'http://minio:9000',
     STORAGE_BUCKET: 'uploads',
     STORAGE_REGION: 'us-east-1',
     STORAGE_ACCESS_KEY: 'k',
     STORAGE_SECRET_KEY: 's',
+    ...overrides,
   };
   return { get: vi.fn((key: string) => env[key]) } as unknown as ConfigService;
 }
@@ -246,7 +267,7 @@ describe('S3StorageAdapter', () => {
   });
 
   describe('finalize', () => {
-    it('copies the exact staging version to a committed final key and deletes the source', async () => {
+    it('copies the exact staging version to the final key and deletes the source', async () => {
       const send = mockSend(adapter);
       send.mockResolvedValue({});
       await adapter.finalize('uploads/user/x.png', 'files/user/y.png', '"etag-1"');
@@ -257,8 +278,6 @@ describe('S3StorageAdapter', () => {
         Key: 'files/user/y.png',
         CopySource: 'uploads/uploads/user/x.png',
         CopySourceIfMatch: '"etag-1"',
-        TaggingDirective: 'REPLACE',
-        Tagging: 'committed=true',
       });
       expect(send.mock.calls[1][0]).toBeInstanceOf(DeleteObjectCommand);
     });
@@ -290,6 +309,49 @@ describe('S3StorageAdapter', () => {
       expect(result.bucket).toBe('uploads');
       expect(result.maxBytes).toBe(1024);
       expect(Date.parse(result.expiresAt)).not.toBeNaN();
+    });
+
+    // A `tagging` field inside a POST policy is a MinIO/AWS extension. SeaweedFS answers
+    // `Policy Condition failed`, which made the whole presign flow unusable there.
+    it('signs a policy no S3-compatible backend can reject over tagging', async () => {
+      await adapter.presignUpload('uploads/x', { contentType: 'image/png', maxBytes: 1024 });
+
+      const [, params] = vi.mocked(createPresignedPost).mock.calls.at(-1) as [unknown, PostParams];
+      expect(params.Fields).not.toHaveProperty('tagging');
+      expect(JSON.stringify(params.Conditions)).not.toContain('tagging');
+    });
+  });
+
+  describe('backend compatibility switches', () => {
+    it('defaults to path-style addressing and SDK checksums', async () => {
+      const client = await resolvedClientConfig(new S3StorageAdapter(makeConfigService()));
+
+      expect(client.forcePathStyle).toBe(true);
+      expect(client.requestChecksumCalculation).toBe('WHEN_SUPPORTED');
+    });
+
+    // Backends that reject `x-amz-checksum-crc32` (older Ceph RGW, B2) need the SDK to stop
+    // sending it; AWS documents WHEN_REQUIRED as the way to do that.
+    it('stops sending upload checksums when STORAGE_CHECKSUM_MODE says so', async () => {
+      const client = await resolvedClientConfig(
+        new S3StorageAdapter(makeConfigService({ STORAGE_CHECKSUM_MODE: 'WHEN_REQUIRED' })),
+      );
+
+      expect(client.requestChecksumCalculation).toBe('WHEN_REQUIRED');
+    });
+
+    it('switches to virtual-hosted addressing for real AWS S3', async () => {
+      const client = await resolvedClientConfig(
+        new S3StorageAdapter(makeConfigService({ STORAGE_FORCE_PATH_STYLE: 'false' })),
+      );
+
+      expect(client.forcePathStyle).toBe(false);
+    });
+
+    it('rejects an unknown checksum mode at construction', () => {
+      expect(
+        () => new S3StorageAdapter(makeConfigService({ STORAGE_CHECKSUM_MODE: 'sometimes' })),
+      ).toThrow(/STORAGE_CHECKSUM_MODE/);
     });
   });
 });

--- a/libs/infra/storage/src/lib/s3-storage.adapter.ts
+++ b/libs/infra/storage/src/lib/s3-storage.adapter.ts
@@ -29,12 +29,10 @@ import type {
   UploadOptions,
 } from './storage.port';
 
-// Applied at presign so the lifecycle rule expires uploads that never reach
-// /confirm; finalize() copies validated bytes to an immutable `files/` key.
-const UNCOMMITTED_TAGGING =
-  '<Tagging><TagSet><Tag><Key>committed</Key><Value>false</Value></Tag></TagSet></Tagging>';
+type ChecksumMode = 'WHEN_SUPPORTED' | 'WHEN_REQUIRED';
 
-// forcePathStyle required for MinIO and S3-compatible services (R2, B2); harmless on AWS S3.
+const CHECKSUM_MODES: readonly ChecksumMode[] = ['WHEN_SUPPORTED', 'WHEN_REQUIRED'];
+
 @Injectable()
 export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(S3StorageAdapter.name);
@@ -58,13 +56,23 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
     const secretAccessKey = this.requireConfig('STORAGE_SECRET_KEY', 'minioadmin');
     const credentials = { accessKeyId, secretAccessKey };
 
-    this.client = new S3Client({
-      endpoint: this.endpoint,
+    // MinIO and most self-hosted backends only answer path-style; AWS S3 accepts both but documents
+    // virtual-hosted as the supported form, so a deployment against real S3 can turn this off.
+    const forcePathStyle = this.config.get<string>('STORAGE_FORCE_PATH_STYLE') !== 'false';
+    // The SDK computes a CRC32 on every upload by default (WHEN_SUPPORTED). AWS S3 and current
+    // MinIO accept it; older Ceph RGW, Backblaze B2 and some gateways reject the header outright,
+    // and WHEN_REQUIRED is the documented way to stop sending it.
+    const requestChecksumCalculation = this.resolveChecksumMode();
+    const clientConfig = {
       region,
       credentials,
-      forcePathStyle: true,
+      forcePathStyle,
       maxAttempts: 3,
-    });
+      requestChecksumCalculation,
+      responseChecksumValidation: requestChecksumCalculation,
+    };
+
+    this.client = new S3Client({ ...clientConfig, endpoint: this.endpoint });
 
     // Presigned URLs must be signed against a host the browser can reach; in
     // containers STORAGE_ENDPOINT is internal (http://minio:9000), so
@@ -76,13 +84,20 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
     this.presignClient =
       this.publicEndpoint === this.endpoint
         ? this.client
-        : new S3Client({
-            endpoint: this.publicEndpoint,
-            region,
-            credentials,
-            forcePathStyle: true,
-            maxAttempts: 3,
-          });
+        : new S3Client({ ...clientConfig, endpoint: this.publicEndpoint });
+  }
+
+  private resolveChecksumMode(): ChecksumMode {
+    const configured = this.config.get<string>('STORAGE_CHECKSUM_MODE')?.trim();
+    if (!configured) {
+      return 'WHEN_SUPPORTED';
+    }
+    if (!CHECKSUM_MODES.includes(configured as ChecksumMode)) {
+      throw new Error(
+        `StorageModule: STORAGE_CHECKSUM_MODE must be one of ${CHECKSUM_MODES.join(', ')}`,
+      );
+    }
+    return configured as ChecksumMode;
   }
 
   // Development MinIO is bootstrapped automatically. Production storage is infrastructure-owned,
@@ -190,6 +205,9 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
   }
 
   // POST policy pins Content-Type and size — prevents mime-type smuggling or oversized payloads.
+  // It deliberately carries no `tagging` field: staging objects live under their own key prefix, so
+  // the orphan-expiry lifecycle rule filters on that prefix instead. Tagging inside a POST policy is
+  // a MinIO/AWS extension that SeaweedFS (and others) reject with `Policy Condition failed`.
   async presignUpload(key: string, options: PresignUploadOptions): Promise<PresignedUpload> {
     const bucket = options.bucket ?? this.bucket;
     const expiresInSeconds = options.expiresInSeconds ?? 300;
@@ -201,9 +219,8 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
         Conditions: [
           ['content-length-range', 1, options.maxBytes],
           ['eq', '$Content-Type', options.contentType],
-          ['eq', '$tagging', UNCOMMITTED_TAGGING],
         ],
-        Fields: { 'Content-Type': options.contentType, tagging: UNCOMMITTED_TAGGING },
+        Fields: { 'Content-Type': options.contentType },
         Expires: expiresInSeconds,
       });
 
@@ -302,8 +319,6 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
           CopySource: encodeCopySource(targetBucket, sourceKey),
           CopySourceIfMatch: expectedEtag,
           MetadataDirective: 'COPY',
-          TaggingDirective: 'REPLACE',
-          Tagging: 'committed=true',
         }),
       );
     } catch (err) {
@@ -314,7 +329,7 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
       });
     }
 
-    // The source stays committed=false, so a delete failure is bounded by lifecycle TTL.
+    // The source keeps its staging prefix, so a delete failure is bounded by the lifecycle TTL.
     await this.delete(sourceKey, targetBucket).catch((err: unknown) => {
       this.logger.warn(
         { err, sourceKey, finalKey },


### PR DESCRIPTION
## Why

MinIO archived its repository in **February 2026** — the last published image is `RELEASE.2025-09-07` and there will be no further security patches. A boilerplate cannot ship a storage backend nobody patches, so the backend has to be replaceable. It was not.

## What was locking us in

The presign policy carried a `tagging` field so a MinIO lifecycle rule could expire uploads that never reached `/confirm`. Tagging inside a POST policy is a MinIO/AWS extension. Verified against a real SeaweedFS container:

```
FAIL  POST policy upload -> 403
      Policy Condition failed: [eq, $tagging, <Tagging>...]
```

Staging objects already live under their own `uploads/` prefix, so the lifecycle rule filters on the prefix instead and the policy stays portable. With the tagging field gone, the same probe passes end to end on SeaweedFS:

```
OK  createPresignedPost      OK  HeadObject
OK  POST policy upload 204   OK  CopyObject + CopySourceIfMatch
OK  GetObject Range          OK  PutObject with SDK default CRC32
```

## Also

- `STORAGE_FORCE_PATH_STYLE` — path-style was hardcoded; real AWS S3 documents virtual-hosted-style.
- `STORAGE_CHECKSUM_MODE` — the SDK attaches `x-amz-checksum-crc32` to every upload by default ([AWS docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html)); older Ceph RGW and Backblaze B2 reject it. Confirmed by capturing the outgoing headers.
- Both are declared in **all three** env validators — zod strips undeclared keys, so a missing declaration would have silently disabled the switch. Caught in self-review.
- MinIO bumped to the last image upstream published.
- `lint-staged` now skips merge/rebase like typecheck and the secret scan: a release merge stages hundreds of files into one type-aware ESLint process, which is what exhausted the default heap.

## Verified

- `nx affected -t lint test build typecheck` green; `api:e2e` 61/61
- Real MinIO `RELEASE.2025-09-07`: presign POST → 204, HeadObject, finalize copy, ranged read all pass
- `mc ilm rule ls` shows `PREFIX=uploads/`, `TAGS=-`