### PR TITLE
fix(upload): stream malware scans and record when nothing scanned

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,10 @@ UPLOAD_PRESIGN_EXPIRES_SECONDS=300
 STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS=3600
 # Full-content malware scanning. Production worker validation requires this to be enabled and
 # reachable; objects remain VERIFYING (not downloadable) while the scanner is unavailable.
+# ClamAV clamps MaxFileSize to 2 GiB internally and skips anything larger. The worker checks the
+# object size against this first, so an oversized upload is never pushed across the network only to
+# be skipped; it is published with scanOutcome=SKIPPED_TOO_LARGE instead of a silent clean.
+MALWARE_SCANNER_MAX_BYTES=2147483648
 MALWARE_SCANNER_ENABLED=false
 MALWARE_SCANNER_HOST=localhost
 MALWARE_SCANNER_PORT=3310

--- a/.env.example
+++ b/.env.example
@@ -117,9 +117,9 @@ UPLOAD_PRESIGN_EXPIRES_SECONDS=300
 STORAGE_DOWNLOAD_URL_EXPIRES_SECONDS=3600
 # Full-content malware scanning. Production worker validation requires this to be enabled and
 # reachable; objects remain VERIFYING (not downloadable) while the scanner is unavailable.
-# ClamAV clamps MaxFileSize to 2 GiB internally and skips anything larger. The worker checks the
-# object size against this first, so an oversized upload is never pushed across the network only to
-# be skipped; it is published with scanOutcome=SKIPPED_TOO_LARGE instead of a silent clean.
+# The worker compares the object size against this before sending anything, so an oversized upload is
+# never pushed across the network only to be skipped — it is published with
+# scanOutcome=SKIPPED_TOO_LARGE instead of a silent clean. Capped at ClamAV's own 2 GiB ceiling.
 MALWARE_SCANNER_MAX_BYTES=2147483648
 MALWARE_SCANNER_ENABLED=false
 MALWARE_SCANNER_HOST=localhost

--- a/apps/api/e2e/test-app.ts
+++ b/apps/api/e2e/test-app.ts
@@ -72,6 +72,12 @@ const e2eStorageStub: StoragePort = {
   readRange: async (key, byteCount) =>
     e2eObjects.get(key)?.body.subarray(0, byteCount) ?? Buffer.alloc(0),
   read: async (key) => e2eObjects.get(key)?.body ?? Buffer.alloc(0),
+  readStream: async (key) => {
+    const body = e2eObjects.get(key)?.body ?? Buffer.alloc(0);
+    return (async function* () {
+      yield body;
+    })();
+  },
 };
 
 // Allowed cross-origin used to assert CORS headers survive the Better Auth hijack path.

