### PR TITLE
test(idempotency): pin the tenant-context replay contract and document the gap

### DIFF
--- a/apps/api/src/common/idempotency/register-idempotency.spec.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.spec.ts
@@ -441,17 +441,18 @@ describe('registerIdempotency', () => {
 
   it('replays across an active-organization switch because tenant context is outside the fingerprint', async () => {
     const { app, callCount } = await buildApp(redis);
+    const sessionCookie = { cookie: 'better-auth.session_token=test-session-1' };
 
     await app.inject({
       method: 'POST',
       url: '/api/v1/echo',
-      headers: { ...KEY_HEADER, 'x-active-organization-id': 'org-a' },
+      headers: { ...KEY_HEADER, ...sessionCookie, 'x-active-organization-id': 'org-a' },
       payload: { a: 1 },
     });
     const second = await app.inject({
       method: 'POST',
       url: '/api/v1/echo',
-      headers: { ...KEY_HEADER, 'x-active-organization-id': 'org-b' },
+      headers: { ...KEY_HEADER, ...sessionCookie, 'x-active-organization-id': 'org-b' },
       payload: { a: 1 },
     });
 

--- a/apps/api/src/common/idempotency/register-idempotency.spec.ts
+++ b/apps/api/src/common/idempotency/register-idempotency.spec.ts
@@ -439,6 +439,26 @@ describe('registerIdempotency', () => {
     expect(res.json().code).toBe('idempotency_key_mismatch');
   });
 
+  it('replays across an active-organization switch because tenant context is outside the fingerprint', async () => {
+    const { app, callCount } = await buildApp(redis);
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/echo',
+      headers: { ...KEY_HEADER, 'x-active-organization-id': 'org-a' },
+      payload: { a: 1 },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/echo',
+      headers: { ...KEY_HEADER, 'x-active-organization-id': 'org-b' },
+      payload: { a: 1 },
+    });
+
+    expect(second.headers['idempotent-replayed']).toBe('true');
+    expect(callCount()).toBe(1);
+  });
+
   it('returns 409 while an identical request is still in flight', async () => {
     const errors: string[] = [];
     let release!: () => void;

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -298,7 +298,7 @@ the status after the interceptor chain.
 - **Invariant:** `IDEMPOTENCY_LOCK_TTL_SECONDS * 1000 > HTTP_REQUEST_TIMEOUT_MS` (validated
   on boot) so a finishing request always still owns its lock — preventing a lock-steal.
 - **Known gap — tenant context is outside the fingerprint.** The fingerprint covers
-  method + URL + body only; the active organization lives server-side on the session row,
+  `method + url + body` only; the active organization lives server-side on the session row,
   which the Fastify-layer plugin cannot see (it runs before the auth guard resolves the
   membership). A retry sent after switching the active organization therefore replays the
   previous organization's response instead of executing against the new one. Until this is

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -297,6 +297,13 @@ the status after the interceptor chain.
   back on error, leaving no committed side effect to duplicate.
 - **Invariant:** `IDEMPOTENCY_LOCK_TTL_SECONDS * 1000 > HTTP_REQUEST_TIMEOUT_MS` (validated
   on boot) so a finishing request always still owns its lock — preventing a lock-steal.
+- **Known gap — tenant context is outside the fingerprint.** The fingerprint covers
+  method + URL + body only; the active organization lives server-side on the session row,
+  which the Fastify-layer plugin cannot see (it runs before the auth guard resolves the
+  membership). A retry sent after switching the active organization therefore replays the
+  previous organization's response instead of executing against the new one. Until this is
+  addressed (options: resolve the membership in the plugin, or add an org-changed marker to
+  the fingerprint), clients that switch organizations should rotate the Idempotency-Key.
 
 **Request timeout** — a global `TimeoutInterceptor` (`HTTP_REQUEST_TIMEOUT_MS`, default
 30s) aborts a handler that runs too long with `504 request_timeout`. WebSocket handlers


### PR DESCRIPTION
Closes #166

## Summary

- Pins the current tenant-context contract with a dedicated spec case: two requests under one session that differ only in active organization produce a replay, because the fingerprint covers `method + url + body` only and the plugin cannot see session-row state.
- Documents the limitation and its client-side mitigation (rotate the key on org switch) in `docs/code-standards.md → HTTP Idempotency`, alongside the options for a future structural fix (resolve membership in the plugin, or add an org-changed marker to the fingerprint).

No runtime behavior changes.

## Testing

- `pnpm nx test api -- register-idempotency`: 25 passed (24 existing + 1 new)
- `pnpm nx affected -t lint typecheck --base=origin/main`: green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented that idempotent retries may replay a previous response when the active organization changes.
  * Added guidance to rotate the idempotency key when switching organizations until context-aware handling is available.

* **Tests**
  * Added coverage confirming requests with the same session, idempotency key, and payload replay the original response even when the active organization changes.
  * Verified the request handler runs only once and replayed responses are identified accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->