### PR TITLE
test(api): drive the timeout interceptor spec on virtual time to stop it flaking

### DIFF
--- a/apps/api/src/common/interceptors/timeout.interceptor.spec.ts
+++ b/apps/api/src/common/interceptors/timeout.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HttpException, type CallHandler, type ExecutionContext } from '@nestjs/common';
 import { HEADERS_METADATA } from '@nestjs/common/constants';
 import type { ConfigService } from '@nestjs/config';
@@ -34,9 +34,21 @@ function handlerEmitting(value: unknown, afterMs = 0): CallHandler {
   } as unknown as CallHandler;
 }
 
-const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+// Everything here is driven by the clock, and the late-capture window is exactly as long as the
+// timeout budget — so on a loaded CI runner a real-timer test can lose the race against the very
+// window it is asserting on. Virtual time makes the ordering exact instead of probable.
+// `advanceTimersByTimeAsync` is what lets the promise chains between timers settle.
+const advance = (ms: number) => vi.advanceTimersByTimeAsync(ms);
 
 describe('TimeoutInterceptor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('passes a fast handler through untouched', async () => {
     const interceptor = makeInterceptor(1000);
     const result = await firstValueFrom(
@@ -47,31 +59,42 @@ describe('TimeoutInterceptor', () => {
 
   it('throws a 504 request_timeout when the handler exceeds the budget', async () => {
     const interceptor = makeInterceptor(10);
-    try {
-      await firstValueFrom(interceptor.intercept(makeContext('http'), handlerEmitting('late', 50)));
-      expect.unreachable('handler should have timed out');
-    } catch (err) {
-      expect(err).toBeInstanceOf(HttpException);
-      const exception = err as HttpException;
-      expect(exception.getStatus()).toBe(504);
-      expect((exception.getResponse() as { code: string }).code).toBe('request_timeout');
-    }
+    const settled = firstValueFrom(
+      interceptor.intercept(makeContext('http'), handlerEmitting('late', 50)),
+    ).then(
+      () => expect.unreachable('handler should have timed out'),
+      (err: unknown) => err,
+    );
+
+    await advance(10);
+
+    const err = await settled;
+    expect(err).toBeInstanceOf(HttpException);
+    const exception = err as HttpException;
+    expect(exception.getStatus()).toBe(504);
+    expect((exception.getResponse() as { code: string }).code).toBe('request_timeout');
   });
 
   it('does not apply to WebSocket contexts', async () => {
     const interceptor = makeInterceptor(10);
-    const result = await firstValueFrom(
+    const settled = firstValueFrom(
       interceptor.intercept(makeContext('ws'), handlerEmitting('late', 50)),
     );
-    expect(result).toBe('late');
+
+    await advance(50);
+
+    expect(await settled).toBe('late');
   });
 
   it('is disabled when the timeout is 0', async () => {
     const interceptor = makeInterceptor(0);
-    const result = await firstValueFrom(
+    const settled = firstValueFrom(
       interceptor.intercept(makeContext('http'), handlerEmitting('late', 50)),
     );
-    expect(result).toBe('late');
+
+    await advance(50);
+
+    expect(await settled).toBe('late');
   });
 
   it('lets non-timeout errors propagate unchanged', async () => {
@@ -96,7 +119,10 @@ describe('TimeoutInterceptor', () => {
       const settled = firstValueFrom(
         interceptor.intercept(makeContext('http', request), handler),
       ).catch((e: unknown) => e);
-      const err = await settled; // resolves when the 504 fires (~50ms)
+
+      await advance(50); // the 504 fires here
+
+      const err = await settled;
       expect(err).toBeInstanceOf(HttpException);
       expect((err as HttpException).getStatus()).toBe(504);
       expect(completeLate).not.toHaveBeenCalled();
@@ -105,7 +131,7 @@ describe('TimeoutInterceptor', () => {
       // explicit content type (defaults to application/json inside completeLate).
       subject.next('late-result');
       subject.complete();
-      await tick(0);
+      await advance(0);
       expect(completeLate).toHaveBeenCalledWith(201, 'late-result', undefined);
     });
 
@@ -119,11 +145,13 @@ describe('TimeoutInterceptor', () => {
       const settled = firstValueFrom(
         interceptor.intercept(makeContext('http', request), handler),
       ).catch((e: unknown) => e);
+
+      await advance(50);
       await settled;
 
       subject.next('a,b,c');
       subject.complete();
-      await tick(0);
+      await advance(0);
       expect(completeLate).toHaveBeenCalledWith(201, 'a,b,c', 'text/csv');
     });
 
@@ -178,28 +206,32 @@ describe('TimeoutInterceptor', () => {
 
     it('hands the subscriber exactly one timeout error, then feeds a late value to the hook', async () => {
       const h = run(10);
-      await tick(20);
+
+      await advance(10); // budget lapses: the 504 goes out and the late window opens
       expect(h.errors).toEqual(['TIMEOUT']);
 
+      // Still inside the late window — the source has not been torn down, so the value is captured
+      // rather than delivered to the (already errored) subscriber.
       h.source.next('x');
-      await tick(0);
-      expect(h.received).toEqual([`late:x`]);
+      expect(h.received).toEqual(['late:x']);
     });
 
     it('stops capturing after the late window elapses', async () => {
       const h = run(10);
-      await tick(15);
-      await tick(15);
+
+      await advance(10); // budget lapses
+      await advance(10); // late window lapses and the source is unsubscribed
 
       h.source.next('too-late');
-      await tick(0);
       expect(h.errors).toEqual(['TIMEOUT']);
       expect(h.received).toEqual([]);
     });
 
     it('ignores a late error after the 504', async () => {
       const h = run(10);
-      await tick(20);
+
+      await advance(10);
+
       expect(() => h.source.error(new Error('boom'))).not.toThrow();
       expect(h.received).toEqual([]);
     });


### PR DESCRIPTION
## The failure

`subscribeWithLateCapture > hands the subscriber exactly one timeout error, then feeds a late value to the hook` fails intermittently in CI with `expected [] to deeply equal [ 'late:x' ]`. It failed on PR #176, then on `main` after #177 landed, and passed on rerun both times with no code change.

## Root cause

The late-capture window is exactly as long as the timeout budget — `lateTimer = setTimeout(..., timeoutMs)` is armed when the budget lapses. The spec used a 10ms budget and then waited `tick(20)` on the real clock before emitting into that window:

```
t=0    budget starts
t=10   budget lapses → 504 sent, late window opens (closes at t=20)
t=20   test resumes and emits 'x'   ← a dead heat with the window closing
```

On a loaded runner the late timer wins, the source is unsubscribed, and the value is never captured. The interceptor is correct; the spec was racing the very window it asserted on.

## Fix

Virtual time for the whole file, so ordering is exact rather than probable: advance to the budget, assert the 504, then emit while the window is provably still open. The two `idempotent late-completion` tests had the same shape with a wider margin (50ms) and are converted too rather than left as a slower-burning version of the same bug.

No production code changed — `timeout.interceptor.ts` is untouched.

## Verification

- 25 consecutive local runs, 0 failures (was reproducible under CI load)
- `api` suite: 358/358 pass, coverage thresholds met
- lint + typecheck + build green
- Spec runtime drops from real sleeps to 15ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timeout test reliability by replacing real-time delays with controlled virtual timers.
  * Added consistent timer setup and cleanup across tests.
  * Updated timeout and late-capture scenarios to assert results after simulated time advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->