--- a/apps/worker/src/app/security/malware-scanner.service.spec.ts
+++ b/apps/worker/src/app/security/malware-scanner.service.spec.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:net';
+import type { ConfigService } from '@nestjs/config';
+import { MalwareScannerService, interpretScannerReply } from './malware-scanner.service';
+import type { WorkerEnvConfig } from '../../config/env.validation';
+
+// A stub clamd: it speaks the INSTREAM protocol well enough to answer, and records how much it was
+// sent so the streaming path can be checked without a real scanner.
+function startFakeClamd(reply: string, options: { hangUpAfterBytes?: number } = {}) {
+  let received = 0;
+  const server: Server = createServer((socket) => {
+    socket.on('data', (chunk) => {
+      received += chunk.length;
+      if (options.hangUpAfterBytes !== undefined && received >= options.hangUpAfterBytes) {
+        socket.end(`${reply}\0`);
+        return;
+      }
+    });
+    socket.on('end', () => socket.end(`${reply}\0`));
+    socket.on('error', () => undefined);
+  });
+  return {
+    server,
+    listen: () =>
+      new Promise<number>((resolve) => {
+        server.listen(0, '127.0.0.1', () => resolve((server.address() as { port: number }).port));
+      }),
+    bytesReceived: () => received,
+  };
+}
+
+function makeConfig(port: number, enabled = true): ConfigService<WorkerEnvConfig, true> {
+  const env: Record<string, unknown> = {
+    MALWARE_SCANNER_ENABLED: enabled,
+    MALWARE_SCANNER_HOST: '127.0.0.1',
+    MALWARE_SCANNER_PORT: port,
+    MALWARE_SCANNER_TIMEOUT_MS: 5_000,
+    MALWARE_SCANNER_MAX_BYTES: 2 * 1024 * 1024 * 1024,
+  };
+  return { get: (key: string) => env[key] } as unknown as ConfigService<WorkerEnvConfig, true>;
+}
+
+async function* chunksOf(total: number, chunkSize: number): AsyncIterable<Uint8Array> {
+  for (let sent = 0; sent < total; sent += chunkSize) {
+    yield Buffer.alloc(Math.min(chunkSize, total - sent), 0x41);
+  }
+}
+
+describe('interpretScannerReply', () => {
+  it('reads a clean reply', () => {
+    expect(interpretScannerReply('stream: OK')).toBe('clean');
+  });
+
+  it('reads an infection', () => {
+    expect(interpretScannerReply('stream: Eicar-Test-Signature FOUND')).toBe('infected');
+  });
+
+  // This is the case that matters: the limit reply arrives on a FOUND line, so a naive
+  // `includes('FOUND')` would report an unscanned 10 GB object as malware.
+  it('reads a limit skip as unscannable, not as an infection', () => {
+    expect(interpretScannerReply('stream: Heuristics.Limits.Exceeded.MaxFileSize FOUND')).toBe(
+      'unscannable',
+    );
+    expect(interpretScannerReply('INSTREAM size limit exceeded. ERROR')).toBe('unscannable');
+  });
+
+  it('refuses to guess at an unrecognised reply', () => {
+    expect(() => interpretScannerReply('something else entirely')).toThrow();
+  });
+});
+
+describe('MalwareScannerService', () => {
+  let fake: ReturnType<typeof startFakeClamd>;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => fake.server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    fake = startFakeClamd('stream: OK');
+  });
+
+  it('streams an async iterable without materialising it', async () => {
+    const port = await fake.listen();
+    const service = new MalwareScannerService(makeConfig(port));
+
+    // 4 MB in 64 KB chunks — enough to cross the socket's high-water mark and exercise backpressure.
+    const result = await service.scan(chunksOf(4 * 1024 * 1024, 64 * 1024));
+
+    expect(result).toBe('clean');
+    // Payload plus the INSTREAM command and one 4-byte length header per chunk.
+    expect(fake.bytesReceived()).toBeGreaterThan(4 * 1024 * 1024);
+  });
+
+  it('still accepts a Buffer', async () => {
+    const port = await fake.listen();
+    const service = new MalwareScannerService(makeConfig(port));
+
+    await expect(service.scan(Buffer.alloc(128 * 1024))).resolves.toBe('clean');
+  });
+
+  it('skips the scanner entirely when disabled', async () => {
+    const port = await fake.listen();
+    const service = new MalwareScannerService(makeConfig(port, false));
+
+    await expect(service.scan(Buffer.from('x'))).resolves.toBe('clean');
+    expect(fake.bytesReceived()).toBe(0);
+  });
+});
+
+describe('MalwareScannerService size ceiling', () => {
+  // Deciding up front is the point: clamd answers and closes as soon as a limit is hit, and a write
+  // racing that close earns an RST that can discard the reply. Never sending avoids the race, the
+  // transfer, and the job lock held while 10 GB crosses the network for nothing.
+  it('refuses an object past the ceiling without opening a connection', async () => {
+    const fake = startFakeClamd('stream: OK');
+    const port = await fake.listen();
+    const config = makeConfig(port);
+    const service = new MalwareScannerService({
+      get: (key: string) =>
+        key === 'MALWARE_SCANNER_MAX_BYTES' ? 1024 : (config.get as (k: string) => unknown)(key),
+    } as never);
+
+    try {
+      const verdict = await service.scan(chunksOf(64 * 1024, 16 * 1024), { sizeBytes: 4096 });
+
+      expect(verdict).toBe('unscannable');
+      expect(fake.bytesReceived()).toBe(0);
+    } finally {
+      await new Promise<void>((resolve) => fake.server.close(() => resolve()));
+    }
+  });
+
+  it('scans an object inside the ceiling', async () => {
+    const fake = startFakeClamd('stream: OK');
+    const port = await fake.listen();
+    const service = new MalwareScannerService(makeConfig(port));
+
+    try {
+      await expect(service.scan(Buffer.alloc(2048), { sizeBytes: 2048 })).resolves.toBe('clean');
+    } finally {
+      await new Promise<void>((resolve) => fake.server.close(() => resolve()));
+    }
+  });
+});

--- a/apps/worker/src/app/security/malware-scanner.service.spec.ts
+++ b/apps/worker/src/app/security/malware-scanner.service.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createServer, type Server } from 'node:net';
+import { createServer, type Server, type Socket } from 'node:net';
 import type { ConfigService } from '@nestjs/config';
 import { MalwareScannerService, interpretScannerReply } from './malware-scanner.service';
 import type { WorkerEnvConfig } from '../../config/env.validation';
@@ -142,4 +142,44 @@ describe('MalwareScannerService size ceiling', () => {
       await new Promise<void>((resolve) => fake.server.close(() => resolve()));
     }
   });
+});
+
+describe('MalwareScannerService when the scanner stops responding', () => {
+  // `socket.setTimeout` only emits an event; it does not close the socket. A scanner that accepts
+  // the connection and then stops reading fills the send window, `write()` returns false, and the
+  // stream loop parks on `drain` — which the timeout event alone never interrupts. The job then
+  // never settles and the rejected reply promise, with nothing awaiting it yet, takes the whole
+  // worker process down. Reproduced against real sockets before this was fixed.
+  it('rejects instead of hanging when the scanner accepts but never reads', async () => {
+    const accepted: Socket[] = [];
+    const stalled = createServer((socket) => {
+      accepted.push(socket);
+      socket.pause();
+    });
+    const port = await new Promise<number>((resolve) => {
+      stalled.listen(0, '127.0.0.1', () => resolve((stalled.address() as { port: number }).port));
+    });
+
+    const config = makeConfig(port);
+    const service = new MalwareScannerService({
+      get: (key: string) =>
+        key === 'MALWARE_SCANNER_TIMEOUT_MS' ? 300 : (config.get as (k: string) => unknown)(key),
+    } as never);
+
+    try {
+      // 256 MB of 64 KB frames: far more than the send buffer can hold, so it must block.
+      const scan = service.scan(chunksOf(256 * 1024 * 1024, 64 * 1024));
+      const outcome = await Promise.race([
+        scan.then(() => 'resolved').catch((err: Error) => `rejected: ${err.message}`),
+        new Promise<string>((resolve) => setTimeout(() => resolve('HUNG'), 5_000)),
+      ]);
+
+      expect(outcome).toContain('timed out');
+    } finally {
+      // The stalled peer still holds the accepted socket, and `net.Server#close` waits for every
+      // connection to end — so it has to be torn down explicitly or the test hangs on teardown.
+      for (const socket of accepted) socket.destroy();
+      await new Promise<void>((resolve) => stalled.close(() => resolve()));
+    }
+  }, 10_000);
 });

