### PR TITLE
fix(security): prevent admin role privilege escalation and purge soft-deleted infected uploads

### DIFF
--- a/libs/infra/auth/src/lib/organization-access-control.spec.ts
+++ b/libs/infra/auth/src/lib/organization-access-control.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { organizationRoles } from './organization-access-control';
+
+describe('organizationAccessControl role definitions', () => {
+  it('grants full access control management (create, read, update, delete) to owner role', () => {
+    const ownerRole = organizationRoles.owner as { statements?: Record<string, string[]> };
+    expect(ownerRole.statements?.['ac']).toEqual(['create', 'read', 'update', 'delete']);
+  });
+
+  it('restricts access control management to read-only for admin role to prevent privilege escalation', () => {
+    const adminRole = organizationRoles.admin as { statements?: Record<string, string[]> };
+    expect(adminRole.statements?.['ac']).toEqual(['read']);
+  });
+
+  it('does not grant access control management to member, billing, or viewer roles', () => {
+    const memberRole = organizationRoles.member as { statements?: Record<string, string[]> };
+    const billingRole = organizationRoles.billing as { statements?: Record<string, string[]> };
+    const viewerRole = organizationRoles.viewer as { statements?: Record<string, string[]> };
+
+    expect(memberRole.statements?.['ac']).toBeUndefined();
+    expect(billingRole.statements?.['ac']).toBeUndefined();
+    expect(viewerRole.statements?.['ac']).toBeUndefined();
+  });
+});

--- a/libs/infra/auth/src/lib/organization-access-control.ts
+++ b/libs/infra/auth/src/lib/organization-access-control.ts
@@ -33,6 +33,7 @@ function roleFor(role: SystemRole) {
   // Owner and admin also administer the organization itself, which lives in Better Auth's own
   // statements; member-level roles get the application permissions only.
   const administers = role === SYSTEM_ROLES.OWNER || role === SYSTEM_ROLES.ADMIN;
+  const isOwner = role === SYSTEM_ROLES.OWNER;
   return organizationAccessControl.newRole({
     ...appPermissions,
     ...(administers
@@ -40,7 +41,7 @@ function roleFor(role: SystemRole) {
           member: [...(appPermissions['member'] ?? []), 'create', 'update', 'delete'],
           invitation: [...(appPermissions['invitation'] ?? []), 'create', 'cancel'],
           team: [...(appPermissions['team'] ?? []), 'create', 'update', 'delete'],
-          ac: ['create', 'read', 'update', 'delete'],
+          ac: isOwner ? ['create', 'read', 'update', 'delete'] : ['read'],
         }
       : {}),
   } as never);

--- a/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.spec.ts
+++ b/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.spec.ts
@@ -61,6 +61,24 @@ describe('PrismaStoredFileRepository — compare-and-set', () => {
     });
   });
 
+  it('allows transition to REJECTED even if the record was soft-deleted to ensure infected files are purged', async () => {
+    const { repository, storedFile } = build();
+
+    await repository.transitionByKey(
+      'k',
+      STORED_FILE_STATUS.VERIFYING,
+      STORED_FILE_STATUS.REJECTED,
+      {
+        failureReason: 'Malware detected',
+      },
+    );
+
+    expect(storedFile.updateMany).toHaveBeenCalledWith({
+      where: { key: 'k', status: STORED_FILE_STATUS.VERIFYING },
+      data: { status: STORED_FILE_STATUS.REJECTED, failureReason: 'Malware detected' },
+    });
+  });
+
   // Deleting by id alone would remove a row another execution had already moved on from.
   it('deletes only while the row still holds the expected status', async () => {
     const { repository, storedFile } = build();

--- a/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.spec.ts
+++ b/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.spec.ts
@@ -61,6 +61,19 @@ describe('PrismaStoredFileRepository — compare-and-set', () => {
     });
   });
 
