### PR TITLE
fix: unbreak the dev docker stack and harden the build gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ pnpm nx affected -t lint test build --base=origin/main
 
 # Inner loop
 ./scripts/dev.sh                   # HOT RELOAD: infra in Docker, api on host (`nx serve` with webpack watch). Pass an app name to reload worker/scheduler instead.
-pnpm nx serve api                  # build once then spawn Node; no file watching. For manual HMR: pnpm nx watch -p api -- pnpm nx run api:build
+pnpm nx serve api                  # same watch loop as dev.sh but without the Docker infra — you supply Postgres/Redis yourself
 pnpm nx test <project>             # vitest
 pnpm nx affected -t lint test build
 pnpm nx run api:e2e                # Testcontainers — Docker required. Set TESTCONTAINERS_REUSE=true to persist containers across runs

--- a/apps/api/src/common/logging/dev-request-logger.spec.ts
+++ b/apps/api/src/common/logging/dev-request-logger.spec.ts
@@ -1,0 +1,137 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerDevRequestLogger } from './dev-request-logger';
+
+type Hook = (req: FastifyRequest, reply: FastifyReply, done: () => void) => void;
+
+function registerHooks() {
+  const hooks = new Map<string, Hook>();
+  const fastify = {
+    addHook: (name: string, fn: Hook) => hooks.set(name, fn),
+  } as unknown as FastifyInstance;
+
+  registerDevRequestLogger(fastify);
+
+  const call = (name: string, req: Partial<FastifyRequest>, reply: Partial<FastifyReply> = {}) => {
+    const done = vi.fn();
+    hooks.get(name)?.(req as FastifyRequest, reply as FastifyReply, done);
+    return done;
+  };
+
+  return { hooks, call };
+}
+
+describe('registerDevRequestLogger', () => {
+  let log: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  const output = () => (log.mock.calls as unknown[][]).map((args) => String(args[0])).join('\n');
+
+  it('registers the three request lifecycle hooks', () => {
+    const { hooks } = registerHooks();
+    expect([...hooks.keys()]).toEqual(['onRequest', 'preHandler', 'onResponse']);
+  });
+
+  // A hook that returns without calling `done` hangs every request, and no assertion on the
+  // logged output would catch it — so check the chain continues on both the logged and skipped path.
+  it.each(['onRequest', 'preHandler', 'onResponse'])('always completes the %s hook', (name) => {
+    const { call } = registerHooks();
+    expect(
+      call(name, { url: '/api/v1/users', method: 'POST', body: { a: 1 } }, { statusCode: 200 }),
+    ).toHaveBeenCalledOnce();
+    expect(
+      call(name, { url: '/metrics', method: 'GET' }, { statusCode: 200 }),
+    ).toHaveBeenCalledOnce();
+  });
+
+  it('logs method and url for a normal request', () => {
+    const { call } = registerHooks();
+    call('onRequest', { url: '/api/v1/users', method: 'GET' });
+    expect(output()).toContain('/api/v1/users');
+    expect(output()).toContain('GET');
+  });
+
+  it('redacts sensitive query values in the logged url', () => {
+    const { call } = registerHooks();
+    call('onRequest', { url: '/api/v1/users?token=supersecret', method: 'GET' });
+    expect(output()).not.toContain('supersecret');
+  });
+
+  it.each(['/api/v1/health/live', '/metrics', '/api/health'])('stays silent for %s', (url) => {
+    const { call } = registerHooks();
+    call('onRequest', { url, method: 'GET' });
+    call('onResponse', { url, method: 'GET' }, { statusCode: 200 });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('logs body field names but never their values', () => {
+    const { call } = registerHooks();
+    call('preHandler', { url: '/api/v1/users', method: 'POST', body: { email: 'a@b.c' } });
+    expect(output()).toContain('email');
+    expect(output()).not.toContain('a@b.c');
+  });
+
+  it('escapes control characters in body keys so they cannot inject ansi sequences', () => {
+    const { call } = registerHooks();
+    call('preHandler', { url: '/api/v1/users', method: 'POST', body: { '[31mred': 1 } });
+    expect(output()).not.toContain('[31m');
+    expect(output()).toContain('\\u001b[31mred');
+  });
+
+  it('truncates the key preview past ten fields', () => {
+    const body = Object.fromEntries(Array.from({ length: 12 }, (_, i) => [`f${i}`, i]));
+    const { call } = registerHooks();
+    call('preHandler', { url: '/api/v1/users', method: 'POST', body });
+    expect(output()).toContain('...+2');
+  });
+
+  it('skips the body hook for reads and for empty bodies', () => {
+    const { call } = registerHooks();
+    call('preHandler', { url: '/api/v1/users', method: 'GET', body: { a: 1 } });
+    call('preHandler', { url: '/api/v1/users', method: 'POST', body: undefined });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('reports a non-object body without inspecting it', () => {
+    const { call } = registerHooks();
+    call('preHandler', { url: '/api/v1/users', method: 'POST', body: 'raw-payload' });
+    expect(output()).toContain('(non-object)');
+    expect(output()).not.toContain('raw-payload');
+  });
+
+  it('reports an empty object body', () => {
+    const { call } = registerHooks();
+    call('preHandler', { url: '/api/v1/users', method: 'POST', body: {} });
+    expect(output()).toContain('(empty)');
+  });
+
+  it.each([
+    [200, '32'],
+    [301, '36'],
+    [404, '33'],
+    [500, '31'],
+  ])('colors status %i by severity', (statusCode, ansi) => {
+    const { call } = registerHooks();
+    call('onResponse', { url: '/api/v1/users', method: 'GET' }, { statusCode });
+    expect(output()).toContain(`[${ansi}m${statusCode}`);
+  });
+
+  it('reports an unknown duration when the request was never timed', () => {
+    const { call } = registerHooks();
+    call('onResponse', { url: '/api/v1/users', method: 'GET' }, { statusCode: 200 });
+    expect(output()).toContain('in ?ms');
+  });
+
+  it('measures duration when the request passed through onRequest', () => {
+    const { call } = registerHooks();
+    const req = { url: '/api/v1/users', method: 'GET' };
+    call('onRequest', req);
+    call('onResponse', req, { statusCode: 200 });
+    expect(output()).toMatch(/in \d+ms/);
+  });
+});

--- a/apps/api/src/common/logging/dev-request-logger.ts
+++ b/apps/api/src/common/logging/dev-request-logger.ts
@@ -47,7 +47,12 @@ function summarizeBody(body: unknown): string {
   if (!body || typeof body !== 'object') return '(non-object)';
   const keys = Object.keys(body);
   if (keys.length === 0) return '(empty)';
-  const preview = keys.slice(0, 10).join(', ');
+  // JSON.stringify escapes control characters — a key like "[31m" would otherwise
+  // inject ANSI sequences into the terminal from attacker-controlled input.
+  const preview = keys
+    .slice(0, 10)
+    .map((key) => JSON.stringify(key))
+    .join(', ');
   return keys.length > 10 ? `{${preview}, ...+${keys.length - 10}}` : `{${preview}}`;
 }
 
@@ -60,28 +65,24 @@ const NOISY_PATHS = ['/api/v1/health', '/metrics', '/api/health'];
 export function registerDevRequestLogger(fastify: FastifyInstance): void {
   const requestTimes = new WeakMap<FastifyRequest, number>();
 
-  // Log request start - runs before everything
-  fastify.addHook('onRequest', (req: FastifyRequest) => {
+  function logRequestStart(req: FastifyRequest): void {
     if (NOISY_PATHS.some((p) => req.url.startsWith(p))) return;
     requestTimes.set(req, performance.now());
 
     const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
     const safeUrl = sanitizeUrlForLogging(req.url) ?? req.url;
     console.log(`${colors.dim}${timestamp}${colors.reset} ${colorMethod(req.method)} ${safeUrl}`);
-  });
+  }
 
-  // Log body field names after parsing (for mutations) - never log values
-  fastify.addHook('preHandler', (req: FastifyRequest) => {
+  function logBodyFields(req: FastifyRequest): void {
     if (NOISY_PATHS.some((p) => req.url.startsWith(p))) return;
     if (!['POST', 'PUT', 'PATCH'].includes(req.method)) return;
     if (!req.body) return;
 
-    const summary = summarizeBody(req.body);
-    console.log(`${colors.dim}            └─ body: ${summary}${colors.reset}`);
-  });
+    console.log(`${colors.dim}            └─ body: ${summarizeBody(req.body)}${colors.reset}`);
+  }
 
-  // Log response - runs after everything, including errors
-  fastify.addHook('onResponse', (req: FastifyRequest, reply: FastifyReply) => {
+  function logResponse(req: FastifyRequest, reply: FastifyReply): void {
     if (NOISY_PATHS.some((p) => req.url.startsWith(p))) return;
 
     const start = requestTimes.get(req);
@@ -91,5 +92,23 @@ export function registerDevRequestLogger(fastify: FastifyInstance): void {
       `${colors.dim}            └─${colors.reset} ${colorStatus(reply.statusCode)} ` +
         `${colors.dim}in ${duration}ms${colors.reset}`,
     );
+  }
+
+  // Fastify only advances the chain once `done` is called, so the logging itself stays in the
+  // helpers above and every hook has exactly one exit path — an early `return` before `done()`
+  // would hang the request instead of skipping the log line.
+  fastify.addHook('onRequest', (req, _reply, done) => {
+    logRequestStart(req);
+    done();
+  });
+
+  fastify.addHook('preHandler', (req, _reply, done) => {
+    logBodyFields(req);
+    done();
+  });
+
+  fastify.addHook('onResponse', (req, reply, done) => {
+    logResponse(req, reply);
+    done();
   });
 }

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -6,12 +6,9 @@ export default defineVitestConfig({
   integrationTests: true,
   testTimeout: 60_000,
   hookTimeout: 60_000,
-  coverageExclude: [
-    'src/main.ts',
-    'src/tracing.ts',
-    'src/common/swagger/**',
-    'src/common/logging/dev-request-logger.ts',
-  ],
+  // Bootstrap-only surfaces: they wire the process together and are exercised by
+  // apps/api/e2e + the CI docker-smoke job, never by unit tests.
+  coverageExclude: ['src/main.ts', 'src/tracing.ts', 'src/common/swagger/**'],
   coverageThresholds: {
     lines: 60,
     functions: 60,

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -92,7 +92,9 @@ services:
     env_file: ../.env
     environment:
       NODE_ENV: development
-      LOG_PRETTY: 'true'
+      # Must stay 'false' in every image: pino-pretty is a devDependency and the images
+      # install --prod, so pino cannot resolve the transport target and dies on boot.
+      LOG_PRETTY: 'false'
       TZ: ${TZ:-UTC}
       # The image only EXPOSEs 9229 and the port is published above — without this the
       # inspector is never actually opened, so attaching silently fails. Bind 0.0.0.0, not
@@ -137,7 +139,7 @@ services:
     env_file: ../.env
     environment:
       NODE_ENV: development
-      LOG_PRETTY: 'true'
+      LOG_PRETTY: 'false'
       TZ: ${TZ:-UTC}
       # .env carries the api's name, which would otherwise label this process as the api.
       OTEL_SERVICE_NAME: nestjs-fastify-worker
@@ -184,7 +186,7 @@ services:
     env_file: ../.env
     environment:
       NODE_ENV: development
-      LOG_PRETTY: 'true'
+      LOG_PRETTY: 'false'
       TZ: ${TZ:-UTC}
       OTEL_SERVICE_NAME: nestjs-fastify-scheduler
       # Container-to-container connection uses service names and internal ports.

--- a/libs/infra/observability/src/lib/pino-logger-config.ts
+++ b/libs/infra/observability/src/lib/pino-logger-config.ts
@@ -60,8 +60,7 @@ export function buildPinoLoggerConfig(overrides: Partial<PinoHttpOptions> = {}):
       mixin: requestContextMixin,
       // Structured logs use a string level label; pino-pretty expects the numeric level.
       formatters: !prettyLogs ? { level: (label) => ({ level: label }) } : undefined,
-      // Dev: disable pino-http access logs — dev-request-logger.ts provides colorful console output.
-      // Prod: log all requests except noisy probes (health, metrics).
+      // Dev access logs come from dev-request-logger.ts instead.
       autoLogging: isProduction ? { ignore: isNoisyProbe } : false,
       // Request essentials only, not the full header/body dump — smaller lines, smaller PII surface.
       // `remoteAddress` is the raw TCP peer (pod IP behind a proxy); pair with X-Forwarded-For

--- a/libs/infra/storage/src/lib/s3-storage.adapter.spec.ts
+++ b/libs/infra/storage/src/lib/s3-storage.adapter.spec.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ConfigService } from '@nestjs/config';
+import type { DomainErrorKind } from '@nestjs-fastify-nx/core';
 import { DomainException } from '@nestjs-fastify-nx/core';
+import { ERROR_CODES } from '@nestjs-fastify-nx/contracts';
 import {
   DeleteObjectCommand,
   CopyObjectCommand,
@@ -13,6 +15,20 @@ import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
 import { S3StorageAdapter } from './s3-storage.adapter';
 
 type PostParams = { Fields?: Record<string, string>; Conditions?: unknown[] };
+
+// `toBeInstanceOf(DomainException)` alone still passes when the adapter reports the wrong kind or
+// code, and the transport maps exactly those two fields onto a status the client keys its retry on.
+async function expectDomainFailure(
+  promise: Promise<unknown>,
+  expected: { kind: DomainErrorKind; code: string; permanent: boolean },
+): Promise<void> {
+  await expect(promise).rejects.toBeInstanceOf(DomainException);
+  const error = await promise.then(
+    () => undefined,
+    (caught: DomainException) => caught,
+  );
+  expect({ kind: error?.kind, code: error?.code, permanent: error?.permanent }).toEqual(expected);
+}
 
 // The adapter keeps its clients private, and the SDK normalises each config value into either a
 // literal or a provider function — so read it back the same way the SDK would.
@@ -130,11 +146,13 @@ describe('S3StorageAdapter', () => {
   });
 
   describe('upload', () => {
-    it('rejects an empty body with DomainException (no S3 call)', async () => {
+    it('rejects an empty body as a permanent validation failure (no S3 call)', async () => {
       const send = mockSend(adapter);
-      await expect(adapter.upload('uploads/x', Buffer.alloc(0))).rejects.toBeInstanceOf(
-        DomainException,
-      );
+      await expectDomainFailure(adapter.upload('uploads/x', Buffer.alloc(0)), {
+        kind: 'validation',
+        code: ERROR_CODES.STORAGE_BODY_EMPTY,
+        permanent: true,
+      });
       expect(send).not.toHaveBeenCalled();
     });
 
@@ -154,12 +172,14 @@ describe('S3StorageAdapter', () => {
       });
     });
 
-    it('wraps S3 errors as DomainException with unavailable kind', async () => {
+    it('wraps S3 errors as a retryable unavailable failure', async () => {
       const send = mockSend(adapter);
       send.mockRejectedValueOnce(new Error('NoSuchBucket'));
-      await expect(adapter.upload('uploads/x', Buffer.from('p'))).rejects.toBeInstanceOf(
-        DomainException,
-      );
+      await expectDomainFailure(adapter.upload('uploads/x', Buffer.from('p')), {
+        kind: 'unavailable',
+        code: ERROR_CODES.STORAGE_UPLOAD_FAILED,
+        permanent: false,
+      });
     });
   });
 

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -12,6 +12,7 @@
 #   NO_CACHE=1       full clean rebuild (default: incremental)
 #   BUILD_PARALLEL=0 build services serially on memory-constrained hosts
 #   BUILD_PARALLEL_LIMIT=2 cap concurrent Compose build tasks (default: 2)
+#   WAIT_TIMEOUT=180 seconds to wait for every started service to become healthy
 #
 # Security scanning (Trivy/SBOM/etc.) is intentionally NOT run here — it lives in
 # CI (.github/workflows). Local builds stay fast; run scripts/security/*.sh
@@ -139,9 +140,13 @@ done
 # API_REPLICAS / WORKER_REPLICAS only take effect in Swarm (deploy.replicas is
 # ignored by plain `docker compose up`); the passthrough keeps them visible in
 # the process environment without changing dev behaviour.
+#
+# --wait is the gate for worker/scheduler: the HTTP smoke test below only covers api, so
+# without it a crash-looping worker still exits 0.
 # shellcheck disable=SC2086
 if ! API_REPLICAS="${API_REPLICAS:-1}" WORKER_REPLICAS="${WORKER_REPLICAS:-1}" \
-  docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate --remove-orphans "${SERVICES[@]}"; then
+  docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate --remove-orphans \
+  --wait --wait-timeout "${WAIT_TIMEOUT:-180}" "${SERVICES[@]}"; then
   sec::err "Compose startup failed. Container status and recent dependency logs follow."
   docker compose "${COMPOSE_ARGS[@]}" ps -a || true
   docker compose "${COMPOSE_ARGS[@]}" logs --tail=100 \

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -58,7 +58,9 @@ export function createVitestConfig(options: VitestProjectOptions) {
       globals: true,
       environment: 'node',
       include: includePattern,
-      exclude: isIntegrationRun ? [] : ['**/*.integration.spec.*'],
+      // The include glob admits both `*.integration.ts` and `*.integration.spec.ts`; excluding
+      // only the latter would run Testcontainers suites in the plain `test` target.
+      exclude: isIntegrationRun ? [] : ['**/*.integration.*'],
       reporters: ['default'],
       setupFiles: [`${relativePath}vitest.setup.ts`],
       passWithNoTests: true,


### PR DESCRIPTION
## Why

`./scripts/build-dev.sh` produced a stack where **all three apps were dead**, and the script still reported success for two independent reasons.

### 1. Every container crash-looped on boot

PR #146 flipped `LOG_PRETTY` from `'false'` to `'true'` for api, worker and scheduler in `compose.dev.yml`. Every image runs `pnpm install --prod` and `pino-pretty` is a `devDependency`, so pino could not resolve the transport target:

```
ERROR [ExceptionHandler] Error: unable to determine transport target for "pino-pretty"
    at fixTarget (pino/lib/transport.js:282:13)
```

Moving `pino-pretty` into `dependencies` does **not** fix this — Nx `generatePackageJson` walks the import graph, and `'pino-pretty'` only ever appears as a string, so it never lands in `dist/apps/*/package.json`. Restoring `LOG_PRETTY=false` is the fix; containers were always meant to emit structured JSON (`docs/environment.md` already documented exactly that).

### 2. Once a container did boot, every request hung

`dev-request-logger.ts` registered **sync** Fastify hooks that never called `done`. Fastify only advances the chain on a returned promise or a `done()` call, so `/api/v1/health/live` never answered — the container accepted the TCP connection and then went silent.

### 3. The gate could not see either failure

`build-dev.sh` only smoke-tested the api over HTTP, so a crash-looping worker/scheduler exited 0. It now boots with `--wait`, the same mechanism the CI `docker-smoke` job uses — that is what caught the dead worker locally.

## Also addressed (review feedback)

| Item | Change |
| --- | --- |
| Log injection (CWE-117) | Body field names go through `JSON.stringify`, so a crafted key cannot emit ANSI sequences |
| Logger had no tests | 20 unit tests added; the file is no longer excluded from coverage |
| S3 specs too weak | Assert `kind` + `code` + `permanent`, not just `instanceof DomainException` |
| Integration test discovery | Exclude every `*.integration.*` form, not only `*.integration.spec.*` |
| Stale doc | `pnpm nx serve api` does watch files (`watch: true`) |

### Deliberately not changed

- **`finalize()` conditional-copy mapping** — `ConfirmUploadHandler` catches every finalize error and rethrows `commitFailed()`, so re-classifying `PreconditionFailed` in the adapter alone changes nothing observable. Doing it properly means deciding the retry semantics of upload confirm; that belongs in its own PR.
- **Percent-encoding `DATABASE_URL` in `compose.dev.yml`** — dev defaults are alphanumeric, and the production path builds its DSN through `injectDatabasePassword`, which already percent-encodes.
- **`root: rootDir` in `vitest.shared.ts`** — `rootDir` is a repo-relative string; every path in that factory (`setupFiles`, coverage `reportsDirectory`) is already computed against it. Setting `root` would double-resolve them.

## Verification

Run locally, not inferred:

- `./scripts/build-dev.sh` → **exit 0**; worker + scheduler `(healthy)`, api answers `200` on `/api/v1/health/live`, `/api/v1/health/ready` and `/docs-json`
- Dev logger observed end-to-end in the container, with keys escaped and no hang:
  ```
  01:55:42 POST    /api/v1/upload/presign
              └─ body: {"email", "password"}
              └─ 401 in 10ms
  ```
- `pnpm nx affected -t lint typecheck test build --base=origin/main --skip-nx-cache` → all 20 projects pass
- `pnpm nx run api:e2e` → 67 passed
- `pnpm nx run api:test -- --coverage` → 78.8% stmts / 73.8% branches / 72.7% funcs / 80.2% lines

Replaces #148.