--- a/apps/worker/src/app/security/malware-scanner.service.ts
+++ b/apps/worker/src/app/security/malware-scanner.service.ts
@@ -1,53 +1,130 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createConnection } from 'node:net';
+import { createConnection, type Socket } from 'node:net';
+import { once } from 'node:events';
 import type { WorkerEnvConfig } from '../../config/env.validation';
 
-export type MalwareScanResult = 'clean' | 'infected';
+// `unscannable` is not a third verdict — it is the absence of one. ClamAV skips any file past its
+// internal 2 GiB ceiling, and with `AlertExceedsMax yes` it reports that skip rather than answering
+// clean. Folding it into either verdict would be a lie in one direction or the other.
+export type MalwareScanResult = 'clean' | 'infected' | 'unscannable';
+
+const INSTREAM_CHUNK_BYTES = 64 * 1024;
+// clamd's replies when a limit stopped the scan. `Heuristics.Limits.Exceeded` arrives on a FOUND
+// line, so it must be matched before the generic infected check or a large file reads as malware.
+const LIMIT_MARKERS = ['Heuristics.Limits.Exceeded', 'size limit exceeded', 'INSTREAM size limit'];
 
 @Injectable()
 export class MalwareScannerService {
   constructor(private readonly config: ConfigService<WorkerEnvConfig, true>) {}
 
-  async scan(content: Buffer): Promise<MalwareScanResult> {
+  async scan(
+    content: AsyncIterable<Uint8Array> | Buffer,
+    options?: { sizeBytes?: number },
+  ): Promise<MalwareScanResult> {
     if (!this.config.get('MALWARE_SCANNER_ENABLED', { infer: true })) return 'clean';
 
-    const host = this.config.get('MALWARE_SCANNER_HOST', { infer: true });
-    const port = this.config.get('MALWARE_SCANNER_PORT', { infer: true });
-    const timeoutMs = this.config.get('MALWARE_SCANNER_TIMEOUT_MS', { infer: true });
+    // Decided before a byte moves. clamd would answer and hang up mid-stream anyway, and a write
+    // racing that close earns an RST that can discard the very reply we need to read.
+    const maxBytes = this.config.get('MALWARE_SCANNER_MAX_BYTES', { infer: true });
+    if (options?.sizeBytes !== undefined && options.sizeBytes > maxBytes) return 'unscannable';
 
-    return new Promise<MalwareScanResult>((resolve, reject) => {
-      const socket = createConnection({ host, port });
-      const responses: Buffer[] = [];
+    const socket = createConnection({
+      host: this.config.get('MALWARE_SCANNER_HOST', { infer: true }),
+      port: this.config.get('MALWARE_SCANNER_PORT', { infer: true }),
+    });
+    socket.setTimeout(this.config.get('MALWARE_SCANNER_TIMEOUT_MS', { infer: true }));
+
+    const state = { replied: false };
+    const reply = this.collectReply(socket, state);
+    try {
+      // A write that fails is never the answer. clamd tears the connection down the moment a limit
+      // is hit, so the reply it already sent is what decides the outcome; if it sent nothing,
+      // `reply` rejects with the underlying error and that is what surfaces.
+      await this.streamToScanner(socket, content, state).catch(() => undefined);
+      return interpretScannerReply(await reply);
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  private async streamToScanner(
+    socket: Socket,
+    content: AsyncIterable<Uint8Array> | Buffer,
+    state: { replied: boolean },
+  ): Promise<void> {
+    await once(socket, 'connect');
+    socket.write('zINSTREAM\0');
+
+    for await (const chunk of toChunks(content)) {
+      // Stop the moment clamd answers. It replies and closes as soon as a limit is hit, and writing
+      // into that closing socket earns an RST — which on some platforms discards the reply still
+      // sitting in the receive buffer, turning a usable verdict into a connection error.
+      if (state.replied || socket.writableEnded || socket.destroyed) break;
+      const header = Buffer.allocUnsafe(4);
+      header.writeUInt32BE(chunk.length);
+      // Respect backpressure: writing a 10 GB object without it queues the whole body in the
+      // socket buffer, which is exactly the memory blow-up this streaming path exists to avoid.
+      if (!socket.write(header) || !socket.write(chunk)) {
+        // Not Promise.race over two `once` calls: the loser stays attached, so a large object
+        // would accumulate one dangling listener per chunk. Waiting on `drain` alone would instead
+        // hang forever against a socket that is already closing.
+        await settleOn(socket, ['drain', 'close']);
+      }
+    }
+
+    if (!socket.writableEnded && !socket.destroyed) socket.end(Buffer.alloc(4));
+  }
+
+  private collectReply(socket: Socket, state: { replied: boolean }): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
       let settled = false;
-      const finish = (error?: Error, result?: MalwareScanResult): void => {
+      const finish = (error?: Error): void => {
         if (settled) return;
         settled = true;
-        socket.destroy();
         if (error) reject(error);
-        else resolve(result ?? 'clean');
+        else resolve(Buffer.concat(chunks).toString('utf8').replace(/\0+$/, '').trim());
       };
 
-      socket.setTimeout(timeoutMs, () => finish(new Error('Malware scanner timed out')));
-      socket.once('error', (error) => finish(error));
-      socket.on('data', (chunk: Buffer) => responses.push(chunk));
-      socket.once('end', () => {
-        const response = Buffer.concat(responses).toString('utf8').replace(/\0+$/, '');
-        if (response.endsWith('OK')) finish(undefined, 'clean');
-        else if (response.includes('FOUND')) finish(undefined, 'infected');
-        else finish(new Error('Malware scanner returned an invalid response'));
+      socket.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+        state.replied = true;
       });
-      socket.once('connect', () => {
-        socket.write('zINSTREAM\0');
-        for (let offset = 0; offset < content.length; offset += 64 * 1024) {
-          const chunk = content.subarray(offset, Math.min(offset + 64 * 1024, content.length));
-          const length = Buffer.allocUnsafe(4);
-          length.writeUInt32BE(chunk.length);
-          socket.write(length);
-          socket.write(chunk);
-        }
-        socket.end(Buffer.alloc(4));
-      });
+      socket.once('end', () => finish());
+      socket.once('close', () => finish());
+      socket.once('timeout', () => finish(new Error('Malware scanner timed out')));
+      // A mid-stream reset means clamd hung up early; whatever it already said is the answer.
+      socket.once('error', (error) => finish(chunks.length > 0 ? undefined : error));
     });
   }
+}
+
+function settleOn(socket: Socket, events: string[]): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const done = (): void => {
+      for (const event of events) socket.off(event, done);
+      resolve();
+    };
+    for (const event of events) socket.once(event, done);
+  });
+}
+
+async function* toChunks(content: AsyncIterable<Uint8Array> | Buffer): AsyncIterable<Buffer> {
+  if (Buffer.isBuffer(content)) {
+    for (let offset = 0; offset < content.length; offset += INSTREAM_CHUNK_BYTES) {
+      yield content.subarray(offset, Math.min(offset + INSTREAM_CHUNK_BYTES, content.length));
+    }
+    return;
+  }
+  for await (const chunk of content) {
+    yield Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+  }
+}
+
+export function interpretScannerReply(reply: string): MalwareScanResult {
+  if (LIMIT_MARKERS.some((marker) => reply.includes(marker))) return 'unscannable';
+  if (reply.endsWith('OK')) return 'clean';
+  if (reply.includes('FOUND')) return 'infected';
+  throw new Error('Malware scanner returned an invalid response');
 }

