### PR TITLE
perf(test): cut the e2e suite from 126s to ~20s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,16 +97,16 @@ jobs:
           fi
 
       - name: Format check
-        run: pnpm nx format:check --base=$NX_BASE --head=$NX_HEAD
+        run: pnpm nx format:check --base="$NX_BASE" --head="$NX_HEAD"
 
       # One task graph instead of three sequential ones: as separate steps, the slowest lint task
       # had to finish before the first typecheck started, leaving the runner idle at each boundary.
       # `test` stays on its own because `-- --coverage` would be forwarded to every target.
       - name: Lint, typecheck and build affected
-        run: pnpm nx affected --targets=lint,typecheck,build --base=$NX_BASE --head=$NX_HEAD --parallel=3
+        run: pnpm nx affected --targets=lint,typecheck,build --base="$NX_BASE" --head="$NX_HEAD" --parallel=3
 
       - name: Unit test affected
-        run: pnpm nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --exclude="*-e2e" --parallel=3 -- --coverage
+        run: pnpm nx affected --target=test --base="$NX_BASE" --head="$NX_HEAD" --exclude="*-e2e" --parallel=3 -- --coverage
 
   # `nx build` emits dist but never boots it, so runtime-only regressions slip
   # through every job above — an swc transpile target that breaks `class extends`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,17 +99,14 @@ jobs:
       - name: Format check
         run: pnpm nx format:check --base=$NX_BASE --head=$NX_HEAD
 
-      - name: Lint affected
-        run: pnpm nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel=3
-
-      - name: Typecheck affected
-        run: pnpm nx affected --target=typecheck --base=$NX_BASE --head=$NX_HEAD --parallel=3
+      # One task graph instead of three sequential ones: as separate steps, the slowest lint task
+      # had to finish before the first typecheck started, leaving the runner idle at each boundary.
+      # `test` stays on its own because `-- --coverage` would be forwarded to every target.
+      - name: Lint, typecheck and build affected
+        run: pnpm nx affected --targets=lint,typecheck,build --base=$NX_BASE --head=$NX_HEAD --parallel=3
 
       - name: Unit test affected
         run: pnpm nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --exclude="*-e2e" --parallel=3 -- --coverage
-
-      - name: Build affected
-        run: pnpm nx affected --target=build --base=$NX_BASE --head=$NX_HEAD --parallel=3
 
   # `nx build` emits dist but never boots it, so runtime-only regressions slip
   # through every job above — an swc transpile target that breaks `class extends`,

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,6 +31,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        # Same trade as libs/testing's Testcontainers config: a CI database that is destroyed with
+        # the job has nothing to recover, so the WAL fsync on every TRUNCATE is pure cost.
+        command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off
 
       redis-cache:
         image: redis:8-alpine
@@ -69,6 +72,13 @@ jobs:
       REDIS_CACHE_PORT: 6379
       REDIS_QUEUE_HOST: localhost
       REDIS_QUEUE_PORT: 6380
+      # The e2e global setup boots its own Postgres + Redis through Testcontainers unless all three
+      # are supplied. This job already runs both as service containers, so pointing the suite at
+      # them removes a duplicate container startup from every run. Nothing else is shared: the
+      # suite still deploys migrations, provisions the NOBYPASSRLS role and truncates per test.
+      E2E_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/nestjs_test_db
+      E2E_REDIS_HOST: localhost
+      E2E_REDIS_PORT: 6379
       # Better Auth replaces the legacy JWT setup; only one secret is needed.
       BETTER_AUTH_SECRET: integration-better-auth-secret-min-32-chars-long
       STORAGE_ENDPOINT: http://localhost:9000

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,9 @@ jobs:
           --health-retries 5
         # Same trade as libs/testing's Testcontainers config: a CI database that is destroyed with
         # the job has nothing to recover, so the WAL fsync on every TRUNCATE is pure cost.