+  it('allows ID transition to REJECTED even if the record was soft-deleted', async () => {
+    const { repository, storedFile } = build();
+
+    await repository.transition('f1', STORED_FILE_STATUS.VERIFYING, STORED_FILE_STATUS.REJECTED, {
+      failureReason: 'Malware detected',
+    });
+
+    expect(storedFile.updateMany).toHaveBeenCalledWith({
+      where: { id: 'f1', status: STORED_FILE_STATUS.VERIFYING },
+      data: { status: STORED_FILE_STATUS.REJECTED, failureReason: 'Malware detected' },
+    });
+  });
+
   it('allows transition to REJECTED even if the record was soft-deleted to ensure infected files are purged', async () => {
     const { repository, storedFile } = build();
 

--- a/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts
+++ b/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService, type TransactionClient } from '@nestjs-fastify-nx/infra-database';
-import type { StoredFileStatus } from '@nestjs-fastify-nx/shared';
+import { STORED_FILE_STATUS, type StoredFileStatus } from '@nestjs-fastify-nx/shared';
 import { StoredFile, type StoredFileProps } from '../../domain/entities/stored-file.entity';
 import type {
   StoredFileRepositoryPort,
@@ -73,10 +73,14 @@ export class PrismaStoredFileRepository implements StoredFileRepositoryPort {
     to: StoredFileStatus,
     fields?: StoredFileTransitionFields,
   ): Promise<boolean> {
+    const where =
+      to === STORED_FILE_STATUS.REJECTED
+        ? { id, status: from }
+        : { id, status: from, deletedAt: null };
     const result = await this.run(
       (client) =>
         client.storedFile.updateMany({
-          where: { id, status: from, deletedAt: null },
+          where,
           data: { status: to, ...fields },
         }),
       { readOnly: false },
@@ -90,10 +94,14 @@ export class PrismaStoredFileRepository implements StoredFileRepositoryPort {
     to: StoredFileStatus,
     fields?: StoredFileTransitionFields,
   ): Promise<boolean> {
+    const where =
+      to === STORED_FILE_STATUS.REJECTED
+        ? { key, status: from }
+        : { key, status: from, deletedAt: null };
     const result = await this.run(
       (client) =>
         client.storedFile.updateMany({
-          where: { key, status: from, deletedAt: null },
+          where,
           data: { status: to, ...fields },
         }),
       { readOnly: false },

--- a/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts
+++ b/libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts
@@ -73,10 +73,10 @@ export class PrismaStoredFileRepository implements StoredFileRepositoryPort {
     to: StoredFileStatus,
     fields?: StoredFileTransitionFields,
   ): Promise<boolean> {
-    const where =
-      to === STORED_FILE_STATUS.REJECTED
-        ? { id, status: from }
-        : { id, status: from, deletedAt: null };
+    const allowDeleted =
+      to === STORED_FILE_STATUS.REJECTED &&
+      (from === STORED_FILE_STATUS.FINALIZING || from === STORED_FILE_STATUS.VERIFYING);
+    const where = allowDeleted ? { id, status: from } : { id, status: from, deletedAt: null };
     const result = await this.run(
       (client) =>
         client.storedFile.updateMany({
@@ -94,10 +94,10 @@ export class PrismaStoredFileRepository implements StoredFileRepositoryPort {
     to: StoredFileStatus,
     fields?: StoredFileTransitionFields,
   ): Promise<boolean> {
-    const where =
-      to === STORED_FILE_STATUS.REJECTED
-        ? { key, status: from }
-        : { key, status: from, deletedAt: null };
+    const allowDeleted =
+      to === STORED_FILE_STATUS.REJECTED &&
+      (from === STORED_FILE_STATUS.FINALIZING || from === STORED_FILE_STATUS.VERIFYING);
+    const where = allowDeleted ? { key, status: from } : { key, status: from, deletedAt: null };
     const result = await this.run(
       (client) =>
         client.storedFile.updateMany({


### PR DESCRIPTION
### Summary

This PR addresses two critical security and consistency issues across authorization and file quarantine lifecycles:
1. Prevents privilege escalation where members with the `admin` role could create dynamic custom roles granting `organization:delete` via Better Auth's `/organization/create-role` endpoint.
2. Fixes a race condition in `VerifyUploadHandler` where infected files were not purged from S3 if a user soft-deleted the file record concurrently while verification was running.

---

### Motivation & Root Cause

#### 1. Privilege Escalation via Dynamic Role Creation
- In `permissions.ts`, `ADMIN_PERMISSIONS` explicitly excludes `organization:delete` (`ALL_PERMISSIONS.filter((p) => p !== PERMISSIONS.ORGANIZATION_DELETE)`).
- However, in `organization-access-control.ts`, the `ac` statement granted full access control permissions (`['create', 'read', 'update', 'delete']`) to both `owner` and `admin`.
- Because `PostgresPbacAdapter` grants any valid permissions defined in custom roles in `organization_roles`, an `admin` could create a custom role with `{ "organization": ["delete"] }` and assign it to themselves, effectively bypassing the role boundary.

#### 2. S3 Quarantine Retention on Soft-Deleted Files
- In `VerifyUploadHandler`, when a file is flagged as `infected`, the handler calls `this.reject()`, which performs a compare-and-set via `transitionByKey(key, 'VERIFYING', 'REJECTED')`.
- If the owner issued `DELETE /api/v1/upload/:id` while the background scanner was running, `softDelete` set `deletedAt = NOW()`.
- The repository previously enforced `deletedAt: null` on all transitions, causing the CAS update to affect 0 rows (`claimed = false`). Consequently, `this.reject()` skipped `storage.delete(key, bucket)`, leaving infected binaries retained in S3 until the 30-day purge cycle.

---

### Changes

- **`libs/infra/auth/src/lib/organization-access-control.ts`**:
  - Restricts the `ac` statement to `['read']` for `admin` roles, reserving `['create', 'read', 'update', 'delete']` strictly for `owner`.
- **`libs/infra/auth/src/lib/organization-access-control.spec.ts`**:
  - Added unit test suite covering role access control statements for all system roles.
- **`libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.ts`**:
  - Relaxed `deletedAt: null` requirement when transitioning to `REJECTED` state so that quarantine rejection can claim and purge soft-deleted records.
- **`libs/modules/upload/src/infrastructure/repositories/prisma-stored-file.repository.spec.ts`**:
  - Added regression test asserting that transitions to `REJECTED` succeed regardless of `deletedAt`.

---

### Verification

- `pnpm nx test infra-auth` (20/20 passed)
- `pnpm nx test modules-upload` (48/48 passed)
- `pnpm nx affected -t lint test build --base=origin/main` (All affected targets passed)
- `pnpm nx run-many -t typecheck` (22/22 projects passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected access permissions so administrators have read-only access control permissions, while owners retain full access.
  * Fixed rejected file processing so soft-deleted files can transition to a rejected state with a failure reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->