### PR TITLE
docs: document the new modules and correct three stale claims

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Stop the stack:
 
 Three-layer design enforced by `@nx/enforce-module-boundaries`:
 
-1. **Bounded Contexts** (`libs/modules/*`) — DDD modules that never import each other. Examples: `users`, `audit-log`, `upload`.
+1. **Bounded Contexts** (`libs/modules/*`) — DDD modules that never import each other: `users`, `audit-log`, `upload`, `organizations`, `api-keys`, `notifications`, `feature-flags`, `terms`, `sessions`.
 2. **Composition Layer** (`libs/composition/*`) — cross-context features that depend on modules. Example: `admin` dashboard.
 3. **Platform Layer** (`libs/infra/*`, `libs/core/*`) — shared auth, database, messaging, observability. Used by everything above.
 
@@ -151,12 +151,23 @@ Enforced by ESLint + Lefthook + CI.
 
 ## Pull Request Checklist
 
-> **Note:** the Lefthook pre-commit hook runs only `lint-staged` + `typecheck` (fast). It does **not** run tests or build — Testcontainers-backed tests are too slow for every commit. Run the full gate yourself before pushing: `pnpm nx affected -t lint test build typecheck --base=origin/main`. CI is the real enforcement point, but running it locally avoids a red PR.
+> **Note:** the Lefthook pre-commit hook runs `lint-staged`, `typecheck` and a staged-only Gitleaks
+> scan (fast). It does **not** run tests or build — Testcontainers-backed tests are too slow for
+> every commit. Run the full gate yourself before pushing:
+> `pnpm nx affected -t lint test build typecheck --base=origin/main`. CI is the real enforcement
+> point, but running it locally avoids a red PR.
+>
+> **Coverage is enforced only in CI.** The local `nx test` target omits `--coverage`, so a project
+> can be green on your machine and still fail the PR on a 60% threshold. Add
+> `pnpm nx run-many -t test -- --coverage` before pushing when you have added files — note the flag
+> belongs to the `test` target alone, and passing it to a combined `lint test build` run fails the
+> other targets.
 
-- [ ] Tests added/updated (`pnpm nx test`)
+- [ ] Tests added/updated (`pnpm nx test`), coverage checked (`pnpm nx run-many -t test -- --coverage`)
 - [ ] Lint pass (`pnpm nx affected -t lint --base=origin/main`)
 - [ ] Build pass (`pnpm nx affected -t build --base=origin/main`)
-- [ ] API docs updated (if endpoints changed)
+- [ ] API docs updated (if endpoints changed) — and `pnpm codegen:full` re-run so `libs/api-client` matches
+- [ ] New permission added to `PERMISSIONS` reaches both authorization engines (parity spec is the check)
 - [ ] CHANGELOG.md updated (if user-facing)
 - [ ] No TODOs in code
 - [ ] Conventional commit (`feat(scope): description`)

--- a/README.md
+++ b/README.md
@@ -347,10 +347,13 @@ Full flow: [docs/deployment.md](docs/deployment.md).
 - [Creating a Module](docs/creating-a-module.md) — DDD/CQRS scaffold walkthrough
 - [Environment Variables](docs/environment.md) — every env var, defaults, validation
 - [Deployment](docs/deployment.md) — Docker, GHCR, Cosign verification, migrations
-- [Security Scanning](docs/security.md) — five-layer pipeline, local + CI parity
+- [Security](docs/security.md) — five-layer scan pipeline plus how API keys and session tokens are held
+- [Error Handling](docs/error-handling.md) — which error to throw, which status the client gets
 - [Troubleshooting](docs/troubleshooting.md) — known issues, debug tips
-- [Runbook](docs/runbook.md) — ops runbook: health, metrics, outbox, BullMQ, performance
+- [Runbook](docs/runbook.md) — ops runbook: outbox, DLQ, leaked API keys, missing notifications, backups
 - [Code Standards](docs/code-standards.md) — logging, error handling, DTOs, boundary rules
