### PR TITLE
chore(security): ignore unreachable image-size dos advisories in dep-scan

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,22 @@
+[[IgnoredVulns]]
+id = "GHSA-5p2g-fcmc-qvqq"
+ignoreUntil = 2026-11-07
+reason = """
+image-size@0.5.5 DoS (infinite loop parsing JXL/HEIF) — CVE-2025-71329.
+No fixed version exists upstream (through 2.0.2, still unpatched as of this ignore).
+image-size is an optional dependency of less@4.5.1, pulled in transitively by
+less-loader via @nx/webpack (build-tooling devDependency only). This repo has
+no .less files, so less-loader/less/image-size never execute — the parser is
+unreachable. Re-evaluate when upstream ships a fix or this ignore expires.
+"""
+
+[[IgnoredVulns]]
+id = "GHSA-w3rx-r6r6-pgpr"
+ignoreUntil = 2026-11-07
+reason = """
+image-size@0.5.5 DoS (infinite loop parsing ICNS) — CVE-2025-71330.
+Same unreachable build-tooling-only dependency chain as GHSA-5p2g-fcmc-qvqq
+(less -> less-loader -> @nx/webpack devDependency; no .less files in repo).
+No fixed version exists upstream. Re-evaluate when upstream ships a fix or
+this ignore expires.
+"""


### PR DESCRIPTION
## Summary
- `dep-scan` (OSV-Scanner) started failing on every PR after GHSA-5p2g-fcmc-qvqq / GHSA-w3rx-r6r6-pgpr (CVE-2025-71329/71330, both High CVSS 8.7) were published against `image-size@0.5.5` on 2026-08-07.
- `image-size` is an optional dependency of `less@4.5.1`, pulled in transitively by `less-loader` via `@nx/webpack` (a build-tooling devDependency). This repo has no `.less` files, so `less`/`less-loader`/`image-size` never execute — the vulnerable JXL/HEIF/ICNS parsers are unreachable.
- No fixed version exists upstream for either advisory (`first_patched_version: null`), so bumping is not currently possible.
- Adds `osv-scanner.toml` at the repo root with a scoped, dated (`ignoreUntil = 2026-11-07`) ignore for both GHSA IDs, with the reasoning above recorded inline so it gets re-evaluated rather than silently ignored forever.

## Test plan
- [x] Verified via `pnpm-lock.yaml` that `image-size@0.5.5` resolves only through `less` -> `less-loader` -> `@nx/webpack`, and confirmed no `.less` files exist in the repo.
- [ ] Confirm `dep-scan` check passes on this PR now that `osv-scanner.toml` is present.
- [ ] Confirm PR #152 (Dependabot, currently blocked by the same failure) goes green once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added documented exceptions for two known denial-of-service vulnerabilities in a transitive build-tooling dependency.
  * Exceptions are set to expire on November 7, 2026, and apply only where the vulnerable functionality is not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->