--- a/apps/worker/src/app/security/malware-scanner.service.ts
+++ b/apps/worker/src/app/security/malware-scanner.service.ts
@@ -33,10 +33,19 @@ export class MalwareScannerService {
       host: this.config.get('MALWARE_SCANNER_HOST', { infer: true }),
       port: this.config.get('MALWARE_SCANNER_PORT', { infer: true }),
     });
-    socket.setTimeout(this.config.get('MALWARE_SCANNER_TIMEOUT_MS', { infer: true }));
+    // `setTimeout` only emits an event — it does not close the socket. Destroying it here with an
+    // error is what unblocks the two waits inside streamToScanner: `connect` rejects and `close`
+    // fires. Without this, a scanner that accepts the connection and then stops reading leaves the
+    // stream loop parked forever, the job never settles, and the socket is never released.
+    socket.setTimeout(this.config.get('MALWARE_SCANNER_TIMEOUT_MS', { infer: true }), () =>
+      socket.destroy(new Error('Malware scanner timed out')),
+    );
 
     const state = { replied: false };
     const reply = this.collectReply(socket, state);
+    // Claim the rejection now. `reply` can settle while the stream loop is still unwinding, and an
+    // unhandled rejection in that window takes down the whole worker process, not just this job.
+    reply.catch(() => undefined);
     try {
       // A write that fails is never the answer. clamd tears the connection down the moment a limit
       // is hit, so the reply it already sent is what decides the outcome; if it sent nothing,
@@ -94,6 +103,7 @@ export class MalwareScannerService {
       socket.once('end', () => finish());
       socket.once('close', () => finish());
       socket.once('timeout', () => finish(new Error('Malware scanner timed out')));
+      // `error` also arrives from the timeout destroy above; `finish` is single-shot either way.
       // A mid-stream reset means clamd hung up early; whatever it already said is the answer.
       socket.once('error', (error) => finish(chunks.length > 0 ? undefined : error));
     });

--- a/apps/worker/src/config/env.validation.spec.ts
+++ b/apps/worker/src/config/env.validation.spec.ts
@@ -40,4 +40,16 @@ describe('validateWorkerConfig', () => {
   it('requires a database URL for durable upload lifecycle state', () => {
     expect(() => validateWorkerConfig({ NODE_ENV: 'development' })).toThrow('DATABASE_URL');
   });
+
+  // Anything above ClamAV's own 2 GiB ceiling would stream an oversized object to clamd and put
+  // back the mid-stream refusal the size gate exists to avoid.
+  it('refuses a scanner ceiling above what ClamAV can actually scan', () => {
+    expect(() =>
+      validateWorkerConfig({
+        NODE_ENV: 'development',
+        DATABASE_URL: 'postgresql://user:pass@db:5432/app',
+        MALWARE_SCANNER_MAX_BYTES: String(10 * 1024 * 1024 * 1024),
+      }),
+    ).toThrow(/MALWARE_SCANNER_MAX_BYTES/);
+  });
 });

--- a/apps/worker/src/config/env.validation.ts
+++ b/apps/worker/src/config/env.validation.ts
@@ -55,11 +55,14 @@ const workerEnvSchema = z
     MALWARE_SCANNER_PORT: z.coerce.number().int().min(1).max(65_535).default(3310),
     MALWARE_SCANNER_TIMEOUT_MS: z.coerce.number().int().min(1_000).max(120_000).default(30_000),
     // ClamAV clamps MaxFileSize to 2 GiB internally and skips anything larger, so sending more is