+- [Scaling to services](docs/scaling-to-services.md) — what is ready to split out, and in what order
+- [Architecture Decisions](docs/adr/README.md) — the decisions that are expensive to reverse
 - [API Reference](http://localhost:3000/docs) (Scalar, dev only)
 
 ## Contributing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,13 +249,32 @@ GET /api/v1/users/me → UsersController.getProfile (BetterAuthGuard)
   → guard validates `better-auth.session_token`, attaches user to request
   → QueryBus.execute(GetUserProfileQuery) → GetUserProfileHandler → UserRepository.findById()
 
-GET /api/v1/admin/users → AdminUsersController.list (BetterAuthGuard + RolesGuard)
-  → guards reject non-ADMIN sessions with 403
+GET /api/v1/admin/users → AdminUsersController.list (BetterAuthGuard + PermissionGuard)
+  → PermissionGuard resolves `member:read` for (user, active organization) and 403s without it
   → QueryBus.execute(ListUsersCursorQuery) → ListUsersCursorHandler (cursor-paginated)
+
+GET /api/v1/feature-flags (Authorization: Bearer sk_…) → FeatureFlagsController.list
+  → ApiKeyGuard verifies the digest, stamps req.apiKey, BetterAuthGuard steps aside
+  → PermissionGuard builds an api_key principal and checks `feature_flag:read` against its scopes
 ```
 
-Protected REST and GraphQL endpoints rely on `BetterAuthGuard` and
-`RolesGuard`, both wired globally as `APP_GUARD` providers in `AppModule`.
+### Guard chain
+
+Four `APP_GUARD` providers run in this order (`apps/api/src/app/app.module.ts`), and the order is
+load-bearing:
+
+| #   | Guard               | Answers                                                                      |
+| --- | ------------------- | ---------------------------------------------------------------------------- |
+| 1   | `GqlThrottlerGuard` | Is this caller over their rate budget?                                       |
+| 2   | `ApiKeyGuard`       | Was an API key presented, is it live, and does this route accept one?        |
+| 3   | `BetterAuthGuard`   | Is there a valid session cookie? Skipped entirely when step 2 verified a key |
+| 4   | `RolesGuard`        | Platform axis — does `User.role` satisfy `@Roles()`?                         |
+| 5   | `PermissionGuard`   | Organization axis — does the principal hold the `@RequirePermission()`?      |
+
+`ApiKeyGuard` must precede `BetterAuthGuard`: it is what lets a machine caller through without a
+cookie. `PermissionGuard` must come last because it needs the principal either of the two produced.
+Every one of them returns early on `context.getType() === 'ws'` — WebSocket frames are authorized at
+the socket.io layer instead.
 
 Sign-up traces the full event chain — note the Postgres trigger writes the
 outbox row inside Better Auth's own transaction, so the event can never be lost:

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -104,6 +104,26 @@ if (await this.users.exists(email)) {
 Pass `messageKey`/`title` as i18n keys, not literals: `GlobalExceptionFilter` only translates dotted
 strings, so a literal silently ships English to every locale.
 
+**Collect a module's exceptions in one file when more than one handler raises the same failure.**
+A module with several handlers that each answer `not_found` for the same aggregate ends up with the
+same twenty-line literal repeated, and the copies drift. Put small factories in
+`application/<context>-errors.ts` and import them:
+
+```typescript
+// libs/modules/organizations/src/application/organization-errors.ts
+export const roleInUse = () =>
+  conflict(
+    'role',
+    ERROR_CODES.ORGANIZATION_ROLE_IN_USE,
+    'Role is still assigned to at least one member',
+    I18N_KEYS.errors.organizations.role_in_use,
+  );
+```
+
+Keep the exception inline when exactly one handler raises it — a factory with one caller is
+indirection without a payoff. Examples: `organization-errors.ts`, `feature-flag-errors.ts`,
+`term-errors.ts`.
+
 ### Input Validation
 
 Use `class-validator` decorators on DTOs. The global `ProblemDetailsValidationPipe` automatically

--- a/docs/domain-module-anatomy.md
+++ b/docs/domain-module-anatomy.md
@@ -669,7 +669,31 @@ export class UserFactory {
 **Rules**: `testing/**` (like `*.spec.ts`, `*.integration.ts`) is exempt from
 the module-boundary lint rule, but keep fakes behaviorally faithful —
 `MockUserRepository.findAllCursor` replicates the same sort/cursor semantics
-as Postgres so handler tests catch real pagination bugs.
+as Postgres so handler tests catch real pagination bugs. A fake that always
+returns everything turns a tenant-scoping bug into a passing test.
+
+Two mechanical points that cost a CI round trip each when missed:
+
+- **Do not mark a fake's methods `async` unless they `await` something.**
+  `@typescript-eslint/require-await` fails the lint step. Return
+  `Promise.resolve(value)` instead — the port's signature is unchanged.
+- **Generate id and secret fixtures rather than hardcoding them.** A literal
+  UUID or `sk_…` string assigned to a name containing `key`/`credential` trips
+  the Gitleaks pre-commit hook, and renaming the constant only moves the
+  problem. Use `generateId()` / `generateApiKey()` from
+  `@nestjs-fastify-nx/shared`.
+
+Newer modules name these `InMemory<Aggregate>Repository` and group several in one
+`testing/in-memory-repositories.ts` when a module owns more than one aggregate
+(`libs/modules/organizations`); `Mock<Port>Repository` in `users` and `audit-log`
+is the same thing under the older name.
+
+**Coverage:** unit specs alone leave repositories and controllers at 0%, which
+sinks a module below the 60% threshold that only CI enforces. Cover repositories
+with a `PrismaService` double asserting the `where` clause the tenant scoping
+depends on, and controllers with `CommandBus`/`QueryBus` doubles asserting the
+dispatched message. Run `pnpm nx test <project> -- --coverage` before pushing —
+the local target omits the flag.
 
 ## 4. Putting it together — adding a feature
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -109,8 +109,8 @@ is the value to quote in a bug report — it appears on every log line for that 
 | Status | Raised by                                                                                                                 | Documented by                                     |
 | ------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | `400`  | `DomainException({ kind: 'malformed' })`, malformed JSON, bad headers                                                     | `ApiCommonErrors` (always)                        |
-| `401`  | `BetterAuthGuard` — missing or invalid session cookie                                                                     | `ApiCommonErrors({ auth: true })`                 |
-| `403`  | `RolesGuard`, non-ACTIVE account, `DomainException({ kind: 'forbidden' })`                                                | `ApiCommonErrors` (implied by `auth`)             |
+| `401`  | `BetterAuthGuard` — missing or invalid session cookie; `ApiKeyGuard` — unknown, revoked or expired key                    | `ApiCommonErrors({ auth: true })`                 |
+| `403`  | `RolesGuard`, `PermissionGuard`, non-ACTIVE account, `DomainException({ kind: 'forbidden' })`                             | `ApiCommonErrors` (implied by `auth`)             |
 | `404`  | `DomainException({ kind: 'not_found' })`, unmatched route                                                                 | `ApiCommonErrors({ notFound: true })`             |
 | `409`  | `DomainException({ kind: 'conflict' })`, Prisma P2002/P2003, in-flight idempotent replay                                  | `ApiCommonErrors({ conflict: true })`             |
 | `413`  | `@fastify/multipart` / body limit                                                                                         | `ApiCommonErrors({ payloadTooLarge: true })`      |
@@ -128,6 +128,44 @@ document a richer one carrying a `checks` breakdown.
 
 Note: an unmatched **method** on an existing path answers `404`, not `405` — that is Fastify's
 router default and this project does not override it.
+
+## Domain codes by area
+
+`code` is the value a client keys its i18n and its retry logic off, so it must come from
+`ERROR_CODES` (`libs/contracts`) and never be an ad-hoc string. Every code below is documented at
+`GET /errors/<slug>` — the same URI the `type` member points at — and `error-catalog.spec.ts` fails
+if a code exists without a doc entry or the other way round.
+
+| Area             | Codes                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Users            | `user_not_found`, `user_already_exists`, `organization_context_required`                                                |
+| Organizations    | `organization_not_found`, `organization_role_not_found`, `organization_role_already_exists`, `organization_role_in_use` |
+| Teams            | `team_not_found`, `team_name_taken`                                                                                     |
+| Invitations      | `invitation_not_found`, `invitation_not_pending`                                                                        |
+| API keys         | `api_key_not_found`, `api_key_invalid_credential`, `api_key_scope_exceeds_grant`                                        |
+| Notifications    | `notification_not_found`                                                                                                |
+| Feature flags    | `feature_flag_not_found`, `feature_flag_key_taken`                                                                      |
+| Terms            | `term_not_found`, `term_not_published`, `term_version_taken`                                                            |
+| Sessions         | `session_not_found`                                                                                                     |
+| Audit log        | `invalid_audit_log_id`                                                                                                  |
+| Pagination       | `invalid_cursor`                                                                                                        |
+| Upload / storage | `upload_*`, `storage_*`                                                                                                 |
+| Idempotency      | `idempotency_key_invalid`, `idempotency_key_conflict`, `idempotency_key_mismatch`                                       |
+
+Two of these carry a decision worth knowing:
+
+- **`api_key_scope_exceeds_grant` (422)** — a key may never carry a permission its issuer does not
+  hold, otherwise `api_key:create` silently becomes a grant of the entire catalog.
+- **`organization_role_in_use` (409)** — deleting a role that members still hold would strip their
+  permissions with no audit trail, so it is refused until they are reassigned.
+
+## Answering `404` where `403` would be truthful
+
+Several handlers return `not_found` for a resource the caller is simply not allowed to see: a
+notification addressed to another member, a session belonging to another user, a team in another
+organization. A distinguishable `403` would confirm that the id exists, which is itself a leak.
+Use `forbidden` when the caller may already know the resource exists (a permission they lack on
+their own organization); use `not_found` when the answer would otherwise reveal existence.
 
 ## Never leak internals
 

--- a/docs/fork-guide.md
+++ b/docs/fork-guide.md
@@ -56,6 +56,34 @@ The API runs at `http://localhost:3000` by default.
 | `POST` | `/api/v1/upload/presign`      | session cookie    | issue a presigned POST policy      |
 | `POST` | `/api/v1/upload/confirm`      | session cookie    | confirm an upload                  |
 
+Tenant-facing endpoints, each gated by an organization permission rather than a platform role:
+
+| Method                  | Endpoint                                          | Permission                        |
+| ----------------------- | ------------------------------------------------- | --------------------------------- |
+| `GET`                   | `/api/v1/organizations/current`                   | `organization:read`               |
+| `GET`/`POST`            | `/api/v1/organizations/current/roles`             | `role:read` / `role:create`       |
+| `PATCH`/`DELETE`        | `/api/v1/organizations/current/roles/{role}`      | `role:update` / `role:delete`     |
+| `GET`/`POST`            | `/api/v1/organizations/current/teams`             | `team:read` / `team:create`       |
+| `PATCH`/`DELETE`        | `/api/v1/organizations/current/teams/{id}`        | `team:update` / `team:delete`     |
+| `GET`                   | `/api/v1/organizations/current/invitations`       | `invitation:read`                 |
+| `DELETE`                | `/api/v1/organizations/current/invitations/{id}`  | `invitation:cancel`               |
+| `GET`                   | `/api/v1/audit-logs`                              | `audit_log:read`                  |
+| `GET`/`POST`            | `/api/v1/api-keys`                                | `api_key:read` / `api_key:create` |
+| `DELETE`                | `/api/v1/api-keys/{id}`                           | `api_key:revoke`                  |
+| `GET`                   | `/api/v1/notifications`                           | `notification:read`               |
+| `POST`                  | `/api/v1/notifications/{id}/read`, `/read-all`    | `notification:update`             |
+| `GET`                   | `/api/v1/feature-flags`, `/evaluate`              | `feature_flag:read`               |
+| `POST`/`PATCH`/`DELETE` | `/api/v1/feature-flags[/{id}]`                    | `feature_flag:manage`             |
+| `GET`                   | `/api/v1/terms`, `/{type}/latest`, `/acceptances` | `term:read`                       |
+| `POST`                  | `/api/v1/terms/{id}/accept`                       | `term:accept`                     |
+| `POST`                  | `/api/v1/terms[/{id}/publish]`                    | `term:manage`                     |
+| `GET`/`DELETE`          | `/api/v1/sessions[/{id}]`                         | `session:read` / `session:revoke` |
+| `POST`                  | `/api/v1/sessions/revoke-others`                  | `session:revoke`                  |
+
+Two endpoints also accept an API key (`Authorization: Bearer sk_…` or `X-Api-Key`):
+`GET /api/v1/feature-flags` and `GET /api/v1/feature-flags/evaluate`. A route accepts a key only
+when it carries `@AllowApiKey()` — see [ADR-0007](adr/0007-api-key-authentication.md).
+
 Upload flow:
 
 ```text
@@ -111,18 +139,26 @@ send the cookie from the same origin; other clients should use `auth.token`.
 
 ## Where to find the code
 
-| Concern                                     | Location               |
-| ------------------------------------------- | ---------------------- |
-| HTTP bootstrap, CORS, Helmet, rate limiting | `apps/api/src/main.ts` |
-| Authentication, sessions, and role guards   | `libs/infra/auth`      |
-| User use cases and repositories             | `libs/modules/users`   |
-| Upload presign and confirmation             | `libs/modules/upload`  |
-| Prisma schema and migrations                | `prisma/`              |
-| Queue processing                            | `apps/worker`          |
-| Cron jobs and outbox relay                  | `apps/scheduler`       |
-| Database, Redis, and S3 adapters            | `libs/infra`           |
-| DTOs, errors, and OpenAPI contracts         | `libs/contracts`       |
-| Generated REST client                       | `libs/api-client`      |
+| Concern                                     | Location                             |
+| ------------------------------------------- | ------------------------------------ |
+| HTTP bootstrap, CORS, Helmet, rate limiting | `apps/api/src/main.ts`               |
+| Authentication, sessions, and role guards   | `libs/infra/auth`                    |
+| User use cases and repositories             | `libs/modules/users`                 |
+| Upload presign and confirmation             | `libs/modules/upload`                |
+| Roles, teams, invitations                   | `libs/modules/organizations`         |
+| Machine credentials                         | `libs/modules/api-keys`              |
+| In-app notifications                        | `libs/modules/notifications`         |
+| Feature flags                               | `libs/modules/feature-flags`         |
+| Legal terms and acceptance                  | `libs/modules/terms`                 |
+| Session listing and revocation              | `libs/modules/sessions`              |
+| Audit trail                                 | `libs/modules/audit-log`             |
+| Permission catalog and system roles         | `libs/shared/src/lib/permissions.ts` |
+| Prisma schema and migrations                | `prisma/`                            |
+| Queue processing                            | `apps/worker`                        |
+| Cron jobs and outbox relay                  | `apps/scheduler`                     |
+| Database, Redis, and S3 adapters            | `libs/infra`                         |
+| DTOs, errors, and OpenAPI contracts         | `libs/contracts`                     |
+| Generated REST client                       | `libs/api-client`                    |
 
 After changing a DTO or controller, run:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -547,7 +547,82 @@ Set `OUTBOX_PURGE_MAX_BATCHES` to at least that value and redeploy.
 
 **Escalation:** Surge of deletions correlated with a single IP range may indicate an automated probe. Tighten `/upload/presign` rate-limit (currently 10/min per session — see `PRESIGN_LIMIT` in `upload.controller.ts`) or add a global ban list.
 
-## 10. Backups
+## 10. Compromised or leaked API key
+
+**Symptom:** a key appears in a paste site, a client log, or an audit trail shows calls from an
+unexpected source.
+
+**Cause:** the raw key was captured somewhere after issuance. Only a SHA-256 digest is stored
+server-side, so the leak is always on the holder's side — a CI log, an env dump, a shared file.
+
+**Diagnostic:**
+
+```bash
+# Which keys exist for the tenant, and when each was last used
+psql "$DATABASE_URL" -c "SELECT id, name, prefix, \"lastUsedAt\", \"expiresAt\", \"revokedAt\"
+  FROM api_keys WHERE \"organizationId\" = '<org-uuid>' ORDER BY \"createdAt\" DESC;"
+```
+
+The `prefix` column is the non-secret leading fragment shown in the UI — match the leaked value's
+first characters against it to identify the key without ever handling the secret.
+
+**Action:**
+
+1. Revoke immediately — takes effect on the next request, there is no cache to invalidate:
+   `DELETE /api/v1/api-keys/{id}` (needs `api_key:revoke`), or as a break-glass measure
+   `UPDATE api_keys SET "revokedAt" = NOW() WHERE id = '<uuid>';`
+2. Issue a replacement and hand it to the integration owner. The raw value appears once, in the
+   creation response.
+3. Review what the key could reach: `SELECT scopes FROM api_keys WHERE id = '<uuid>';` — the blast
+   radius is exactly those scopes, and never more than the issuer held.
+4. Check `audit_logs` for the window between leak and revocation.
+
+**Escalation:** if several keys of one tenant leak together, the leak is upstream of any single key
+— treat the tenant's credential handling as compromised rather than rotating one at a time.
+
+**Prevention:** set `expiresAt` when issuing. An unbounded key is a credential nobody will ever
+remember to rotate.
+
+## 11. Notifications are not appearing
+
+**Symptom:** `GET /api/v1/notifications` stays empty although members are being added or their
+roles changed.
+
+**Cause:** notifications are written by `MembershipNotificationListener`, which subscribes to
+`organizations.member_added` / `organizations.member_role_updated`. Those events reach a listener
+only in the process the **outbox relay** runs in — the scheduler. If the scheduler is not running
+`NotificationsListenersModule`, nothing is ever written, and no error appears anywhere: the events
+are delivered to a process with no subscriber.
+
+**Diagnostic:**
+
+```bash
+# 1. Are the events being produced at all?
+psql "$DATABASE_URL" -c "SELECT \"eventType\", COUNT(*), MAX(\"createdAt\")
+  FROM outbox_events WHERE \"eventType\" LIKE 'organizations.%' GROUP BY 1;"
+
+# 2. Is the relay draining them? (processedAt NULL = still pending)
+psql "$DATABASE_URL" -c "SELECT COUNT(*) FROM outbox_events
+  WHERE \"processedAt\" IS NULL AND \"eventType\" LIKE 'organizations.%';"
+
+# 3. Is the scheduler loading the listener slice?
+docker compose logs scheduler | grep -i "NotificationsListenersModule\|MembershipNotificationListener"
+```
+
+**Action:**
+
+1. Events missing entirely → the Postgres triggers are the producer; see section 1 (outbox stuck)
+   and confirm the trigger exists on `members`.
+2. Events present but unprocessed → outbox relay problem, section 1.
+3. Events processed but no rows in `notifications` → the scheduler is not importing
+   `NotificationsListenersModule` (`apps/scheduler/src/app/app.module.ts`). This is the failure mode
+   that shipped once already: the listener lived only in `api`, where no relay runs.
+
+**Note:** a redelivered event is a no-op, not a duplicate — the notification id is derived from the
+outbox `eventId` and the repository treats the resulting primary-key collision as the idempotency
+signal.
+
+## 12. Backups
 
 **Reality check:** this repo does NOT schedule database backups. It ships `scripts/pg-backup.sh` (on-demand `pg_dump` in custom format) so the restore steps elsewhere in this runbook have something to restore from — but scheduling and off-host retention are the operator's responsibility. A backup on the same volume/host as the database it protects is not a backup.
 

--- a/docs/scaling-to-services.md
+++ b/docs/scaling-to-services.md
@@ -4,23 +4,31 @@ How this codebase gets split into separately deployed services — and why it is
 
 ## Where the repo already stands
 
-| Property              | State                                                                                                    |
-| --------------------- | -------------------------------------------------------------------------------------------------------- |
-| Deployable units      | 4 (`api`, `worker`, `scheduler`, `migration`), each with its own Docker target and pruned `package.json` |
-| Bounded contexts      | 3 (`users`, `audit-log`, `upload`)                                                                       |
-| Cross-context imports | Blocked by `@nx/enforce-module-boundaries` — `scope:modules` cannot import another `scope:modules`       |
-| Table ownership       | Clean: each context's repository touches only its own tables                                             |
-| Cross-context FKs     | None. `StoredFile.userId` and `AuditLog.userId` deliberately carry **no** foreign key                    |
-| Cross-process events  | `outbox_events` + `OutboxRelayService`, at-least-once, with backoff                                      |
-| Event names           | `DOMAIN_EVENTS` in `@nestjs-fastify-nx/shared`, locked to the trigger SQL by `domain-events.spec.ts`     |
+| Property              | State                                                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Deployable units      | 4 (`api`, `worker`, `scheduler`, `migration`), each with its own Docker target and pruned `package.json`               |
+| Bounded contexts      | 9 (`users`, `audit-log`, `upload`, `organizations`, `api-keys`, `notifications`, `feature-flags`, `terms`, `sessions`) |
+| Cross-context imports | Blocked by `@nx/enforce-module-boundaries` — `scope:modules` cannot import another `scope:modules`                     |
+| Table ownership       | Clean: each context's repository touches only its own tables                                                           |
+| Cross-context FKs     | Only to the Better Auth core (`users`, `organizations`) — never between two feature contexts                           |
+| Cross-process events  | `outbox_events` + `OutboxRelayService`, at-least-once, with backoff                                                    |
+| Event names           | `DOMAIN_EVENTS` in `@nestjs-fastify-nx/shared`, locked to the trigger SQL by `domain-events.spec.ts`                   |
 
-The only foreign keys in the schema are `Session.userId → User` and `Account.userId → User` — all three
-tables belong to Better Auth, so they move together as one unit. Nothing else joins across contexts.
+Foreign keys fall into two groups. Better Auth's own tables (`sessions`, `accounts`, `members`,
+`invitations`, `teams`, `organization_roles`) reference `users`/`organizations` and move together as
+one unit. The newer feature tables (`api_keys`, `notifications`, `feature_flags`, `term_acceptances`)
+also reference that core, which is deliberate: the core is the last thing to be split, so a foreign
+key pointing _into_ it costs nothing until Stage 3.
+
+What matters is what is absent — **no feature context references another feature context**.
+`stored_files.userId` and `audit_logs.userId` carry no foreign key at all so the scheduler can still
+purge objects after a user row is gone.
 
 ## What is deliberately not done yet
 
 Splitting costs network failures, eventual consistency, per-service CI/CD and distributed tracing.
-With 3 contexts and 7 tables that trade is a loss. Split when one of these is true, not before:
+With 9 contexts sharing one database and one deploy, that trade is still a loss — the contexts grew,
+the coupling did not. Split when one of these is true, not before:
 
 - a context needs to scale on a different axis (upload is I/O bound, audit is write bound)
 - two or more teams block each other on release
@@ -46,6 +54,11 @@ Gains independent deploy, scaling and blast radius. Does not gain data isolation
 ## Stage 2 — separate data for an edge context
 
 `audit-log` and `upload` are the two candidates, because their tables have no inbound foreign key.
+`notifications` is a third: it is written only by a listener reacting to `organizations.*` events and
+read only by its owner, so it already behaves like a downstream consumer of the event stream.
+
+`api-keys` is explicitly **not** a candidate — verification sits on the authentication path of every
+machine request, so moving it across the network buys nothing and adds a hop to every call.
 
 Per context:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,10 +20,14 @@ Run the whole stack locally: `./scripts/security/scan-all.sh`.
 
 ### Gitleaks — secrets
 
-API keys, tokens, private keys committed to the repo. The pre-push hook scans the
-full history; CI scans the entire diff. There is deliberately no Gitleaks step on
-`pre-commit` — lefthook keeps that hook to `lint-staged` + `typecheck` so commits
-stay fast, and push is the last point before anything leaves the machine.
+API keys, tokens, private keys committed to the repo. Three layers, each catching
+what the previous one would have let past:
+
+| Hook         | Scope                       | Command                    |
+| ------------ | --------------------------- | -------------------------- |
+| `pre-commit` | Staged changes only (fast)  | `scan-secrets.sh --staged` |
+| `pre-push`   | Full history                | `scan-secrets.sh full`     |
+| CI           | Full history + SARIF upload | `secret-scan` job          |
 
 ```bash
 ./scripts/security/scan-secrets.sh           # full repo + history
@@ -31,7 +35,20 @@ stay fast, and push is the last point before anything leaves the machine.
 ./scripts/security/scan-secrets.sh --no-git  # filesystem only (skips .git)
 ```
 
-False positives go in `.gitleaksignore` (one fingerprint per line).
+**Test fixtures trip the `generic-api-key` rule.** The rule fires on a high-entropy literal
+assigned to a name containing `key`, `credential` and similar — a UUID v7 fixture is
+indistinguishable from a live secret to it, and renaming the constant only moves the problem.
+Generate the fixture instead of hardcoding it:
+
+```ts
+const RAW_KEY = generateApiKey().raw; // not 'sk_…'
+const ORG_ID = generateId(); // not '019dd1a5-…'
+```
+
+Both come from `@nestjs-fastify-nx/shared`, so the test is pinned to the real formats for free.
+Reserve `.gitleaksignore` (one fingerprint per line, and fingerprints embed line numbers, so they
+rot) for the cases where a literal is genuinely required — see the entry for
+`scripts/smoke-expanded.sh`.
 
 ### OSV-Scanner — dependency CVEs
 
@@ -164,6 +181,40 @@ are deployment-specific and intentionally not wired into this workflow — see
 | `OSV_VERSION`      | Pin OSV-Scanner image                  | `v2.0.2`         |
 | `COSIGN_VERSION`   | Pin Cosign image                       | `v2.4.1`         |
 | `COSIGN_IDENTITY`  | Expected signing identity for `verify` | (required)       |
+
+## Application credentials
+
+Scanning keeps secrets out of the repo; this section is about the ones the application issues
+itself.
+
+### API keys
+
+Machine-to-machine callers authenticate with a key rather than a session cookie. The properties
+that matter, all enforced in code and pinned by tests:
+
+- **Only a SHA-256 digest is stored.** The raw key is returned once, by `POST /api/v1/api-keys`,
+  and is unrecoverable afterwards. A database leak yields digests, not credentials.
+- **A key can never exceed its issuer.** Requested scopes are checked against the permissions the
+  calling member actually holds; anything beyond them is refused with
+  `api_key_scope_exceeds_grant`. Without this, `api_key:create` is a grant of the whole catalog.
+- **Routes opt in explicitly** with `@AllowApiKey()`. A key presented to any other route is
+  refused _before_ the database lookup, so the response cannot confirm the key exists and no
+  handler expecting a session is ever reached.
+- **Revocation is immediate** — `revokedAt` and `expiresAt` are evaluated on every request, with
+  no cache to invalidate.
+
+Rationale for SHA-256 rather than a slow KDF, and the alternatives rejected:
+[ADR-0007](adr/0007-api-key-authentication.md).
+
+Operationally: keys are organization-scoped, so revoking one never affects another tenant. To
+rotate, issue the new key, deploy it, then revoke the old one — there is no overlap window to
+configure because both are live until revoked.
+
+### Session tokens
+
+Never projected into any response. `GET /api/v1/sessions` returns id, IP, user agent and
+timestamps so a person can recognise their own devices, and deliberately omits `token` — a listing
+that included it would let one compromised response hand over every other device.
 
 ## Container hardening reference
 


### PR DESCRIPTION
Documentation-only. No source, schema or config changed.

## Added

| Doc | What was missing |
| --- | --- |
| `fork-guide.md` | The 25 new endpoints with the permission each one requires, plus the new modules in the code map |
| `error-handling.md` | Domain codes by area (18 new ones had no home), and why several handlers answer 404 where 403 would be truthful |
| `security.md` | How API keys and session tokens are held — digest at rest, scope ceiling, opt-in routes, revocation |
| `runbook.md` | §10 compromised/leaked API key, §11 notifications not appearing (with the exact failure mode that shipped once) |
| `architecture.md` | The five-guard chain and why its order is load-bearing |
| `code-standards.md` | When to collect a module's exceptions into an errors file, and when not to |
| `domain-module-anatomy.md` | Test-double conventions, and the coverage gap that only CI catches |

## Corrected — these said things that were no longer true

1. **`security.md` and `CONTRIBUTING.md`: "no Gitleaks step on pre-commit".** There is one (`secrets-staged` in `lefthook.yml`), and it rejects hardcoded UUID/`sk_` fixtures in specs. Both now describe all three scan layers and the generate-don't-hardcode fix.
2. **`architecture.md`: `/admin/users` documented as `RolesGuard` + ADMIN.** It has been `PermissionGuard` + `member:read` since the authorization rework — the old text described exactly the bug that change fixed (locking out the org owner while letting provider staff read another tenant).
3. **`scaling-to-services.md`: "3 bounded contexts", "no cross-context FKs".** There are 9 now, and the new tables do reference the Better Auth core. That is deliberate and the doc now says why — what matters is that no feature context references another.

## Verified

- `prettier --check` clean on every touched file (CI's format step)
- Docker dev stack built and booted from scratch (`./scripts/build-dev.sh`): 4 images, all containers healthy, `/health/live` green
- Migration ledger on the fresh database holds exactly one row, `20260501000000_init`, with all 22 tables present — the single-init claim in the docs is now demonstrated, not asserted
- End-to-end on that stack: issued an API key, called `/feature-flags` with it (200), called `/users/me` with the same key (401, route did not opt in)