### PR TITLE
refactor(users): compose cursor filters without overwriting the organization scope

### DIFF
--- a/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.integration.spec.ts
+++ b/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.integration.spec.ts
@@ -223,5 +223,87 @@ describe('PrismaUserRepository (integration)', () => {
       expect(underscoreResult.items).toHaveLength(1);
       expect(underscoreResult.items[0].email.toString()).toBe('has_underscore@test.com');
     });
+
+    it('filters by membership role within the organization', async () => {
+      const admin = UserFactory.create({ email: 'admin@test.com' });
+      await repository.save(admin);
+      await prismaService.db.member.create({
+        data: { organizationId: ORG_ID, userId: admin.id, role: 'admin' },
+      });
+      await saveAsMember(UserFactory.create({ email: 'member@test.com' }));
+
+      const result = await repository.findAllCursor({
+        organizationId: ORG_ID,
+        limit: 10,
+        role: 'admin',
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].email.toString()).toBe('admin@test.com');
+    });
+
+    it('keeps the organization scope when role and search are combined', async () => {
+      const otherOrgId = '019dd1a5-9235-70db-8d57-54ef90300003';
+      await prismaService.db.organization.create({
+        data: { id: otherOrgId, name: 'Other Role Org', slug: 'other-role-org' },
+      });
+
+      const mine = UserFactory.create({
+        email: 'admin-mine@test.com',
+        name: 'Shared Admin',
+      });
+      await repository.save(mine);
+      await prismaService.db.member.create({
+        data: { organizationId: ORG_ID, userId: mine.id, role: 'admin' },
+      });
+
+      const theirs = UserFactory.create({
+        email: 'admin-theirs@test.com',
+        name: 'Shared Admin',
+      });
+      await repository.save(theirs);
+      await prismaService.db.member.create({
+        data: { organizationId: otherOrgId, userId: theirs.id, role: 'admin' },
+      });
+
+      const result = await repository.findAllCursor({
+        organizationId: ORG_ID,
+        limit: 10,
+        role: 'admin',
+        search: 'Shared Admin',
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe(mine.id);
+    });
+
+    it('paginates role-filtered results with the same cursor semantics', async () => {
+      for (let i = 0; i < 3; i++) {
+        const admin = UserFactory.create({ email: `paged-admin${i}@test.com` });
+        await repository.save(admin);
+        await prismaService.db.member.create({
+          data: { organizationId: ORG_ID, userId: admin.id, role: 'admin' },
+        });
+      }
+      await saveAsMember(UserFactory.create({ email: 'paged-member@test.com' }));
+
+      const page1 = await repository.findAllCursor({
+        organizationId: ORG_ID,
+        limit: 2,
+        role: 'admin',
+      });
+      expect(page1.items).toHaveLength(2);
+      expect(page1.hasMore).toBe(true);
+
+      const last = page1.items[page1.items.length - 1];
+      const page2 = await repository.findAllCursor({
+        organizationId: ORG_ID,
+        limit: 2,
+        role: 'admin',
+        startingAfter: { createdAt: last.createdAt, id: last.id },
+      });
+      expect(page2.items).toHaveLength(1);
+      expect(page2.hasMore).toBe(false);
+    });
   });
 }, 90_000);

--- a/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.ts
+++ b/libs/modules/users/src/infrastructure/repositories/prisma-user.repository.ts
@@ -142,9 +142,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
   async findAllCursor(options: FindAllCursorOptions): Promise<FindAllCursorResult> {
     const { organizationId, startingAfter, limit, role, status, search } = options;
     const where: Prisma.UserWhereInput = {
-      memberships: { some: { organizationId } },
+      memberships: { some: { organizationId, ...(role ? { role } : {}) } },
     };
-    if (role) where.memberships = { some: { organizationId, role } };
     if (status) where.status = status;
     if (search) {
       const escapedSearch = escapeLikePattern(search);


### PR DESCRIPTION
Closes #167

## Summary

`PrismaUserRepository.findAllCursor` assigned `where.memberships` twice — once for the tenant scope, once more when a role filter was present. Correct today, but a future filter added after the role branch that writes `where.memberships` again would silently wipe either the tenant scope or the role. The memberships join is the only tenant guard on `users` (no RLS behind it), so the shape is hardened here: the membership filter is composed in a single expression with nothing left to overwrite.

## Tests

Three new integration cases on real Postgres (Testcontainers):

- **role filter** returns only matching members within the organization
- **role + search combined** keeps cross-tenant isolation — two users sharing the same display name across different organizations, only the caller's org member is returned
- **role + cursor pagination** — page boundaries and `hasMore` unchanged under the combined filter

Existing suite (tenant isolation, search literal `%`/`_`, 30-user pagination walk) still green.

## Testing

- `pnpm nx test modules-users -- integration`: 15 passed
- `pnpm nx affected -t lint typecheck --base=origin/main`: green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of user listing filters by role, search term, organization, and cursor-based pagination.

* **Tests**
  * Added integration coverage for role filtering, combined filters, organization isolation, and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->