### PR TITLE
chore(deps): raise fast-uri and qs override floors to the patched releases

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   follow-redirects: '>=1.16.0'
   picomatch: '>=4.0.4'
   uuid: ^14.0.1
-  fast-uri: '>=4.1.2 <5'
+  fast-uri: '>=4.1.3 <5'
   fast-xml-builder: '>=1.2.0'
   hono: 4.12.27
   immutable: 5.1.8
@@ -24,7 +24,7 @@ overrides:
   esbuild: '>=0.28.1'
   kysely: '>=0.28.17'
   protobufjs: '>=8.0.2'
-  qs: '>=6.15.2'
+  qs: '>=6.16.0 <7'
   tmp: '>=0.2.7'
   webpack-dev-server: '>=5.2.6'
   ws: '>=8.21.0'
@@ -6365,8 +6365,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
@@ -8319,8 +8319,8 @@ packages:
     resolution: {integrity: sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==}
     engines: {node: '>= 16'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -11061,7 +11061,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
 
   '@fastify/busboy@3.2.0': {}
 
@@ -14556,14 +14556,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14903,7 +14903,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -15885,7 +15885,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -15921,7 +15921,7 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-ref-resolver: 1.0.1
       rfdc: 1.4.1
 
@@ -15930,7 +15930,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -15942,7 +15942,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
   fastify-plugin@4.5.1: {}
 
@@ -18143,7 +18143,7 @@ snapshots:
 
   qlobber@8.0.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -18804,7 +18804,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.3
+      qs: 6.16.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19158,7 +19158,7 @@ snapshots:
 
   union@0.5.0:
     dependencies:
-      qs: 6.15.3
+      qs: 6.16.0
 
   universalify@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,10 @@ overrides:
   follow-redirects: '>=1.16.0'
   picomatch: '>=4.0.4'
   uuid: '^14.0.1'
-  fast-uri: '>=4.1.2 <5'
+  # GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp (high, 7.5).
+  # Reached through @fastify/ajv-compiler (a fastify core dep) and ajv, neither of which offers a
+  # range that resolves 4.1.3, so the floor has to move here. Capped below the next major.
+  fast-uri: '>=4.1.3 <5'
   fast-xml-builder: '>=1.2.0'
   hono: '4.12.27'
   immutable: '5.1.8'
@@ -76,7 +79,10 @@ overrides:
   esbuild: '>=0.28.1'
   kysely: '>=0.28.17'
   protobufjs: '>=8.0.2'
-  qs: '>=6.15.2'
+  # GHSA-4mjr-xmp4-gh2g + GHSA-x5fp-wj9c-mxmx (medium, 6.3). Pulled in only through
+  # body-parser -> express, itself a transitive of @nestjs/platform-express; capped below the next
+  # major per the policy above.
+  qs: '>=6.16.0 <7'
   tmp: '>=0.2.7'
   webpack-dev-server: '>=5.2.6'
   ws: '>=8.21.0'


### PR DESCRIPTION
`dep-scan` is red on every open PR because OSV resolves two transitive packages to vulnerable versions:

| Package | Resolved | Advisories | Fixed in |
| --- | --- | --- | --- |
| `fast-uri` | 4.1.2 | GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp (high, 7.5) | 4.1.3 |
| `qs` | 6.15.3 | GHSA-4mjr-xmp4-gh2g, GHSA-x5fp-wj9c-mxmx (medium, 6.3) | 6.16.0 |

Neither is a direct dependency — `fast-uri` arrives via `@fastify/ajv-compiler` (a Fastify core dep) and `ajv`; `qs` via `body-parser` -> `express` -> `@nestjs/platform-express`. No parent declares a range that reaches the fix, so the existing overrides move to the patched floors, both capped below the next major per the policy in CLAUDE.md.

Resolves to `fast-uri@4.1.4` and `qs@6.16.0`.

Verified locally: `pnpm nx affected -t lint test build typecheck --base=origin/main` — green for 28 projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency security requirements for `fast-uri` and `qs` to use newer approved versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->