+        # actionlint's service schema does not list `command` and flags it, but the runner does
+        # honour it — verified in the job log, which shows `docker create ... postgres:18-alpine
+        # postgres -c fsync=off …`. The redis-queue and minio services below rely on it too.
         command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off
 
       redis-cache:
@@ -118,7 +121,7 @@ jobs:
         # inferred @nx/vitest target runs vitest directly, which has no Jest-style
         # `--testPathPattern`. Only integration test files match; unit-only projects
         # match nothing and pass via `passWithNoTests`.
-        run: pnpm nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --parallel=1 -- integration
+        run: pnpm nx affected --target=test --base="$NX_BASE" --head="$NX_HEAD" --parallel=1 -- integration
 
       - name: E2E tests
-        run: pnpm nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --parallel=1
+        run: pnpm nx affected --target=e2e --base="$NX_BASE" --head="$NX_HEAD" --parallel=1

--- a/apps/api/e2e/api-client-contract.e2e-spec.ts
+++ b/apps/api/e2e/api-client-contract.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createTestApp, cookieHeaderFromSetCookies, type TestAppContext } from './test-app';
 
@@ -18,10 +18,6 @@ describe('api-client contract — UserProfileResponseDto', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/e2e/auth.e2e-spec.ts
+++ b/apps/api/e2e/auth.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
 import {
@@ -17,10 +17,6 @@ describe('Auth E2E (Better Auth)', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/e2e/error-docs.e2e-spec.ts
+++ b/apps/api/e2e/error-docs.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import request from 'supertest';
 import { ERROR_CATALOG_ENTRIES, errorTypeSlug } from '@nestjs-fastify-nx/contracts';
 import { createTestApp, type TestAppContext } from './test-app';
@@ -11,10 +11,6 @@ describe('Error type documentation E2E', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   it('serves the type URI advertised by a real error response', async () => {
     const problem = await request(ctx.app.getHttpServer())

--- a/apps/api/e2e/health.e2e-spec.ts
+++ b/apps/api/e2e/health.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createTestApp, type TestAppContext } from './test-app';
 
@@ -11,10 +11,6 @@ describe('Health & Metrics E2E', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/e2e/idempotency.e2e-spec.ts
+++ b/apps/api/e2e/idempotency.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import {
   createTestApp,
@@ -17,10 +17,6 @@ describe('Idempotency E2E', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/e2e/organizations.e2e-spec.ts
+++ b/apps/api/e2e/organizations.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { Client } from 'pg';
 import {
@@ -42,10 +42,6 @@ describe('Organizations E2E', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/e2e/test-app.ts
+++ b/apps/api/e2e/test-app.ts
@@ -89,12 +89,38 @@ export interface TestAppContext {
   prisma: PrismaService;
 }
 
+// See docs/adr/0006-shared-e2e-application-instance.md for why the app is shared across specs
+// and how it is torn down.
+let sharedApp: Promise<TestAppContext> | undefined;
+let closingSharedApp: Promise<void> | undefined;
+let throttlerRedis: Redis | undefined;
+
+function closeSharedApp(): Promise<void> {
+  if (!sharedApp) return Promise.resolve();
+  closingSharedApp ??= sharedApp
+    .then((ctx) => ctx.app.close())
+    .catch(() => undefined)
+    .finally(() => {
+      sharedApp = undefined;
+    });
+  return closingSharedApp;
+}
+
+process.once('beforeExit', () => {
+  void Promise.allSettled([closeSharedApp(), closeThrottlerRedis()]);
+});
+
 // Mirrors main.ts (prefix, ProblemDetailsValidationPipe, Better Auth mount)
 // minus helmet/swagger/sentry/bull-board. Do NOT call useGlobalFilters here —
 // AppModule's APP_FILTER would wrap responses twice. Postgres + Redis are
 // spun up once by global-setup.ts and the connection info is read from the
 // E2E_DATABASE_URL / E2E_REDIS_HOST / E2E_REDIS_PORT env vars below.
-export async function createTestApp(): Promise<TestAppContext> {
+export function createTestApp(): Promise<TestAppContext> {
+  sharedApp ??= bootstrapTestApp();
+  return sharedApp;
+}
+
+async function bootstrapTestApp(): Promise<TestAppContext> {
   const dbUrl = process.env['E2E_DATABASE_URL'];
   const redisHost = process.env['E2E_REDIS_HOST'];
   const redisPort = process.env['E2E_REDIS_PORT'];
@@ -255,16 +281,19 @@ export async function createTestApp(): Promise<TestAppContext> {
 // spec that uploads a lot silently 429s whichever spec happens to run next. Clearing that db keeps
 // specs independent of execution order without weakening the limits the app actually ships.
 export async function resetRateLimitBudget(): Promise<void> {
-  const redis = new Redis({
+  throttlerRedis ??= new Redis({
     host: process.env['E2E_REDIS_HOST'],
     port: Number(process.env['E2E_REDIS_PORT']),
     db: 1,
   });
-  try {
-    await redis.flushdb();
-  } finally {
-    await redis.quit().catch(() => redis.disconnect());
-  }
+  await throttlerRedis.flushdb();
+}
+
+async function closeThrottlerRedis(): Promise<void> {
+  if (!throttlerRedis) return;
+  const redis = throttlerRedis;
+  throttlerRedis = undefined;
+  await redis.quit().catch(() => redis.disconnect());
 }
 
 export function cookieHeaderFromSetCookies(setCookieHeader: string | string[] | undefined): string {

--- a/apps/api/e2e/upload.e2e-spec.ts
+++ b/apps/api/e2e/upload.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { Client } from 'pg';
 import {
@@ -18,10 +18,6 @@ describe('Upload E2E', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/e2e/users.e2e-spec.ts
+++ b/apps/api/e2e/users.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import request from 'supertest';
 import { PrismaService } from '@nestjs-fastify-nx/infra-database';
 import { createTestApp, cookieHeaderFromSetCookies, type TestAppContext } from './test-app';
@@ -11,10 +11,6 @@ describe('Users E2E', () => {
   beforeAll(async () => {
     ctx = await createTestApp();
   }, 60_000);
-
-  afterAll(async () => {
-    await ctx.app.close();
-  });
 
   beforeEach(async () => {
     await ctx.cleaner.truncateAll();

--- a/apps/api/vite.e2e.config.ts
+++ b/apps/api/vite.e2e.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     testTimeout: 120_000,
     hookTimeout: 120_000,
     fileParallelism: false,
+    // See docs/adr/0006-shared-e2e-application-instance.md
+    isolate: false,
+    pool: 'threads',
     reporters: ['default'],
     // Boot Postgres + Redis once for the entire e2e run; each spec calls
     // databaseCleaner.truncateAll() in beforeEach to maintain isolation.

--- a/docs/adr/0006-shared-e2e-application-instance.md
+++ b/docs/adr/0006-shared-e2e-application-instance.md
@@ -1,0 +1,105 @@
+# ADR-0006: The e2e suite shares one module registry, one application and one database container
+
+- **Status**: Accepted
+- **Date**: 2026-08-26
+
+## Context
+
+`nx run api:e2e` took 126 s wall clock for 82 tests. Vitest's own breakdown put
+84 s of that in `import` and 17 s in `tests` — the assertions themselves were
+never the cost. Three structural choices produced it:
+
+1. `fileParallelism: false` with Vitest's default per-file isolation. Every one
+   of the nine spec files pulls `AppModule`, so the entire Nest + Fastify +
+   Prisma + BullMQ graph was transformed and evaluated into a fresh module
+   registry nine times, at roughly 9.3 s each.
+2. Each spec called `createTestApp()` in `beforeAll`, so the DI container was
+   instantiated, Fastify was booted and Prisma/Redis connections were opened
+   nine times.
+3. The Postgres container ran with default durability settings, and
+   `truncateAll()` runs before every test — 82 `TRUNCATE ... CASCADE`
+   statements, each paying a WAL fsync that a container destroyed minutes later
+   can never benefit from. Postgres and Redis were also started sequentially.
+
+Separately, `TESTCONTAINERS_REUSE=true` — documented as the fast local loop —
+aborted on its second run: `provisionRlsRole` issued `DROP ROLE`, which
+Postgres refuses once the role holds grants.
+
+## Decision
+
+**One worker, one module registry.** `vite.e2e.config.ts` sets
+`isolate: false` with `pool: 'threads'` and `poolOptions.threads.singleThread`.
+All spec files execute in a single worker that evaluates the module graph once.
+
+**One application instance.** `createTestApp()` memoises the boot promise in
+module scope, which now survives across spec files. Specs no longer call
+`app.close()` in `afterAll`; `test-app.ts` closes the app and the throttler
+Redis client on `process.once('beforeExit')`.
+
+**Ephemeral-database Postgres settings.** The Testcontainers Postgres and the
+CI service container both run with `fsync=off`, `synchronous_commit=off` and
+`full_page_writes=off`. Postgres and Redis start concurrently.
+
+**Idempotent RLS provisioning.** `provisionRlsRole` creates the role only when
+absent and re-asserts its attributes otherwise, instead of dropping and
+recreating it.
+
+**CI reuses the job's service containers.** `integration.yml` exports
+`E2E_DATABASE_URL` / `E2E_REDIS_HOST` / `E2E_REDIS_PORT`, taking the branch
+`global-setup.ts` already had, so the job stops booting a second Postgres and
+Redis through Testcontainers alongside the ones it already declares.
+
+Result: 126 s → 21 s, same 82 tests.
+
+## Consequences
+
+Isolation now comes from resetting external state, not from discarding the
+module registry. `truncateAll()` and `resetRateLimitBudget()` are what keep
+specs independent, and a spec that mutates module-level state in an imported
+module will leak it into whichever spec runs next. The one such holder in the
+suite is the in-process storage stub in `test-app.ts`, which is keyed by upload
+id and therefore collision-free.
+
+Sharing the application means the Fastify rate-limit buckets — in-memory, keyed
+by `ip:email`, per route — now span the whole run rather than one file. This is
+safe only because every spec that signs users up derives a unique email; the
+sole exception, `auth.e2e-spec.ts`, uses fixed addresses that no other spec
+touches. **A new spec that signs up with a fixed email can silently exhaust a
+bucket for a later spec.** Derive the email per test.
+
+Vitest exposes no per-worker teardown hook, so the shared app is closed on
+`beforeExit`. If a stray handle keeps the loop alive that hook never fires; the
+worker is terminated by Vitest and the containers are stopped by
+`global-setup.ts`'s `teardown`, so this is a clean-shutdown path rather than the
+only one.
+
+Turning off `fsync` trades crash recovery for speed. That is free for a database
+that is discarded at the end of the run and must never be applied to a container
+whose data outlives it.
+
+We would know this was wrong if specs started failing depending on execution
+order, or if a 429 appeared in a spec that does not assert one — both point at
+shared state that survives `truncateAll()`.
+
+## Alternatives rejected
+
+**Keep per-file isolation and only share the containers.** This is the state
+that measured 126 s; it leaves the dominant cost, re-importing the module graph
+nine times, untouched.
+
+**Run spec files in parallel instead of sharing.** Every file would still pay
+its own import and boot, and they would contend for one Postgres — the
+`TRUNCATE` in `beforeEach` is not safe against a concurrently running spec
+without a database per worker, which costs more than it saves at this suite
+size.
+
+**A custom resettable store for `@fastify/rate-limit`.** It would make bucket
+state resettable per test and remove the unique-email requirement, at the price
+of no longer exercising the store the application actually ships with. The
+requirement is cheap to satisfy and is documented above instead.
+
+**ESLint `--cache` to speed up linting.** ESLint invalidates its cache on file
+content and config only, so a type-aware rule reporting on file B because of a
+change in file A would serve a stale result. Nx already caches lint per project
+(2.5 s for a fully cached workspace lint), which covers the same ground without
+the correctness risk.

--- a/docs/adr/0006-shared-e2e-application-instance.md
+++ b/docs/adr/0006-shared-e2e-application-instance.md
@@ -27,9 +27,12 @@ Postgres refuses once the role holds grants.
 
 ## Decision
 
-**One worker, one module registry.** `vite.e2e.config.ts` sets
-`isolate: false` with `pool: 'threads'` and `poolOptions.threads.singleThread`.
-All spec files execute in a single worker that evaluates the module graph once.
+**One worker, one module registry.** `vite.e2e.config.ts` keeps
+`fileParallelism: false`, which pins `maxWorkers` to 1, and adds `isolate: false`
+with `pool: 'threads'`. All spec files execute in that single worker, which
+evaluates the module graph once. Vitest 4 removed `poolOptions`, so
+`poolOptions.threads.singleThread` is neither available nor needed —
+`fileParallelism: false` already delivers the single worker.
 
 **One application instance.** `createTestApp()` memoises the boot promise in
 module scope, which now survives across spec files. Specs no longer call

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,13 +4,14 @@ One file per decision that is expensive to reverse. Numbered, immutable once
 accepted: a decision that changes gets a new ADR that supersedes the old one,
 the old file stays for the reasoning trail.
 
-| ADR                                       | Title                                                             | Status   |
-| ----------------------------------------- | ----------------------------------------------------------------- | -------- |
-| [0001](0001-multi-tenancy-model.md)       | Multi-tenancy: shared schema, organization-scoped, RLS-enforced   | Accepted |
-| [0002](0002-authorization-engine-port.md) | Authorization behind a port so PBAC and ReBAC are interchangeable | Accepted |
-| [0003](0003-billing-provider-port.md)     | Billing state is internal; payment providers are thin adapters    | Accepted |
-| [0004](0004-deletion-model.md)            | Deletion is three distinct mechanisms, not one flag               | Accepted |
-| [0005](0005-trusted-proxy-allow-list.md)  | Client IP resolution trusts an allow-list, not a hop count        | Accepted |
+| ADR                                             | Title                                                                                | Status   |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
+| [0001](0001-multi-tenancy-model.md)             | Multi-tenancy: shared schema, organization-scoped, RLS-enforced                      | Accepted |
+| [0002](0002-authorization-engine-port.md)       | Authorization behind a port so PBAC and ReBAC are interchangeable                    | Accepted |
+| [0003](0003-billing-provider-port.md)           | Billing state is internal; payment providers are thin adapters                       | Accepted |
+| [0004](0004-deletion-model.md)                  | Deletion is three distinct mechanisms, not one flag                                  | Accepted |
+| [0005](0005-trusted-proxy-allow-list.md)        | Client IP resolution trusts an allow-list, not a hop count                           | Accepted |
+| [0006](0006-shared-e2e-application-instance.md) | The e2e suite shares one module registry, one application and one database container | Accepted |
 
 ## Template
 

--- a/libs/testing/src/lib/containers/test-containers.ts
+++ b/libs/testing/src/lib/containers/test-containers.ts
@@ -9,21 +9,49 @@ export interface TestContainers {
   teardown: () => Promise<void>;
 }
 
+const EPHEMERAL_POSTGRES_COMMAND = [
+  'postgres',
+  '-c',
+  'fsync=off',
+  '-c',
+  'synchronous_commit=off',
+  '-c',
+  'full_page_writes=off',
+];
+
 // TESTCONTAINERS_REUSE=true enables container reuse across test runs. Disabled by default for CI.
 export async function createTestContainers(): Promise<TestContainers> {
   const reuse = process.env['TESTCONTAINERS_REUSE'] === 'true';
 
-  const pgContainer = new PostgreSqlContainer('postgres:18-alpine');
-  const postgres = await (reuse ? pgContainer.withReuse() : pgContainer).start();
+  const pgContainer = new PostgreSqlContainer('postgres:18-alpine').withCommand(
+    EPHEMERAL_POSTGRES_COMMAND,
+  );
+  const redisContainer = new RedisContainer('redis:8-alpine');
 
-  let redis: StartedRedisContainer;
-  try {
-    const redisContainer = new RedisContainer('redis:8-alpine');
-    redis = await (reuse ? redisContainer.withReuse() : redisContainer).start();
-  } catch (error) {
-    if (!reuse) await postgres.stop().catch(() => undefined);
-    throw error;
+  const [postgresResult, redisResult] = await Promise.allSettled([
+    (reuse ? pgContainer.withReuse() : pgContainer).start(),
+    (reuse ? redisContainer.withReuse() : redisContainer).start(),
+  ]);
+
+  const stopStarted = async (): Promise<void> => {
+    if (reuse) return;
+    await Promise.allSettled([
+      postgresResult.status === 'fulfilled' ? postgresResult.value.stop() : Promise.resolve(),
+      redisResult.status === 'fulfilled' ? redisResult.value.stop() : Promise.resolve(),
+    ]);
+  };
+
+  if (postgresResult.status === 'rejected') {
+    await stopStarted();
+    throw postgresResult.reason;
   }
+  if (redisResult.status === 'rejected') {
+    await stopStarted();
+    throw redisResult.reason;
+  }
+
+  const postgres = postgresResult.value;
+  const redis = redisResult.value;
 
   return {
     postgres,

--- a/libs/testing/src/lib/helpers/database-cleaner.ts
+++ b/libs/testing/src/lib/helpers/database-cleaner.ts
@@ -1,9 +1,18 @@
 import type { PrismaClient } from '@nestjs-fastify-nx/infra-database';
 
 export class DatabaseCleaner {
+  private truncateStatement: string | undefined;
+
   constructor(private readonly prisma: PrismaClient) {}
 
   async truncateAll(): Promise<void> {
+    this.truncateStatement ??= await this.buildTruncateStatement();
+    if (this.truncateStatement) {
+      await this.prisma.$executeRawUnsafe(this.truncateStatement);
+    }
+  }
+
+  private async buildTruncateStatement(): Promise<string> {
     const tables = await this.prisma.$queryRaw<{ tablename: string }[]>`
       SELECT tablename FROM pg_tables
       WHERE schemaname = 'public'
@@ -11,8 +20,6 @@ export class DatabaseCleaner {
     `;
 
     const tableNames = tables.map((t) => `"${t.tablename}"`).join(', ');
-    if (tableNames) {
-      await this.prisma.$executeRawUnsafe(`TRUNCATE TABLE ${tableNames} RESTART IDENTITY CASCADE`);
-    }
+    return tableNames ? `TRUNCATE TABLE ${tableNames} RESTART IDENTITY CASCADE` : '';
   }
 }

--- a/libs/testing/src/lib/helpers/deploy-test-migrations.ts
+++ b/libs/testing/src/lib/helpers/deploy-test-migrations.ts
@@ -1,5 +1,6 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 
 // The inferred @nx/vitest target runs vitest with cwd = projectRoot (not the
@@ -19,10 +20,15 @@ function resolveWorkspaceRoot(): string {
   return dir;
 }
 
+function resolvePrismaCli(): string {
+  const resolveFrom = createRequire(import.meta.url);
+  return join(dirname(resolveFrom.resolve('prisma/package.json')), 'build', 'index.js');
+}
+
 export function deployTestMigrations(databaseUrl: string): void {
-  execSync('pnpm prisma migrate deploy', {
+  execFileSync(process.execPath, [resolvePrismaCli(), 'migrate', 'deploy'], {
     cwd: resolveWorkspaceRoot(),
-    env: { ...process.env, DATABASE_URL: databaseUrl },
+    env: { ...process.env, DATABASE_URL: databaseUrl, PRISMA_HIDE_UPDATE_MESSAGE: 'true' },
     stdio: 'inherit',
   });
 }

--- a/libs/testing/src/lib/helpers/rls-role.ts
+++ b/libs/testing/src/lib/helpers/rls-role.ts
@@ -3,20 +3,30 @@ import { Client } from 'pg';
 const RLS_ROLE = 'app_request_e2e';
 const RLS_PASSWORD = 'app-request-e2e';
 
+const ENSURE_ROLE_SQL = `
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${RLS_ROLE}') THEN
+    ALTER ROLE ${RLS_ROLE} LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD '${RLS_PASSWORD}';
+  ELSE
+    CREATE ROLE ${RLS_ROLE} LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD '${RLS_PASSWORD}';
+  END IF;
+END
+$$;
+`;
+
 export async function provisionRlsRole(adminDatabaseUrl: string): Promise<string> {
   const admin = new Client({ connectionString: adminDatabaseUrl });
   await admin.connect();
   try {
-    await admin.query(`DROP ROLE IF EXISTS ${RLS_ROLE}`);
-    await admin.query(
-      `CREATE ROLE ${RLS_ROLE} LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD '${RLS_PASSWORD}'`,
-    );
-    await admin.query(`GRANT USAGE ON SCHEMA public TO ${RLS_ROLE}`);
-    await admin.query(
-      `GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA public TO ${RLS_ROLE}`,
-    );
-    await admin.query(`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${RLS_ROLE}`);
-    await admin.query(`GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO ${RLS_ROLE}`);
+    await admin.query(ENSURE_ROLE_SQL);
+    await admin.query(`
+      GRANT USAGE ON SCHEMA public TO ${RLS_ROLE};
+      GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+        ON ALL TABLES IN SCHEMA public TO ${RLS_ROLE};
+      GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${RLS_ROLE};
+      GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO ${RLS_ROLE};
+    `);
   } finally {
     await admin.end();
   }


### PR DESCRIPTION
## Summary

The e2e suite took **126 s** for 82 tests. Vitest's own breakdown put 84 s of the 114 s run in `import` and only 17 s in `tests` — the assertions were never the cost. Three structural choices produced it:

1. `fileParallelism: false` with default per-file isolation, so each of the nine specs pulled the whole `AppModule` graph into a fresh module registry (~9.3 s each).
2. Each spec called `createTestApp()` in `beforeAll`, booting Nest + Fastify + Prisma + BullMQ nine times.
3. The Postgres container ran with full durability while `truncateAll()` runs before all 82 tests, and Postgres/Redis started sequentially.

### Measured

| | before | after |
| --- | --- | --- |
| `nx run api:e2e` (fresh containers) | **126 s** | **16–30 s** (3 runs: 16.4 / 21.3 / 29.6 — Docker variance) |
| `nx run api:e2e` with `TESTCONTAINERS_REUSE=true` | **crashed on the 2nd run** | **~15 s**, repeatable |
| lint + typecheck + test + build, 22 projects, `--skip-nx-cache` | — | 33 s |
| same, 100 % Nx cache hit | — | 4.3 s (69/69 tasks) |

Vitest breakdown: `import` 84.2 s → **3.4 s**, `tests` 16.8 s → **7.0 s**. 82/82 pass.

### What changed

**e2e**
- `vite.e2e.config.ts`: `isolate: false` + `pool: 'threads'` — one worker, one shared module registry, so the graph is imported once instead of nine times.
- `test-app.ts`: the application instance is memoised across specs; the eight `afterAll(() => ctx.app.close())` blocks are gone and teardown happens once on `beforeExit`. `resetRateLimitBudget()` reuses a single Redis client instead of opening and quitting one per test.
- `database-cleaner.ts`: the `TRUNCATE` statement is built once, removing 82 `pg_tables` round trips.
- `test-containers.ts`: Postgres runs with `fsync=off -c synchronous_commit=off -c full_page_writes=off`, and Postgres + Redis start concurrently.
- `deploy-test-migrations.ts`: the Prisma CLI is invoked with `process.execPath` rather than through the `pnpm` wrapper.

**Bug fixed along the way** — `provisionRlsRole` issued `DROP ROLE`, which Postgres refuses once the role holds grants, so `TESTCONTAINERS_REUSE=true` (documented in `CLAUDE.md` as the fast local loop) aborted on its second run. It is now create-if-absent and idempotent.

**CI**
- `integration.yml` exports `E2E_DATABASE_URL` / `E2E_REDIS_HOST` / `E2E_REDIS_PORT` pointing at the service containers the job **already declares**, taking the branch `global-setup.ts` already had — the job stops booting a second Postgres and Redis through Testcontainers. The service Postgres gets the same ephemeral-durability flags.
- `ci.yml` collapses the separate lint / typecheck / build steps into one Nx task graph, removing two idle barriers. `test` stays on its own because `-- --coverage` would be forwarded to every target.

`docs/adr/0006-shared-e2e-application-instance.md` records the decisions, the trade-offs and the rejected alternatives.

### Considered and rejected

- **Raising `nx.json` `parallel` from 6 to 12.** A/B measured no difference (lint 24.7 s vs 24.6 s, typecheck 3.4 vs 3.4, test 11.9 vs 12.1) — the critical path is the single `api` lint task, not the slot count. Reverted.
- **ESLint `--cache`.** It invalidates on file content and config only, so a type-aware rule reporting on file B because of a change in file A would serve a stale result. Nx already caches lint per project.

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix (`TESTCONTAINERS_REUSE=true` was broken)
- [ ] refactor — no behavior change
- [x] perf — performance improvement
- [x] docs — documentation only
- [ ] test — tests only
- [x] chore / build / ci — tooling, infra, dependencies

## Affected scope

`apps/api/e2e`, `apps/api/vite.e2e.config.ts`, `libs/testing`, `.github/workflows/{ci,integration}.yml`, `docs/adr`.

No application source is touched — production behaviour is unchanged.

## Checklist

- [x] Conventional Commits in branch history
- [x] `pnpm nx affected -t lint test build` passes locally (ran `run-many -t lint typecheck test build --skip-nx-cache` across all 22 projects — green)
- [x] Updated relevant `.md` files (new ADR-0006 + index)
- [x] No `TODO` / `FIXME` left in production code
- [x] No JWT / refresh-token plumbing reintroduced
- [x] Module boundaries respected
- [x] Added/updated tests where it makes sense — this PR changes how the existing suite runs, not what it asserts; all 82 e2e tests still pass

## Reviewer notes

**Isolation now comes from resetting external state, not from discarding the module registry.** `truncateAll()` and `resetRateLimitBudget()` are what keep specs independent. In particular, the Fastify rate-limit buckets (in-memory, keyed by `ip:email`, per route) now span the whole run rather than one file. That is safe only because every spec that signs users up derives a unique email; the one exception, `auth.e2e-spec.ts`, uses fixed addresses no other spec touches. **A new spec that signs up with a fixed email can silently exhaust a bucket for a later spec** — derive it per test. This is written up in ADR-0006.

**The `integration.yml` change is the one thing that cannot be verified locally** — it only exercises in GitHub Actions. The `global-setup.ts` branch it activates predates this PR and the logic was reviewed, but this run is its first real test. If the `integration` job fails, dropping the three `E2E_*` variables restores the previous behaviour immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Accelerated automated test execution by reusing application and service instances, reducing runtime from 126 to 21 seconds.
  * Improved reliability when starting test databases and caching test setup resources.
  * CI now runs linting, type checks, and builds in parallel while keeping unit-test coverage handling separate.
* **Documentation**
  * Added architectural guidance describing shared end-to-end testing, performance trade-offs, and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->