-    // pure waste. Lower it to match a scanner configured more tightly.
+    // pure waste. Capped at that ceiling rather than left open: a higher value would stream an
+    // oversized object to clamd and reopen the mid-stream refusal this gate exists to avoid. Lower
+    // it to match a scanner configured more tightly.
     MALWARE_SCANNER_MAX_BYTES: z.coerce
       .number()
       .int()
       .min(1)
+      .max(2 * 1024 * 1024 * 1024)
       .default(2 * 1024 * 1024 * 1024),
 
     // Mail (Nodemailer SMTP)

--- a/apps/worker/src/config/env.validation.ts
+++ b/apps/worker/src/config/env.validation.ts
@@ -54,6 +54,13 @@ const workerEnvSchema = z
     MALWARE_SCANNER_HOST: z.string().default('localhost'),
     MALWARE_SCANNER_PORT: z.coerce.number().int().min(1).max(65_535).default(3310),
     MALWARE_SCANNER_TIMEOUT_MS: z.coerce.number().int().min(1_000).max(120_000).default(30_000),
+    // ClamAV clamps MaxFileSize to 2 GiB internally and skips anything larger, so sending more is
+    // pure waste. Lower it to match a scanner configured more tightly.
+    MALWARE_SCANNER_MAX_BYTES: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(2 * 1024 * 1024 * 1024),
 
     // Mail (Nodemailer SMTP)
     MAIL_HOST: z.string().default('localhost'),

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -156,6 +156,14 @@ services:
       - FOWNER
       - SETGID
       - SETUID
+    environment:
+      # Without AlertExceedsMax, ClamAV reports a file it refused to scan as clean. With it, the
+      # skip comes back as Heuristics.Limits.Exceeded and the worker records SKIPPED_TOO_LARGE.
+      CLAMD_CONF_AlertExceedsMax: 'yes'
+      # 2 GiB is ClamAV's internal per-file ceiling; asking for more is silently clamped.
+      CLAMD_CONF_MaxFileSize: '2G'
+      CLAMD_CONF_MaxScanSize: '2G'
+      CLAMD_CONF_StreamMaxLength: '2G'
     volumes:
       - clamav_signatures:/var/lib/clamav
     healthcheck:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -56,6 +56,7 @@ Copy `.env.example` to `.env` and fill in the values.
 | `MALWARE_SCANNER_HOST`                 | `localhost`             | No                   | ClamAV daemon host (production worker uses the internal `malware-scanner` service)                                                                                                                                                                            |
 | `MALWARE_SCANNER_PORT`                 | `3310`                  | No                   | ClamAV TCP port                                                                                                                                                                                                                                               |
 | `MALWARE_SCANNER_TIMEOUT_MS`           | `30000`                 | No                   | Maximum scan duration before the file remains quarantined                                                                                                                                                                                                     |
+| `MALWARE_SCANNER_MAX_BYTES`            | `2147483648`            | No                   | Objects larger than this are published with `scanOutcome=SKIPPED_TOO_LARGE` instead of being sent to the scanner. The default is ClamAV's internal 2 GiB per-file ceiling, past which it skips the file — and, without `AlertExceedsMax`, reports it clean    |
 
 **Upload pattern** — clients call `POST /api/v1/upload/presign` to receive a
 short-lived (5 min) S3 presigned-POST policy, upload the bytes browser→S3
@@ -71,6 +72,11 @@ Confirmed objects are tracked in `stored_files`: `FINALIZING` before the S3 copy
 `VERIFYING` after durable BullMQ enqueue, then `READY` or `REJECTED` in the worker.
 The scheduler removes stale records, committed objects belonging to deleted users,
 and objects rejected by verification.
+
+`READY` on its own does not mean the object was scanned. Every scanner has a size ceiling — ClamAV
+skips anything past 2 GiB — so `stored_files.scanOutcome` records which happened: `CLEAN` for an
+object the scanner actually inspected, `SKIPPED_TOO_LARGE` for one published without inspection.
+Anything treating `READY` as "virus-checked" must read `scanOutcome` too.
 
 **Which backend to run.** The bundled MinIO is a development convenience, not a recommendation:
 upstream archived the repository in February 2026, the last published image is

--- a/libs/infra/storage/src/lib/s3-storage.adapter.ts
+++ b/libs/infra/storage/src/lib/s3-storage.adapter.ts
@@ -362,6 +362,25 @@ export class S3StorageAdapter implements StoragePort, OnModuleInit, OnModuleDest
     }
   }
 
+  async readStream(key: string, bucket?: string): Promise<AsyncIterable<Uint8Array>> {
+    try {
+      const res = await this.client.send(
+        new GetObjectCommand({ Bucket: bucket ?? this.bucket, Key: key }),
+      );
+      const body = res.Body as AsyncIterable<Uint8Array> | undefined;
+      if (!body?.[Symbol.asyncIterator]) {
+        throw new Error('S3 GetObject returned no streamable body');
+      }
+      return body;
+    } catch (err) {
+      this.logger.error({ err, key }, 'S3 readStream failed');
+      throw new InternalServerErrorException({
+        messageKey: I18N_KEYS.errors.storage.read_range_failed,
+        message: 'Storage readStream failed',
+      });
+    }
+  }
+
   async read(key: string, bucket?: string): Promise<Buffer> {
     try {
       const res = await this.client.send(

--- a/libs/infra/storage/src/lib/storage.port.ts
+++ b/libs/infra/storage/src/lib/storage.port.ts
@@ -56,5 +56,9 @@ export interface StoragePort {
   // magic-byte verifier so the worker doesn't have to download whole files.
   readRange(key: string, byteCount: number, bucket?: string): Promise<Buffer>;
   // Complete quarantined object for malware scanning; it remains unavailable until scan success.
+  // Only for objects known to be small — it materialises the whole body in memory.
   read(key: string, bucket?: string): Promise<Buffer>;
+  // The same bytes as `read`, streamed. Uploads are capped in the hundreds of megabytes upward,
+  // so the scanner consumes this instead: one 10 GB object would otherwise be one 10 GB Buffer.
+  readStream(key: string, bucket?: string): Promise<AsyncIterable<Uint8Array>>;
 }

--- a/libs/modules/upload/src/application/commands/confirm-upload/confirm-upload.handler.spec.ts
+++ b/libs/modules/upload/src/application/commands/confirm-upload/confirm-upload.handler.spec.ts
@@ -33,6 +33,7 @@ function storageMock(): Record<keyof StoragePort, Mock> {
     finalize: vi.fn().mockResolvedValue(undefined),
     readRange: vi.fn().mockResolvedValue(PNG_HEADER),
     read: vi.fn(),
+    readStream: vi.fn(),
   };
 }
 

--- a/libs/modules/upload/src/application/commands/verify-upload/verify-upload.handler.spec.ts
+++ b/libs/modules/upload/src/application/commands/verify-upload/verify-upload.handler.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
-import { STORED_FILE_STATUS } from '@nestjs-fastify-nx/shared';
+import { MALWARE_SCAN_OUTCOME, STORED_FILE_STATUS } from '@nestjs-fastify-nx/shared';
 import type { StoragePort } from '@nestjs-fastify-nx/infra-storage';
 import type { StoredFileRepositoryPort } from '../../../domain/ports/stored-file-repository.port';
 import type { MalwareScannerPort } from '../../../domain/ports/malware-scanner.port';
@@ -121,5 +121,49 @@ describe('VerifyUploadHandler', () => {
     files.transitionByKey.mockResolvedValue(false);
 
     await expect(handler.execute(command())).resolves.toBe('skipped');
+  });
+  describe('when the scanner cannot inspect the object', () => {
+    // READY on its own would claim the object was checked. Everything downstream that treats READY
+    // as "virus-checked" relies on this column to tell the two apart.
+    it('publishes it but records that nothing scanned it', async () => {
+      const { handler, files, scanner, storage } = build();
+      scanner.scan.mockResolvedValue('unscannable');
+
+      await expect(handler.execute(command())).resolves.toBe('verified');
+
+      expect(files.transitionByKey).toHaveBeenCalledWith(
+        KEY,
+        STORED_FILE_STATUS.VERIFYING,
+        STORED_FILE_STATUS.READY,
+        expect.objectContaining({ scanOutcome: MALWARE_SCAN_OUTCOME.SKIPPED_TOO_LARGE }),
+      );
+      expect(storage.delete).not.toHaveBeenCalled();
+    });
+
+    it('records a real scan as CLEAN', async () => {
+      const { handler, files } = build();
+
+      await handler.execute(command());
+
+      expect(files.transitionByKey).toHaveBeenCalledWith(
+        KEY,
+        STORED_FILE_STATUS.VERIFYING,
+        STORED_FILE_STATUS.READY,
+        expect.objectContaining({ scanOutcome: MALWARE_SCAN_OUTCOME.CLEAN }),
+      );
+    });
+
+    // Without the size, the scanner cannot refuse before the transfer — which is the whole point of
+    // the gate, since pushing 10 GB across only to have it skipped wastes the transfer and the lock.
+    it('passes the object size so the scanner can refuse before any bytes move', async () => {
+      const { handler, scanner } = build();
+
+      await handler.execute(command());
+
+      expect(scanner.scan).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ sizeBytes: PNG_HEADER.length }),
+      );
+    });
   });
 });

--- a/libs/modules/upload/src/application/commands/verify-upload/verify-upload.handler.spec.ts
+++ b/libs/modules/upload/src/application/commands/verify-upload/verify-upload.handler.spec.ts
@@ -18,9 +18,20 @@ const LIMITS: UploadLimits = {
 };
 
 function build() {
-  const storage: { readRange: Mock; read: Mock; delete: Mock } = {
+  const storage: { readRange: Mock; read: Mock; readStream: Mock; head: Mock; delete: Mock } = {
     readRange: vi.fn().mockResolvedValue(PNG_HEADER),
     read: vi.fn().mockResolvedValue(PNG_HEADER),
+    readStream: vi.fn().mockImplementation(async () =>
+      (async function* () {
+        yield PNG_HEADER;
+      })(),
+    ),
+    head: vi.fn().mockResolvedValue({
+      contentType: 'image/png',
+      size: PNG_HEADER.length,
+      bucket: 'uploads',
+      etag: '"e"',
+    }),
     delete: vi.fn().mockResolvedValue(undefined),
   };
   const files: { transitionByKey: Mock } = { transitionByKey: vi.fn().mockResolvedValue(true) };

--- a/libs/modules/upload/src/application/commands/verify-upload/verify-upload.handler.ts
+++ b/libs/modules/upload/src/application/commands/verify-upload/verify-upload.handler.ts
@@ -1,7 +1,7 @@
 import { Inject, Logger } from '@nestjs/common';
 import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
 import { isDomainException } from '@nestjs-fastify-nx/core';
-import { STORED_FILE_STATUS } from '@nestjs-fastify-nx/shared';
+import { MALWARE_SCAN_OUTCOME, STORED_FILE_STATUS } from '@nestjs-fastify-nx/shared';
 import { STORAGE_PORT, type StoragePort } from '@nestjs-fastify-nx/infra-storage';
 import { assertMagicBytesMatch } from '../../../domain/entities/stored-file.entity';
 import {
@@ -45,7 +45,14 @@ export class VerifyUploadHandler implements ICommandHandler<
       return this.reject(key, bucket, reason);
     }
 
-    if ((await this.scanner.scan(await this.storage.read(key, bucket))) === 'infected') {
+    // Streamed, not read into a Buffer: an object here can be tens of gigabytes, and one job
+    // materialising all of it would take the worker down with it. The size goes along so a scanner
+    // that cannot handle the object says so before the transfer starts.
+    const meta = await this.storage.head(key, bucket);
+    const verdict = await this.scanner.scan(await this.storage.readStream(key, bucket), {
+      sizeBytes: meta?.size,
+    });
+    if (verdict === 'infected') {
       this.logger.warn(
         { key, declaredContentType, correlationId },
         'upload-verification: infected object rejected and deleted',
@@ -53,11 +60,27 @@ export class VerifyUploadHandler implements ICommandHandler<
       return this.reject(key, bucket, 'Malware scan rejected the object');
     }
 
+    // ClamAV cannot scan past its own 2 GiB per-file ceiling. The object is published anyway, but
+    // the row records that nothing actually inspected it — a silent READY would claim otherwise.
+    if (verdict === 'unscannable') {
+      this.logger.warn(
+        { key, declaredContentType, correlationId },
+        'upload-verification: object exceeds the scanner limit — publishing unscanned',
+      );
+    }
+
     const flipped = await this.files.transitionByKey(
       key,
       STORED_FILE_STATUS.VERIFYING,
       STORED_FILE_STATUS.READY,
-      { verifiedAt: new Date(), failureReason: null },
+      {
+        verifiedAt: new Date(),
+        failureReason: null,
+        scanOutcome:
+          verdict === 'unscannable'
+            ? MALWARE_SCAN_OUTCOME.SKIPPED_TOO_LARGE
+            : MALWARE_SCAN_OUTCOME.CLEAN,
+      },
     );
     if (!flipped) {
       // A duplicate or retried job — or a row already flipped or purged — is a safe no-op.

--- a/libs/modules/upload/src/domain/ports/malware-scanner.port.ts
+++ b/libs/modules/upload/src/domain/ports/malware-scanner.port.ts
@@ -1,9 +1,16 @@
-export type MalwareScanResult = 'clean' | 'infected';
+// `unscannable` records that nothing inspected the object — every scanner has a size ceiling, and
+// an object past it must not be reported clean.
+export type MalwareScanResult = 'clean' | 'infected' | 'unscannable';
 
 export const MALWARE_SCANNER_PORT = Symbol('MALWARE_SCANNER_PORT');
 
 // The verification command lives here so the api and the worker share one implementation of the
 // upload lifecycle; only the scanner itself is process-specific, so it enters through this port.
 export interface MalwareScannerPort {
-  scan(content: Buffer): Promise<MalwareScanResult>;
+  // `sizeBytes` lets an adapter refuse before a byte moves: pushing 10 GB across the network only
+  // to have the scanner skip it wastes the transfer and the job's lock.
+  scan(
+    content: AsyncIterable<Uint8Array> | Buffer,
+    options?: { sizeBytes?: number },
+  ): Promise<MalwareScanResult>;
 }

--- a/libs/modules/upload/src/domain/ports/stored-file-repository.port.ts
+++ b/libs/modules/upload/src/domain/ports/stored-file-repository.port.ts
@@ -1,7 +1,13 @@
-import type { StoredFileStatus } from '@nestjs-fastify-nx/shared';
+import type { MalwareScanOutcome, StoredFileStatus } from '@nestjs-fastify-nx/shared';
 import type { StoredFile, StoredFileProps } from '../entities/stored-file.entity';
 
 export const STORED_FILE_REPOSITORY = Symbol('STORED_FILE_REPOSITORY');
+
+export interface StoredFileTransitionFields {
+  verifiedAt?: Date;
+  failureReason?: string | null;
+  scanOutcome?: MalwareScanOutcome;
+}
 
 export interface StoredFileRepositoryPort {
   findBySourceKey(sourceKey: string): Promise<StoredFile | null>;
@@ -17,13 +23,13 @@ export interface StoredFileRepositoryPort {
     id: string,
     from: StoredFileStatus,
     to: StoredFileStatus,
-    fields?: { verifiedAt?: Date; failureReason?: string | null },
+    fields?: StoredFileTransitionFields,
   ): Promise<boolean>;
   transitionByKey(
     key: string,
     from: StoredFileStatus,
     to: StoredFileStatus,
-    fields?: { verifiedAt?: Date; failureReason?: string | null },
+    fields?: StoredFileTransitionFields,
   ): Promise<boolean>;
   deleteIfStatus(id: string, status: StoredFileStatus): Promise<void>;
 }

--- a/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts
+++ b/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
 import type { StoredFileStatus } from '@nestjs-fastify-nx/shared';
 import { StoredFile, type StoredFileProps } from '../../domain/entities/stored-file.entity';
-import type { StoredFileRepositoryPort } from '../../domain/ports/stored-file-repository.port';
+import type {
+  StoredFileRepositoryPort,
+  StoredFileTransitionFields,
+} from '../../domain/ports/stored-file-repository.port';
 
 interface StoredFileRow {
   id: string;
@@ -48,7 +51,7 @@ export class PrismaStoredFileRepository implements StoredFileRepositoryPort {
     id: string,
     from: StoredFileStatus,
     to: StoredFileStatus,
-    fields?: { verifiedAt?: Date; failureReason?: string | null },
+    fields?: StoredFileTransitionFields,
   ): Promise<boolean> {
     const result = await this.writer.storedFile.updateMany({
       where: { id, status: from },
@@ -61,7 +64,7 @@ export class PrismaStoredFileRepository implements StoredFileRepositoryPort {
     key: string,
     from: StoredFileStatus,
     to: StoredFileStatus,
-    fields?: { verifiedAt?: Date; failureReason?: string | null },
+    fields?: StoredFileTransitionFields,
   ): Promise<boolean> {
     const result = await this.writer.storedFile.updateMany({
       where: { key, status: from },

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -35,3 +35,4 @@ export { encodeCursor, decodeCursor, type DecodedCursor } from './lib/cursor-pag
 export { injectDatabasePassword } from './lib/db-password-file';
 export { withTimeout } from './lib/with-timeout';
 export { STORED_FILE_STATUS, type StoredFileStatus } from './lib/stored-file-status';
+export { MALWARE_SCAN_OUTCOME, type MalwareScanOutcome } from './lib/malware-scan-outcome';

--- a/libs/shared/src/lib/malware-scan-outcome.ts
+++ b/libs/shared/src/lib/malware-scan-outcome.ts
@@ -1,0 +1,10 @@
+// ClamAV refuses to scan a file past its internal 2 GiB per-file ceiling, and with
+// `AlertExceedsMax yes` it says so instead of reporting the object clean. Recording which of the two
+// happened is the point: without it a 10 GB upload reaching READY is indistinguishable from one that
+// was actually scanned.
+export const MALWARE_SCAN_OUTCOME = {
+  CLEAN: 'CLEAN',
+  SKIPPED_TOO_LARGE: 'SKIPPED_TOO_LARGE',
+} as const;
+
+export type MalwareScanOutcome = (typeof MALWARE_SCAN_OUTCOME)[keyof typeof MALWARE_SCAN_OUTCOME];

--- a/prisma/migrations/20260801090000_add_stored_file_scan_outcome/migration.sql
+++ b/prisma/migrations/20260801090000_add_stored_file_scan_outcome/migration.sql
@@ -1,0 +1,3 @@
+-- ClamAV skips any file past its internal 2 GiB ceiling. Recording the outcome keeps READY from
+-- implying the object was inspected: SKIPPED_TOO_LARGE says plainly that nothing scanned it.
+ALTER TABLE "stored_files" ADD COLUMN "scanOutcome" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,9 @@ model StoredFile {
   etag          String
   status        String    @default("FINALIZING")
   failureReason String?
+  // CLEAN or SKIPPED_TOO_LARGE. Null until verification runs; SKIPPED_TOO_LARGE marks an object
+  // published past the scanner's per-file ceiling, so READY alone never implies it was inspected.
+  scanOutcome   String?
   verifiedAt    DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt


### PR DESCRIPTION
First of two PRs for supporting uploads in the multi-gigabyte range. This one is the scanner; the API change (multipart presign, dropping the staging copy) follows separately.

## The silent half

`verify-upload.handler.ts` did `storage.read()` — the entire object into one Buffer — then scanned it. Two problems at 10 GB:

1. One job holds ten gigabytes of RAM. The worker has no memory limit in compose to stop it.
2. Worse, and quiet: **ClamAV clamps `MaxFileSize` to 2 GiB internally and skips anything larger**, and without `AlertExceedsMax` it reports the skip as *clean* ([clamd.conf](https://manpages.debian.org/unstable/clamav-daemon/clamd.conf.5.en.html), [Cisco-Talos/clamav#809](https://github.com/Cisco-Talos/clamav/issues/809)). A 10 GB upload reached `READY` looking virus-checked.

## What changed

- Scanning **streams** from S3 with backpressure instead of buffering.
- The object size is checked against `MALWARE_SCANNER_MAX_BYTES` (default 2 GiB) **before a byte moves**, and the row records `scanOutcome=SKIPPED_TOO_LARGE`. `READY` alone no longer implies inspection — anything treating it as "virus-checked" must read `scanOutcome`.
- ClamAV is configured with `AlertExceedsMax yes` so a skip can never come back as clean.

Deciding up front rather than letting clamd refuse mid-stream is deliberate, and was driven by a failing test: clamd answers and closes the connection at once, and a write racing that close earns an RST that can discard the reply we need. That path proved unreliable, so the test asserting it was replaced with one asserting we never send at all.

## Verified

- `nx affected -t lint test build typecheck` green; `api:e2e` 67/67 against the new migration
- 29 worker tests including a stub clamd that counts bytes: the streaming path pushes 4 MB across in 64 KB frames, and the oversized path opens no connection at all
- Self-review caught a listener leak this change introduced — `Promise.race` over two one-shot listeners leaves the loser attached, one dangling pair per chunk. Fixed and replaced with an explicit waiter that detaches both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Malware scanning now supports large files through streaming.
  * Files exceeding the configured scan-size limit are published as ready and marked `SKIPPED_TOO_LARGE`.
  * Scan outcomes are recorded for stored files, including clean and skipped results.
  * Added a configurable maximum scan size, defaulting to 2 GiB.

* **Documentation**
  * Documented scan-size limits, skipped-scan behavior, and outcome verification requirements.

* **Tests**
  * Added coverage for streaming scans, size limits, scanner responses, and disabled scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->